### PR TITLE
Add Sagui to the list of alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ If you don’t agree with the choices made in this project, you might want to ex
 * [rackt-cli](https://github.com/mzabriskie/rackt-cli)
 * [budō](https://github.com/mattdesl/budo)
 * [rwb](https://github.com/petehunt/rwb)
+* [sagui](https://github.com/saguijs/sagui)
 
 You can also use module bundlers like [webpack](http://webpack.github.io) and [Browserify](http://browserify.org/) directly.  
 React documentation includes [a walkthrough](https://facebook.github.io/react/docs/package-management.html) on this topic.


### PR DESCRIPTION
Sagui is the single development dependency that provides the tooling required to build, test and develop modern JavaScript applications.

https://github.com/saguijs/sagui