### PR TITLE
Ignores my-app* directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 build
 .DS_Store
 *.tgz
+my-app*


### PR DESCRIPTION
The Contributing instructions in the README give my-app as the sample
app name when running `npm run create-react-app my-app`. This just adds
those directories to the .gitignore so they don't accidentally get
committed.