### PR TITLE
Make local classnames global

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -68,7 +68,10 @@ module.exports = {
       {
         test: /\.css$/,
         include: srcPath,
-        loader: 'style!css!postcss'
+        // We "disable" local classes by setting the "unique" classname to the original classname,
+        // making it global again.
+        // Ref: https://github.com/facebookincubator/create-react-app/issues/90
+        loader: 'style!css?localIdentName=[name]!postcss'
       },
       {
         test: /\.json$/,


### PR DESCRIPTION
This is the only way I've found to "disable" the `:local(.class)` notation.

It disables it in the sense that the generated classname will just be `"class"` – it doesn't keep users from doing the webpack-specific thing though:

```JSX
import styles from './styles.css';

<div className={styles.class} />
```

That means it'll still break users builds if they for some reason rely on the above and we change to a different bundler.

Closes #90