### PR TITLE
Add build directory to gitignore

### DIFF
--- a/template/gitignore
+++ b/template/gitignore
@@ -3,5 +3,8 @@
 # dependencies
 node_modules
 
+# production
+build
+
 # misc
 npm-debug.log


### PR DESCRIPTION
I think it's a good practice to exclude production files (ones created on `npm run build`) by default.

Related to https://github.com/facebookincubator/create-react-app/pull/79