### PR TITLE
Added support for jsx extension

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+var PORT = process.env.PORT || 3000;
 
 var path = require('path');
 var autoprefixer = require('autoprefixer');
@@ -32,7 +33,7 @@ var buildPath = path.join(__dirname, isInNodeModules ? '../../..' : '..', 'build
 module.exports = {
   devtool: 'eval',
   entry: [
-    require.resolve('webpack-dev-server/client') + '?http://localhost:3000',
+    require.resolve('webpack-dev-server/client') + '?http://localhost:'+PORT,
     require.resolve('webpack/hot/dev-server'),
     path.join(srcPath, 'index')
   ],

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -60,7 +60,7 @@ module.exports = {
     ],
     loaders: [
       {
-        test: /\.js$/,
+        test: /\.js(|x)$/,
         include: srcPath,
         loader: 'babel',
         query: require('./babel.dev')

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -8,6 +8,7 @@
  */
 
 process.env.NODE_ENV = 'development';
+var PORT = process.env.PORT || 3000;
 
 var path = require('path');
 var chalk = require('chalk');
@@ -77,7 +78,7 @@ compiler.plugin('done', function (stats) {
   if (!hasErrors && !hasWarnings) {
     console.log(chalk.green('Compiled successfully!'));
     console.log();
-    console.log('The app is running at http://localhost:3000/');
+    console.log('The app is running at http://localhost:'+PORT+'/');
     console.log();
     return;
   }
@@ -130,7 +131,7 @@ function openBrowser() {
       execSync(
         'osascript ' +
         path.resolve(__dirname, './openChrome.applescript') +
-        ' http://localhost:3000/'
+        ' http://localhost:'+PORT+'/'
       );
       return;
     } catch (err) {
@@ -139,7 +140,7 @@ function openBrowser() {
   }
   // Fallback to opn
   // (It will always open new tab)
-  opn('http://localhost:3000/');
+  opn('http://localhost:'+PORT+'/');
 }
 
 new WebpackDevServer(compiler, {
@@ -147,7 +148,7 @@ new WebpackDevServer(compiler, {
   hot: true, // Note: only CSS is currently hot reloaded
   publicPath: config.output.publicPath,
   quiet: true
-}).listen(3000, 'localhost', function (err, result) {
+}).listen(PORT, 'localhost', function (err, result) {
   if (err) {
     return console.log(err);
   }


### PR DESCRIPTION
Apply babel loader to jsx files so that sublime and github can automatically display jsx code correctly.