### PR TITLE
Explicitly specify ESLint config path for editor plugins in package.json

### DIFF
--- a/scripts/eject.js
+++ b/scripts/eject.js
@@ -104,6 +104,11 @@ prompt('Are you sure you want to eject? This action is permanent. [y/N]', functi
   });
   delete hostPackage.scripts['eject'];
 
+  // explicitly specify ESLint config path for editor plugins
+  hostPackage.eslintConfig = {
+    extends: "./config/eslint.js",
+  };
+
   console.log('Writing package.json');
   fs.writeFileSync(
     path.join(hostPath, 'package.json'),

--- a/scripts/eject.js
+++ b/scripts/eject.js
@@ -106,7 +106,7 @@ prompt('Are you sure you want to eject? This action is permanent. [y/N]', functi
 
   // explicitly specify ESLint config path for editor plugins
   hostPackage.eslintConfig = {
-    extends: "./config/eslint.js",
+    extends: './config/eslint.js',
   };
 
   console.log('Writing package.json');

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -31,7 +31,7 @@ module.exports = function(hostPath, appName, verbose) {
 
   // explicitly specify ESLint config path for editor plugins
   hostPackage.eslintConfig = {
-    extends: "./node_modules/react-scripts/config/eslint.js",
+    extends: './node_modules/react-scripts/config/eslint.js',
   };
 
   fs.writeFileSync(

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -29,6 +29,11 @@ module.exports = function(hostPath, appName, verbose) {
     hostPackage.scripts[command] = 'react-scripts ' + command;
   });
 
+  // explicitly specify ESLint config path for editor plugins
+  hostPackage.eslintConfig = {
+    extends: "./node_modules/react-scripts/config/eslint.js",
+  };
+
   fs.writeFileSync(
     path.join(hostPath, 'package.json'),
     JSON.stringify(hostPackage, null, 2)


### PR DESCRIPTION
Fixes #124. Notice that we need to change the path in `package.json` while ejecting since the config folder gets moved.

Tested with Atom (Nuclide) and Visual Studio Code and it works both before and after ejection. ~~I'm not sure about Sublime Text -- seems like `SublimeLinter-eslint` only recognizes `.eslintrc` config. However, it could be fixed by [configuring](https://github.com/roadhump/SublimeLinter-eslint#i-want-not-to-lint-files-if-there-is-no-eslintrc-file-in-project-folder-for-eslint-100) the linter plugin itself. Or even better, could someone who uses Sublime Text send a PR to let it recognize the `eslintConfig` field in `package.json`? :)~~

Edit: @kevinastone confirmed that Sublime Text works fine too.