### PR TITLE
Disable jsx-handler-name eslint rule

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -179,10 +179,6 @@ module.exports = {
 
     // https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules
     'react/jsx-equals-spacing': [WARNING, 'never'],
-    'react/jsx-handler-names': [WARNING, {
-      eventHandlerPrefix: 'handle',
-      eventHandlerPropPrefix: 'on',
-    }],
     'react/jsx-no-duplicate-props': [WARNING, { ignoreCase: true }],
     'react/jsx-no-undef': WARNING,
     'react/jsx-pascal-case': [WARNING, {


### PR DESCRIPTION
Closes #156

Not sure if we can simply delete the line and that'll disable it, so I
went with setting it to 0. Let me know!