### PR TITLE
fix cdpath bug

### DIFF
--- a/global-cli/index.js
+++ b/global-cli/index.js
@@ -88,15 +88,16 @@ function createApp(name, verbose, version) {
     private: true,
   };
   fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(packageJson));
+  var originalDirectory = process.cwd();
   process.chdir(root);
 
   console.log('Installing packages. This might take a couple minutes.');
   console.log('Installing react-scripts from npm...');
 
-  run(root, appName, version, verbose);
+  run(root, appName, version, verbose, originalDirectory);
 }
 
-function run(root, appName, version, verbose) {
+function run(root, appName, version, verbose, originalDirectory) {
   var args = [
     'install',
     verbose && '--verbose',
@@ -121,7 +122,7 @@ function run(root, appName, version, verbose) {
       'init.js'
     );
     var init = require(scriptsPath);
-    init(root, appName, verbose);
+    init(root, appName, verbose, originalDirectory);
   });
 }
 

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -11,7 +11,7 @@ var fs = require('fs-extra');
 var path = require('path');
 var spawn = require('cross-spawn');
 
-module.exports = function(hostPath, appName, verbose) {
+module.exports = function(hostPath, appName, verbose, originalDirectory) {
   var selfPath = path.join(hostPath, 'node_modules', 'react-scripts');
 
   var hostPackage = require(path.join(hostPath, 'package.json'));
@@ -60,9 +60,12 @@ module.exports = function(hostPath, appName, verbose) {
       return;
     }
 
-    // Make sure to display the right way to cd
+    // Display the most elegant way to cd.
+    // This needs to handle an undefined originalDirectory for
+    // backward compatibility with old global-cli's.
     var cdpath;
-    if (path.join(process.cwd(), appName) === hostPath) {
+    if (originalDirectory &&
+        path.join(originalDirectory, appName) === hostPath) {
       cdpath = appName;
     } else {
       cdpath = hostPath;


### PR DESCRIPTION
Fixes the instructions printed by the script so that if you create a new app with `create-react-app foo`, it will suggest getting there with `cd foo` rather than `cd /some/big/long/path/foo`.

This will require a new global-cli deploy to work, but it's backward compatible so that the new init script works with the old global-cli (and just is buggy in the same way the current one is).