### PR TITLE
Simplify path resolving for react-scripts

### DIFF
--- a/bin/react-scripts.js
+++ b/bin/react-scripts.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-var path = require('path');
 var spawn = require('cross-spawn');
 var script = process.argv[2];
 var args = process.argv.slice(3);
@@ -10,7 +9,7 @@ case 'start':
 case 'eject':
   spawn(
     'node',
-    [path.resolve(__dirname, '..', 'scripts', script)].concat(args),
+    [require.resolve('../scripts/' + script)].concat(args),
     {stdio: 'inherit'}
   );
   break;


### PR DESCRIPTION
No change in functionality, just thought it was easier to understand using `require.resolve` rather than `path.resolve` for resolving the location of a JavaScript file.