### PR TITLE
Add polyfill from polyfill.io

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -17,5 +17,6 @@
       To begin the development, run `npm start` in this folder.
       To create a production bundle, use `npm run build`.
     -->
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default-3.6"></script>
   </body>
 </html>


### PR DESCRIPTION
Note that we lock to the current default feature set (default-3.6).  Future versions of create-react-app will want to update this version number, but we wouldn't want users to inadvertently get different polyfills.

[closes #170]