### PR TITLE
Add select eslint-plugin-jsx-a11y rules to lint config.

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -24,7 +24,7 @@ module.exports = {
   parser: 'babel-eslint',
 
   // import plugin is termporarily disabled, scroll below to see why
-  plugins: ['react'/*, 'import'*/],
+  plugins: ['react'/*, 'import'*/, 'jsx-a11y'],
 
   env: {
     es6: true,
@@ -191,6 +191,12 @@ module.exports = {
     'react/no-direct-mutation-state': WARNING,
     'react/no-is-mounted': WARNING,
     'react/react-in-jsx-scope': WARNING,
-    'react/require-render-return': WARNING
+    'react/require-render-return': WARNING,
+
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
+    'jsx-a11y/aria-role': WARNING,
+    'jsx-a11y/img-has-alt': WARNING,
+    'jsx-a11y/img-redundant-alt': WARNING,
+    'jsx-a11y/no-access-key': WARNING
   }
 };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint": "3.1.1",
     "eslint-loader": "1.4.1",
     "eslint-plugin-import": "1.10.3",
+    "eslint-plugin-jsx-a11y": "2.0.1",
     "eslint-plugin-react": "5.2.2",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",


### PR DESCRIPTION
This project is a really good use case to apply some accessibility rules to the lint config. For beginners getting started with React and/or web in general, we can also teach & enforce basic accessibility rules in the web at author time.

For now, I’ve just applied to the rules that are listed in `eslint-config-airbnb` because these are most real-world tested, and we can continue to add as you see fit.

I know from Twitter that you're wary about adding more dependencies, but very happy to help if there are any questions/issues/concerns about the plugin!