### PR TITLE
Upgrade to webpack v2

### DIFF
--- a/config/babel.dev.js
+++ b/config/babel.dev.js
@@ -10,7 +10,7 @@
 module.exports = {
   cacheDirectory: true,
   presets: [
-    'babel-preset-es2015',
+    'babel-preset-es2015-webpack',
     'babel-preset-es2016',
     'babel-preset-react'
   ].map(require.resolve),

--- a/config/babel.dev.js
+++ b/config/babel.dev.js
@@ -11,7 +11,6 @@ module.exports = {
   cacheDirectory: true,
   presets: [
     'babel-preset-es2015-webpack',
-    'babel-preset-es2016',
     'babel-preset-react'
   ].map(require.resolve),
   plugins: [

--- a/config/babel.prod.js
+++ b/config/babel.prod.js
@@ -10,7 +10,6 @@
 module.exports = {
   presets: [
     'babel-preset-es2015-webpack',
-    'babel-preset-es2016',
     'babel-preset-react'
   ].map(require.resolve),
   plugins: [

--- a/config/babel.prod.js
+++ b/config/babel.prod.js
@@ -9,7 +9,7 @@
 
 module.exports = {
   presets: [
-    'babel-preset-es2015',
+    'babel-preset-es2015-webpack',
     'babel-preset-es2016',
     'babel-preset-react'
   ].map(require.resolve),

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -48,7 +48,7 @@ module.exports = {
     extensions: ['', '.js'],
   },
   resolveLoader: {
-    root: nodeModulesPath,
+    modules: nodeModulesPath,
     moduleTemplates: ['*-loader']
   },
   module: {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -49,7 +49,7 @@ module.exports = {
     extensions: ['', '.js'],
   },
   resolveLoader: {
-    root: nodeModulesPath,
+    modules: nodeModulesPath,
     moduleTemplates: ['*-loader']
   },
   module: {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -73,7 +73,7 @@ module.exports = {
         // Disable autoprefixer in css-loader itself:
         // https://github.com/webpack/css-loader/issues/281
         // We already have it thanks to postcss.
-        loader: ExtractTextPlugin.extract('style', 'css?-autoprefixer!postcss')
+        loader: ExtractTextPlugin.extract({ fallbackLoader: 'style', loader: 'css?-autoprefixer!postcss' })
       },
       {
         test: /\.json$/,

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -120,6 +120,7 @@ module.exports = {
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.UglifyJsPlugin({
+      sourceMap: true,
       compressor: {
         screw_ie8: true,
         warnings: false

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-import": "1.10.3",
     "eslint-plugin-jsx-a11y": "2.0.1",
     "eslint-plugin-react": "5.2.2",
-    "extract-text-webpack-plugin": "^2.0.0-beta.3",
+    "extract-text-webpack-plugin": "2.0.0-beta.3",
     "file-loader": "0.9.0",
     "fs-extra": "^0.30.0",
     "html-webpack-plugin": "2.22.0",
@@ -56,7 +56,7 @@
     "rimraf": "2.5.3",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
-    "webpack": "^2.1.0-beta.20",
+    "webpack": "2.1.0-beta.20",
     "webpack-dev-server": "1.14.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-plugin-transform-class-properties": "6.10.2",
     "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-plugin-transform-react-constant-elements": "6.9.1",
-    "babel-preset-es2015-webpack": "^6.4.2",
+    "babel-preset-es2015-webpack": "6.4.2",
     "babel-preset-es2016": "6.11.3",
     "babel-preset-react": "6.11.1",
     "chalk": "1.1.3",
@@ -57,7 +57,7 @@
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
     "webpack": "2.1.0-beta.20",
-    "webpack-dev-server": "1.14.1"
+    "webpack-dev-server": "2.1.0-beta.0"
   },
   "devDependencies": {
     "bundle-deps": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-plugin-transform-class-properties": "6.10.2",
     "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-plugin-transform-react-constant-elements": "6.9.1",
-    "babel-preset-es2015": "6.9.0",
+    "babel-preset-es2015-webpack": "^6.4.2",
     "babel-preset-es2016": "6.11.3",
     "babel-preset-react": "6.11.1",
     "chalk": "1.1.3",
@@ -46,7 +46,7 @@
     "eslint-plugin-import": "1.10.3",
     "eslint-plugin-jsx-a11y": "2.0.1",
     "eslint-plugin-react": "5.2.2",
-    "extract-text-webpack-plugin": "1.0.1",
+    "extract-text-webpack-plugin": "^2.0.0-beta.3",
     "file-loader": "0.9.0",
     "fs-extra": "^0.30.0",
     "html-webpack-plugin": "2.22.0",
@@ -56,7 +56,7 @@
     "rimraf": "2.5.3",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
-    "webpack": "1.13.1",
+    "webpack": "^2.1.0-beta.20",
     "webpack-dev-server": "1.14.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Ref #183 

This is a first step towards webpack 2. Everything builds and works just fine.

Build stats:

**v1**

```
4.0K    build/84287d09b8053c6fa598893b8910786a.svg
 28K    build/favicon.ico
4.0K    build/index.html
140K    build/main.c7a1d762a452b452a7e7.js
4.0K    build/main.7cbecfc47e1de8546c1a31e27e545145.css
4.0K    build/main.7cbecfc47e1de8546c1a31e27e545145.css.map
1.5M    build/main.c7a1d762a452b452a7e7.js.map
```

**v2**

```
4.0K    build/84287d09b8053c6fa598893b8910786a.svg
 28K    build/favicon.ico
4.0K    build/index.html
140K    build/main.3e41bc8b11563538fb8e.js
4.0K    build/main.5d2cacffab6444a5357d533f016e1b6d.css
4.0K    build/main.5d2cacffab6444a5357d533f016e1b6d.css.map
```

I think nothing is different because we have to not use `babel-plugin-transform-es2015-modules-commonjs`, which is what `babel-preset-es2015-webpack` does so we get the benefits of tree shaking.

Annoyingly we're using `babel-preset-es2016`, which doesn't have a `babel-preset-es2016-webpack` with `babel-plugin-transform-es2015-modules-commonjs` removed!

Would appreciate somebody forking `babel-preset-es2016`, removing that, publishing it and trying it with this PR!

*I'm going to bed now, feel free to continue the work against the `webpack-v2` branch!*