### PR TITLE
eliminate dev-only code on eject #53 #191

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -12,6 +12,11 @@
 
 var path = require('path');
 
+function resolve(relativePath) {
+  return path.resolve(__dirname, relativePath);
+}
+
+// Dead code on eject: start
 // True when used as a dependency, false after ejecting
 var isInNodeModules = (
   'node_modules' ===
@@ -22,10 +27,6 @@ var isInNodeModules = (
 var isInCreateReactAppSource = (
   process.argv.some(arg => arg.indexOf('--debug-template') > -1)
 );
-
-function resolve(relativePath) {
-  return path.resolve(__dirname, relativePath);
-}
 
 if (isInCreateReactAppSource) {
   // create-react-app development: we're in ./config/
@@ -52,6 +53,8 @@ if (isInCreateReactAppSource) {
   };
 } else {
   // after eject: we're in ./config/
+// Dead code on eject: end
+// Dead code on eject: start
   module.exports = {
     appBuild: resolve('../build'),
     appHtml: resolve('../index.html'),
@@ -61,4 +64,5 @@ if (isInCreateReactAppSource) {
     appNodeModules: resolve('../node_modules'),
     ownNodeModules: resolve('../node_modules')
   };
+// Dead code on eject: end
 }

--- a/config/paths.js
+++ b/config/paths.js
@@ -54,7 +54,6 @@ if (isInCreateReactAppSource) {
 } else {
   // after eject: we're in ./config/
 // Dead code on eject: end
-// Dead code on eject: start
   module.exports = {
     appBuild: resolve('../build'),
     appHtml: resolve('../index.html'),
@@ -64,5 +63,6 @@ if (isInCreateReactAppSource) {
     appNodeModules: resolve('../node_modules'),
     ownNodeModules: resolve('../node_modules')
   };
-// Dead code on eject: end
+// Dead code on eject: start
 }
+// Dead code on eject: end

--- a/scripts/eject.js
+++ b/scripts/eject.js
@@ -80,6 +80,8 @@ prompt('Are you sure you want to eject? This action is permanent. [y/N]', functi
       .replace(/^\/\*\*(\*(?!\/)|[^*])*\*\//, '')
       // Remove license header from AppleScript
       .replace(/^--.*\n/gm, '')
+      // Remove dead code on eject
+      .replace(/\/\/ Dead code on eject: start([\s\S]*?)\/\/ Dead code on eject: end/g, '')
       .trim() + '\n';
     fs.writeFileSync(path.join(appPath, file), content);
   });

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -17,9 +17,10 @@ var config = require('../config/webpack.config.dev');
 var execSync = require('child_process').execSync;
 var opn = require('opn');
 
-// TODO: hide this behind a flag and eliminate dead code on eject.
+// hide this behind a flag and eliminate dead code on eject.
 // This shouldn't be exposed to the user.
 var handleCompile;
+// Dead code on eject: start
 var isSmokeTest = process.argv.some(arg => arg.indexOf('--smoke-test') > -1);
 if (isSmokeTest) {
   handleCompile = function (err, stats) {
@@ -30,6 +31,7 @@ if (isSmokeTest) {
     }
   };
 }
+// Dead code on eject: end
 
 var friendlySyntaxErrorLabel = 'Syntax error:';
 


### PR DESCRIPTION
```
// Dead code on eject: start
dev-only code
// Dead code on eject: end
```
will be removed when the scripts are exposed to users on `eject`

`npm pack` copies all files to the created package.  To adopt the approach proposed in #191 and give a `clean` code in the published package , we may need to temporary add files to .npmignore before npm, similar to what we do to package.json [code link](https://github.com/facebookincubator/create-react-app/blob/master/tasks/release.sh#L42)
