### PR TITLE
Trigger recompilation on node module changes.

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -11,6 +11,7 @@ var path = require('path');
 var autoprefixer = require('autoprefixer');
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
+var NpmInstallPlugin = require('npm-install-webpack-plugin');
 var paths = require('./paths');
 
 module.exports = {
@@ -86,6 +87,7 @@ module.exports = {
     }),
     new webpack.DefinePlugin({ 'process.env.NODE_ENV': '"development"' }),
     // Note: only CSS is currently hot reloaded
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.HotModuleReplacementPlugin(),
+    new NpmInstallPlugin()
   ]
 };

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "fs-extra": "^0.30.0",
     "html-webpack-plugin": "2.22.0",
     "json-loader": "0.5.4",
+    "npm-install-webpack-plugin": "^4.0.4",
     "opn": "4.0.2",
     "postcss-loader": "0.9.1",
     "rimraf": "2.5.3",


### PR DESCRIPTION
An Attempt at fixing #186.

This plugin offers a bit more than just recompiling when the `node_modules` change, it also auto installs dependencies that are referenced if they don't already exist (which may or may not be a good thing).

Personally I like the feature, but I could see it being obtrusive, I am open to solving this in a different way.