### PR TITLE
Add Promise and fetch polyfills

### DIFF
--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -1,0 +1,9 @@
+if (typeof Promise === 'undefined') {
+  // Rejection tracking prevents a common issue where React gets into an
+  // inconsistent state due to an error, but it gets swallowed by a Promise,
+  // and the user has no idea what causes React's erratic future behavior.
+  require('promise/lib/rejection-tracking').enable();
+  window.Promise = require('promise/lib/es6-extensions.js');
+}
+
+require('whatwg-fetch');

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -18,6 +18,7 @@ module.exports = {
   entry: [
     require.resolve('webpack-dev-server/client') + '?http://localhost:3000',
     require.resolve('webpack/hot/dev-server'),
+    require.resolve('./polyfills'),
     path.join(paths.appSrc, 'index')
   ],
   output: {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -25,7 +25,10 @@ if (!publicPath.endsWith('/')) {
 module.exports = {
   bail: true,
   devtool: 'source-map',
-  entry: path.join(paths.appSrc, 'index'),
+  entry: [
+    require.resolve('./polyfills'),
+    path.join(paths.appSrc, 'index')
+  ],
   output: {
     path: paths.appBuild,
     filename: '[name].[chunkhash:8].js',

--- a/package.json
+++ b/package.json
@@ -53,11 +53,13 @@
     "json-loader": "0.5.4",
     "opn": "4.0.2",
     "postcss-loader": "0.9.1",
+    "promise": "7.1.1",
     "rimraf": "2.5.3",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
     "webpack": "1.13.1",
-    "webpack-dev-server": "1.14.1"
+    "webpack-dev-server": "1.14.1",
+    "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {
     "bundle-deps": "1.0.0",

--- a/scripts/eject.js
+++ b/scripts/eject.js
@@ -47,6 +47,7 @@ prompt('Are you sure you want to eject? This action is permanent. [y/N]', functi
     path.join('config', 'flow', 'file.js.flow'),
     path.join('config', 'eslint.js'),
     path.join('config', 'paths.js'),
+    path.join('config', 'polyfills.js'),
     path.join('config', 'webpack.config.dev.js'),
     path.join('config', 'webpack.config.prod.js'),
     path.join('scripts', 'build.js'),


### PR DESCRIPTION
I used [promise](https://github.com/then/promise) (maintained by @ForbesLindesay and widely used at Facebook) and [fetch](https://github.com/github/fetch) (pretty much standard in the community).

These will be included for everyone. In terms of size, it adds about 4kB min+gzip, and I think it’s a fair tradeoff for getting these features as baseline since they’re so commonly used in the React tutorials.

Promise rejection tracking is on in all environments. If it truly causes performance issues, we can disable it in production. However I wouldn’t expect it to: front-end code isn’t usually as Promise-heavy as Node. There’s a difference between using a Promise here and there, and creating thousands of Promises in tight loops or whatever it is that most benchmarks measure.