### PR TITLE
Turn off .babelrc usage (fixes #233)

### DIFF
--- a/config/babel.dev.js
+++ b/config/babel.dev.js
@@ -18,5 +18,6 @@ module.exports = {
     'babel-plugin-syntax-trailing-function-commas',
     'babel-plugin-transform-class-properties',
     'babel-plugin-transform-object-rest-spread'
-  ].map(require.resolve)
+  ].map(require.resolve),
+  babelrc: false
 };

--- a/config/babel.prod.js
+++ b/config/babel.prod.js
@@ -18,5 +18,6 @@ module.exports = {
     'babel-plugin-transform-class-properties',
     'babel-plugin-transform-object-rest-spread',
     'babel-plugin-transform-react-constant-elements'
-  ].map(require.resolve)
+  ].map(require.resolve),
+  babelrc: false
 };


### PR DESCRIPTION
Here is how I verified.

1. cloned create-react-app
2. created .babelrc in the parent directory as specified in #233 
3. ran npm start in create-react-app and got the error message

With the fix in place, I'm no longer getting the "Failed to compile" message.