### PR TITLE
Improve error handling within e2e.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "start": "node scripts/start.js --debug-template",
     "build": "node scripts/build.js --debug-template",
-    "create-react-app": "node global-cli/index.js --scripts-version \"$PWD/`npm pack`\""
+    "create-react-app": "node global-cli/index.js --scripts-version \"$PWD/`npm pack`\"",
+    "test": "tasks/e2e.sh"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
`trap` provides more robust error handling than `set -e`.  (http://mywiki.wooledge.org/BashFAQ/105)

This may actually fix #163. I was seeing a trapped error when I tried to replicate the state described in that issue, but it'd be helpful to have someone else confirm this.

I also point the npm test command to e2e.sh for convenience. Could go either way on that one. It's unimportant.

Error messages look like:

![this](https://s3.amazonaws.com/vigesharing-is-vigecaring/lkurtz/sh_taskse2e.sh_2016-07-27_15-55-14.png)