### PR TITLE
WIP: Add a 'run' script

### DIFF
--- a/bin/react-scripts.js
+++ b/bin/react-scripts.js
@@ -7,6 +7,7 @@ switch (script) {
 case 'build':
 case 'start':
 case 'eject':
+case 'run':
   spawn(
     'node',
     [require.resolve('../scripts/' + script)].concat(args),

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "fs-extra": "0.30.0",
     "html-webpack-plugin": "2.22.0",
     "json-loader": "0.5.4",
+    "null-loader": "0.1.1",
     "opn": "4.0.2",
     "postcss-loader": "0.9.1",
     "promise": "7.1.1",

--- a/scripts/eject.js
+++ b/scripts/eject.js
@@ -51,6 +51,7 @@ prompt('Are you sure you want to eject? This action is permanent. [y/N]', functi
     path.join('config', 'webpack.config.dev.js'),
     path.join('config', 'webpack.config.prod.js'),
     path.join('scripts', 'build.js'),
+    path.join('scripts', 'run.js'),
     path.join('scripts', 'start.js'),
     path.join('scripts', 'openChrome.applescript')
   ];

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -25,7 +25,7 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
 
   // Setup the script rules
   appPackage.scripts = {};
-  ['start', 'build', 'eject'].forEach(function(command) {
+  ['start', 'build', 'eject', 'run'].forEach(function(command) {
     appPackage.scripts[command] = 'react-scripts ' + command;
   });
 

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+var webpack = require('webpack');
+
+var paths = require('../config/paths');
+
+// Hacky command-line parsing. All flags are just ignored and there
+// may be no args.
+// TODO: support passing args to the script we're running
+var nonflags = process.argv.filter(function(x) { return x[0] !== '-'; });
+if (nonflags.length != 3) {
+  console.error('Usage: react-scripts run foo.js');
+  console.error(
+    'foo.js is your script, resolved relative to the src directory.')
+  process.exit(1);
+}
+var scriptName = nonflags[2];
+var pathToEntry = path.join(paths.appSrc, scriptName);
+
+// Figure out what all the node_modules are.
+// We don't want to compile the node_modules, but we still want to
+// do a commonjs require for them.
+var nodeModules = {};
+fs.readdirSync(paths.appNodeModules).filter(function(x) {
+  return ['.bin'].indexOf(x) === -1;
+}).forEach(function(mod) {
+  nodeModules[mod] = 'commonjs ' + mod;
+});
+
+// Construct our script in a temporary file.
+var outputPath = os.tmpDir();
+var outputFile = 'entry.js';
+
+// Configure webpack.
+// TODO: support sourcemaps
+// TODO: figure out if we want to automatically polyfill fetch
+var config = {
+  entry: [
+    pathToEntry,
+  ],
+  target: 'node',
+  output: {
+    libraryTarget: 'commonjs2',
+    path: outputPath,
+    filename: outputFile
+  },
+  externals: nodeModules,
+  resolve: {
+    extensions: ['', '.js', '.json'],
+  },
+  resolveLoader: {
+    root: paths.ownNodeModules,
+    moduleTemplates: ['*-loader']
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        include: paths.appSrc,
+        loader: 'babel',
+        query: require('../config/babel.dev')
+      },
+      {
+        test: /\.css$/,
+        include: [paths.appSrc, paths.appNodeModules],
+        loader: 'null'
+      },
+      {
+        test: /\.json$/,
+        include: [paths.appSrc, paths.appNodeModules],
+        loader: 'json'
+      },
+      {
+        test: /\.(jpg|png|gif|eot|svg|ttf|woff|woff2)$/,
+        include: [paths.appSrc, paths.appNodeModules],
+        loader: 'null',
+      },
+      {
+        test: /\.(mp4|webm)$/,
+        include: [paths.appSrc, paths.appNodeModules],
+        loader: 'null'
+      }
+    ]
+  },
+};
+
+// Compile the script
+webpack(config).run(function(err, stats) {
+  if (err) {
+    console.error('error:', err.code, err.message);
+    console.error(err);
+    process.exit(2);
+  }
+  if (stats.hasErrors()) {
+    var errors = stats.toJson().errors;
+    console.error('stats has', errors.length, 'errors:');
+    for (var i = 0; i < errors.length; i++) {
+      console.error(errors[i]);
+    }
+    process.exit(3);
+  }
+
+  var scriptPath = path.resolve(outputPath, outputFile);
+  require(scriptPath);
+});


### PR DESCRIPTION
This adds a `run` script so that you can invoke a script in the same ES6-and-React-compatible environment you get when you run `npm start`, but in node.

To run a script:
* Put your script in `src`, like at `src/foobar.js`
* `react-scripts run foobar.js`

I wanted to get feedback if this seems like it's headed in the right direction. In particular are these decisions the right behavior:

* This doesn't compile node_modules.
* This doesn't set NODE_ENV.
* This stores the compiled files in a global temp directory.
* This doesn't automatically polyfill `fetch`.

Things that I'm pretty sure are *not* the ideal behavior but can be improved later:
* This doesn't cache anything
* No sourcemaps
* No arguments are passed to the script

It seems like a lot of the behavior will be similar between "run a one-off script" and "run unit tests" so perhaps we should have some underlying library that is shared between this and testing like https://github.com/facebookincubator/create-react-app/pull/216 .