### PR TITLE
Return proper exit code in bin/react-scripts via spawnSync (#252)

### DIFF
--- a/bin/react-scripts.js
+++ b/bin/react-scripts.js
@@ -7,11 +7,12 @@ switch (script) {
 case 'build':
 case 'start':
 case 'eject':
-  spawn(
+  var result = spawn.sync(
     'node',
     [require.resolve('../scripts/' + script)].concat(args),
     {stdio: 'inherit'}
   );
+  process.exit(result.status);
   break;
 default:
   console.log('Unknown script "' + script + '".');


### PR DESCRIPTION
This fixes #252 