### PR TITLE
Remove LICENSE from package.json/files

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "test": "tasks/e2e.sh"
   },
   "files": [
-    "LICENSE",
     "PATENTS",
     "bin",
     "config",


### PR DESCRIPTION
The `LICENSE` file is being included regardless of what's specified in `package.json/files`.