### PR TITLE
Add a temporary fix for generators

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -30,6 +30,17 @@ module.exports = {
   },
   resolve: {
     extensions: ['', '.js', '.json'],
+    alias: {
+      // This `alias` section can be safely removed after ejection.
+      // We do this because `babel-runtime` may be inside `react-scripts`,
+      // so when `babel-plugin-transform-runtime` imports it, it will not be
+      // available to the app directly. This is a temporary solution that lets
+      // us ship support for generators. However it is far from ideal, and
+      // if we don't have a good solution, we should just make `babel-runtime`
+      // a dependency in generated projects.
+      // See https://github.com/facebookincubator/create-react-app/issues/255
+      'babel-runtime/regenerator': require.resolve('babel-runtime/regenerator')
+    }
   },
   resolveLoader: {
     root: paths.ownNodeModules,

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -37,6 +37,17 @@ module.exports = {
   },
   resolve: {
     extensions: ['', '.js', '.json'],
+    alias: {
+      // This `alias` section can be safely removed after ejection.
+      // We do this because `babel-runtime` may be inside `react-scripts`,
+      // so when `babel-plugin-transform-runtime` imports it, it will not be
+      // available to the app directly. This is a temporary solution that lets
+      // us ship support for generators. However it is far from ideal, and
+      // if we don't have a good solution, we should just make `babel-runtime`
+      // a dependency in generated projects.
+      // See https://github.com/facebookincubator/create-react-app/issues/255
+      'babel-runtime/regenerator': require.resolve('babel-runtime/regenerator')
+    }
   },
   resolveLoader: {
     root: paths.ownNodeModules,


### PR DESCRIPTION
This enables us to ship them now, and find a way to resolve runtime path without webpack later.
See https://github.com/facebookincubator/create-react-app/issues/255