### PR TITLE
Webpack plugin to detect case mismatch in requires

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -11,6 +11,7 @@ var path = require('path');
 var autoprefixer = require('autoprefixer');
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
+var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 var paths = require('./paths');
 
 module.exports = {
@@ -87,6 +88,7 @@ module.exports = {
     }),
     new webpack.DefinePlugin({ 'process.env.NODE_ENV': '"development"' }),
     // Note: only CSS is currently hot reloaded
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.HotModuleReplacementPlugin(),
+    new CaseSensitivePathsPlugin()
   ]
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-preset-es2016": "6.11.3",
     "babel-preset-react": "6.11.1",
     "babel-runtime": "6.11.6",
+    "case-sensitive-paths-webpack-plugin": "1.1.2",
     "chalk": "1.1.3",
     "cross-spawn": "4.0.0",
     "css-loader": "0.23.1",


### PR DESCRIPTION
Addresses #240.
Plugin works as advertised, both with requires and imports.
I was not sure if we need this in prod, so only included in dev for now. Also, pinned the version as with other dependencies.
<img width="870" alt="screen shot 2016-07-28 at 23 03 16" src="https://cloud.githubusercontent.com/assets/93752/17227566/9cd266e4-5517-11e6-9222-9059eb3ce5de.png">
