### PR TITLE
Symlink-friendly path resolution

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -12,10 +12,10 @@
 
 var path = require('path');
 
-// True when used as a dependency, false after ejecting
-var isInNodeModules = (
-  'node_modules' ===
-  path.basename(path.resolve(path.join(__dirname, '..', '..')))
+// True after ejecting, false when used as a dependency
+var isEjected = (
+  path.resolve(path.join(__dirname, '..')) ===
+  path.resolve(process.cwd())
 );
 
 // Are we developing create-react-app locally?
@@ -23,42 +23,46 @@ var isInCreateReactAppSource = (
   process.argv.some(arg => arg.indexOf('--debug-template') > -1)
 );
 
-function resolve(relativePath) {
+function resolveLib(relativePath) {
   return path.resolve(__dirname, relativePath);
+}
+
+function resolveApp(relativePath) {
+  return path.resolve(relativePath);
 }
 
 if (isInCreateReactAppSource) {
   // create-react-app development: we're in ./config/
   module.exports = {
-    appBuild: resolve('../build'),
-    appHtml: resolve('../template/index.html'),
-    appFavicon: resolve('../template/favicon.ico'),
-    appPackageJson: resolve('../package.json'),
-    appSrc: resolve('../template/src'),
-    appNodeModules: resolve('../node_modules'),
-    ownNodeModules: resolve('../node_modules')
+    appBuild: resolveLib('../build'),
+    appHtml: resolveLib('../template/index.html'),
+    appFavicon: resolveLib('../template/favicon.ico'),
+    appPackageJson: resolveLib('../package.json'),
+    appSrc: resolveLib('../template/src'),
+    appNodeModules: resolveLib('../node_modules'),
+    ownNodeModules: resolveLib('../node_modules')
   };
-} else if (isInNodeModules) {
+} else if (!isEjected) {
   // before eject: we're in ./node_modules/react-scripts/config/
   module.exports = {
-    appBuild: resolve('../../../build'),
-    appHtml: resolve('../../../index.html'),
-    appFavicon: resolve('../../../favicon.ico'),
-    appPackageJson: resolve('../../../package.json'),
-    appSrc: resolve('../../../src'),
-    appNodeModules: resolve('../..'),
+    appBuild: resolveApp('build'),
+    appHtml: resolveApp('index.html'),
+    appFavicon: resolveApp('favicon.ico'),
+    appPackageJson: resolveApp('package.json'),
+    appSrc: resolveApp('src'),
+    appNodeModules: resolveApp('node_modules'),
     // this is empty with npm3 but node resolution searches higher anyway:
-    ownNodeModules: resolve('../node_modules')
+    ownNodeModules: resolveLib('../node_modules')
   };
 } else {
   // after eject: we're in ./config/
   module.exports = {
-    appBuild: resolve('../build'),
-    appHtml: resolve('../index.html'),
-    appFavicon: resolve('../favicon.ico'),
-    appPackageJson: resolve('../package.json'),
-    appSrc: resolve('../src'),
-    appNodeModules: resolve('../node_modules'),
-    ownNodeModules: resolve('../node_modules')
+    appBuild: resolveApp('../build'),
+    appHtml: resolveApp('../index.html'),
+    appFavicon: resolveApp('../favicon.ico'),
+    appPackageJson: resolveApp('../package.json'),
+    appSrc: resolveApp('../src'),
+    appNodeModules: resolveApp('../node_modules'),
+    ownNodeModules: resolveApp('../node_modules')
   };
 }

--- a/config/paths.js
+++ b/config/paths.js
@@ -23,7 +23,7 @@ var isInCreateReactAppSource = (
   process.argv.some(arg => arg.indexOf('--debug-template') > -1)
 );
 
-function resolveLib(relativePath) {
+function resolveOwn(relativePath) {
   return path.resolve(__dirname, relativePath);
 }
 
@@ -34,13 +34,13 @@ function resolveApp(relativePath) {
 if (isInCreateReactAppSource) {
   // create-react-app development: we're in ./config/
   module.exports = {
-    appBuild: resolveLib('../build'),
-    appHtml: resolveLib('../template/index.html'),
-    appFavicon: resolveLib('../template/favicon.ico'),
-    appPackageJson: resolveLib('../package.json'),
-    appSrc: resolveLib('../template/src'),
-    appNodeModules: resolveLib('../node_modules'),
-    ownNodeModules: resolveLib('../node_modules')
+    appBuild: resolveOwn('../build'),
+    appHtml: resolveOwn('../template/index.html'),
+    appFavicon: resolveOwn('../template/favicon.ico'),
+    appPackageJson: resolveOwn('../package.json'),
+    appSrc: resolveOwn('../template/src'),
+    appNodeModules: resolveOwn('../node_modules'),
+    ownNodeModules: resolveOwn('../node_modules')
   };
 } else if (!isEjected) {
   // before eject: we're in ./node_modules/react-scripts/config/
@@ -52,7 +52,7 @@ if (isInCreateReactAppSource) {
     appSrc: resolveApp('src'),
     appNodeModules: resolveApp('node_modules'),
     // this is empty with npm3 but node resolution searches higher anyway:
-    ownNodeModules: resolveLib('../node_modules')
+    ownNodeModules: resolveOwn('../node_modules')
   };
 } else {
   // after eject: we're in ./config/

--- a/config/paths.js
+++ b/config/paths.js
@@ -57,12 +57,12 @@ if (isInCreateReactAppSource) {
 } else {
   // after eject: we're in ./config/
   module.exports = {
-    appBuild: resolveApp('../build'),
-    appHtml: resolveApp('../index.html'),
-    appFavicon: resolveApp('../favicon.ico'),
-    appPackageJson: resolveApp('../package.json'),
-    appSrc: resolveApp('../src'),
-    appNodeModules: resolveApp('../node_modules'),
-    ownNodeModules: resolveApp('../node_modules')
+    appBuild: resolveApp('build'),
+    appHtml: resolveApp('index.html'),
+    appFavicon: resolveApp('favicon.ico'),
+    appPackageJson: resolveApp('package.json'),
+    appSrc: resolveApp('src'),
+    appNodeModules: resolveApp('node_modules'),
+    ownNodeModules: resolveApp('node_modules')
   };
 }


### PR DESCRIPTION
I was having difficulties using a local copy of `react-scripts` and `npm link`ing it into a real world project. This change resolves paths relative to the current working directory (that is, most likely the directory of the app) rather than assuming a certain directory structure.

I've tested the "happy path" (that is, the use case I was trying to solve) locally and solved the problem, both by just running `npm start` and `npm run eject`ing and then running the app again. I was unable to test the other case of installing from npm - I'm actually not quite sure how to verify that. I imagine that's pretty important though, so I'd be very open to suggestions and guidance! I did run `npm test` which seems to cover a lot of cases though.