### PR TITLE
Make GH Pages support more discoverable

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -88,6 +88,9 @@ webpack(config).run(function(err, stats) {
     console.log('  pushstate-server build');
     console.log('  ' + openCommand + ' http://localhost:9000');
     console.log();
+    console.log(chalk.dim('The project was built assuming it is hosted at the root.'));
+    console.log(chalk.dim('Set the "homepage" field in package.json to override this.'));
+    console.log(chalk.dim('For example, "homepage": "http://user.github.io/project".'));
   }
   console.log();
 });


### PR DESCRIPTION
We need to better educate our users about support for this since it’s implicit.
I keep it dim so it’s less annoying.
Also, this notice will go away once you fill `homepage`.

<img width="771" alt="screen shot 2016-07-29 at 20 27 32" src="https://cloud.githubusercontent.com/assets/810438/17260918/034a3ac4-55cb-11e6-88fe-77402571a5dc.png">
