### PR TITLE
Add `dev-toolkit` Alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ If you don’t agree with the choices made in this project, you might want to ex
 * [roc](https://github.com/rocjs/roc)
 * [aik](https://github.com/d4rkr00t/aik)
 * [react-app](https://github.com/kriasoft/react-app)
+* [dev-toolkit](https://github.com/stoikerty/dev-toolkit)
 
 You can also use module bundlers like [webpack](http://webpack.github.io) and [Browserify](http://browserify.org/) directly.<br>
 React documentation includes [a walkthrough](https://facebook.github.io/react/docs/package-management.html) on this topic.


### PR DESCRIPTION
Adds the [`dev-toolkit` npm package](https://github.com/stoikerty/dev-toolkit) to the list of Alternatives.

I think it's awesome to finally see an official solution to what people have been asking for! So thanks a lot for that! :)

Sidenote:
Since I've needed something like `create-react-app`, I built something quite similar to this project and although [its sibling/cousin starter-project `dev-toolkit-starter`](https://github.com/stoikerty/dev-toolkit-starter) still has a few babel-dependencies, I'm trying to find a way to remove them. The `dev-toolkit-starter` is similar to what you get after using `create-react-app my-app`. Any ideas how I can remove those dependencies? You guys seem to have gotten rid of them quite easily.

##### Quick list of features:

- ES2015 / ES6
- root-relative imports
- Vanilla HMR
- Browsersync
- ESLint
- React
- jsx-control-statements
- sass / scss
- css-modules
- Autoprefixer
- classnames
- express
- react-router