### PR TITLE
Prevent Webpack from watching node_modules dir

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -155,7 +155,10 @@ function runDevServer(port) {
     historyApiFallback: true,
     hot: true, // Note: only CSS is currently hot reloaded
     publicPath: config.output.publicPath,
-    quiet: true
+    quiet: true,
+    watchOptions: {
+      ignored: /node_modules/
+    }
   }).listen(port, (err, result) => {
     if (err) {
       return console.log(err);


### PR DESCRIPTION
As discussed in #293, Webpack is watching the `node_modules` directory, which causes high CPU usage in some situations. This PR adds sets the `ignored` watchOption to prevent this.