### PR TITLE
Add `dev-toolkit` Alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ If you don’t agree with the choices made in this project, you might want to ex
 * [roc](https://github.com/rocjs/roc)
 * [aik](https://github.com/d4rkr00t/aik)
 * [react-app](https://github.com/kriasoft/react-app)
+* [dev-toolkit](https://github.com/stoikerty/dev-toolkit)
 
 You can also use module bundlers like [webpack](http://webpack.github.io) and [Browserify](http://browserify.org/) directly.<br>
 React documentation includes [a walkthrough](https://facebook.github.io/react/docs/package-management.html) on this topic.


### PR DESCRIPTION
Adds the [`dev-toolkit` npm package](https://github.com/stoikerty/dev-toolkit) to the list of Alternatives.

After some suggestions in my last PR https://github.com/facebookincubator/create-react-app/pull/292, I've changed my project to provide better command-line utilities for initializing an app. Managed to get rid of babel's dev-dependencies as well, so this is now a dependency-free project just like `create-react-app` :smiley: 