### PR TITLE
Added env (IGNORE_OPEN) before openBrowser.

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -167,7 +167,9 @@ function runDevServer(port) {
     clearConsole();
     console.log(chalk.cyan('Starting the development server...'));
     console.log();
-    openBrowser(port);
+    if(Boolean(process.env.IGNORE_OPEN))
+      openBrowser(port);
+    }
   });
 }
 


### PR DESCRIPTION
This env is chosen to make sure that there isn't a browser window showing up, when developing a Electron application. The start.js script can be used in the Electron index.js for launching the dev server and loading its url. 