### PR TITLE
Fix port detection lag on OS X with Firewall enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "chalk": "1.1.3",
     "cross-spawn": "4.0.0",
     "css-loader": "0.23.1",
-    "detect-port": "0.1.4",
     "eslint": "3.1.1",
     "eslint-loader": "1.4.1",
     "eslint-plugin-flowtype": "2.4.0",

--- a/scripts/eject.js
+++ b/scripts/eject.js
@@ -40,6 +40,7 @@ prompt(
     path.join('scripts', 'build.js'),
     path.join('scripts', 'start.js'),
     path.join('scripts', 'utils', 'chrome.applescript'),
+    path.join('scripts', 'utils', 'detectPort.js'),
     path.join('scripts', 'utils', 'prompt.js')
   ];
 

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -15,7 +15,7 @@ var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var execSync = require('child_process').execSync;
 var opn = require('opn');
-var detect = require('detect-port');
+var detect = require('./utils/detectPort');
 var prompt = require('./utils/prompt');
 var config = require('../config/webpack.config.dev');
 

--- a/scripts/utils/detectPort.js
+++ b/scripts/utils/detectPort.js
@@ -1,0 +1,86 @@
+/* ================================================================
+ * detect-port by xdf(xudafeng[at]126.com)
+ *
+ * first created at : Tue Mar 17 2015 00:16:10 GMT+0800 (CST)
+ *
+ * ================================================================
+ * Copyright xdf
+ *
+ * Licensed under the MIT License
+ * You may not use this file except in compliance with the License.
+ *
+ * ================================================================ */
+
+// We are forking this temporarily to resolve
+// https://github.com/facebookincubator/create-react-app/issues/302.
+
+// We can replace this fork with `detect-port` package when this is merged:
+// https://github.com/xudafeng/detect-port/pull/4.
+
+'use strict';
+
+var net = require('net');
+
+var inject = function(port) {
+  var options = global.__detect ? global.__detect.options : {};
+
+  if (options.verbose) {
+    console.log('port %d was occupied', port);
+  }
+};
+
+function detect(port, fn) {
+
+  var _detect = function(port) {
+    return new Promise(function(resolve, reject) {
+      var socket = new net.Socket();
+      socket.once('error', function() {
+        socket.removeAllListeners('connect');
+        socket.removeAllListeners('error');
+        socket.end();
+        socket.destroy();
+        socket.unref();
+        var server = new net.Server();
+        server.on('error', function() {
+          inject(port);
+          port++;
+          resolve(_detect(port));
+        });
+
+        server.listen(port, function() {
+          server.once('close', function() {
+            resolve(port);
+          });
+          server.close();
+        });
+      });
+      socket.once('connect', function() {
+        inject(port);
+        port++;
+        resolve(_detect(port));
+        socket.removeAllListeners('connect');
+        socket.removeAllListeners('error');
+        socket.end();
+        socket.destroy();
+        socket.unref();
+      });
+      socket.connect({
+        port: port
+      });
+    });
+  }
+
+  var _detect_with_cb = function(_fn) {
+    _detect(port)
+      .then(function(result) {
+        _fn(null, result);
+      })
+      .catch(function(e) {
+        _fn(e);
+      });
+  };
+
+  return fn ? _detect_with_cb(fn) : _detect(port);
+}
+
+module.exports = detect;


### PR DESCRIPTION
This fixes #302 by temporarily forking `detect-port`.
Hopefully this fix will be merged into the original project, and we can refer to it again.