### PR TITLE
Added a note with instructions on eslint plugin configuration

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -289,7 +289,11 @@ They are not required for linting. You should see the linter output right in you
 
 You would need to install an ESLint plugin for your editor first.
 
->Note: if you are using the `linter-eslint` plugin on Atom, make sure that **Use global ESLint installation** option is checked.
+>**A note for Atom `linter-eslint` users**
+
+>If you are using the Atom `linter-eslint` plugin, make sure that **Use global ESLint installation** option is checked:
+
+><img src="https://i.imgsafe.org/24b793bcf2.png" width="300">
 
 Then make sure `package.json` of your project ends with this block:
 

--- a/template/README.md
+++ b/template/README.md
@@ -275,7 +275,7 @@ import 'bootstrap/dist/css/bootstrap-theme.css';
 ```
 import React, { Component } from 'react';
 import { Navbar, Jumbotron, Button } from 'react-bootstrap';
-``` 
+```
 
 Now you are ready to use the imported React Bootstrap components within your component hierarchy defined in the render method. Here is an example [App.js](https://github.com/manavsehgal/react-eshop/blob/master/src/App.js) redone using React Bootstrap.
 
@@ -287,7 +287,10 @@ Some editors, including Sublime Text, Atom, and Visual Studio Code, provide plug
 
 They are not required for linting. You should see the linter output right in your terminal as well as the browser console. However, if you prefer the lint results to appear right in your editor, there are some extra steps you can do.
 
-You would need to install an ESLint plugin for your editor first.  
+You would need to install an ESLint plugin for your editor first.
+
+>Note: if you are using the `linter-eslint` plugin on Atom, make sure that **Use global ESLint installation** option is checked.
+
 Then make sure `package.json` of your project ends with this block:
 
 ```js


### PR DESCRIPTION
I've installed both Sublime Text and Visual Studio Code in order to see if I needed to add any extra configuration to make eslint work. 
Since the only editor that I found the issue was Atom, I added
just the instruction for the _linter-eslint_ plugin.

Below is the instruction that I added:

>Note: if you are using the `linter-eslint` plugin on Atom, make sure that **Use global ESLint installation** option is checked.