### PR TITLE
added initial POC for flow support

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -55,6 +55,11 @@ module.exports = {
         test: /\.js$/,
         loader: 'eslint',
         include: paths.appSrc,
+      },
+      {
+        test: /\.js$/,
+        loader: 'flowtype',
+        include: paths.appSrc,
       }
     ],
     loaders: [

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",
     "filesize": "3.3.0",
+    "flow-bin": "^0.30.0",
+    "flowtype-loader": "^0.2.0",
     "fs-extra": "0.30.0",
     "gzip-size": "3.0.0",
     "html-webpack-plugin": "2.22.0",


### PR DESCRIPTION
POC for issue #324 

``` sh
$ npm run create-react-app my-app
$ cd my-app
$ vim .flowconfig # copy template from: https://github.com/facebookincubator/create-react-app/blob/master/template/README.md#adding-flow
$ npm start
```

Instead of `vim .flowconfig`, you can do `wget https://gist.githubusercontent.com/torifat/756443d1bab62abda5f87c3ca2c90dc8/raw/ab2464634e3b0cd873d0ff302a83a5097964276f/.flowconfig` too.

Sample `App.js`:

```
/* @flow */
import React, { Component } from 'react';
import logo from './logo.svg';
import './App.css';

Math.pow('1212');

class App extends Component {
  render() {
    return (
      <div className="App">
        <div className="App-header">
          <img src={logo} className="App-logo" alt="logo" />
          <h2>Welcome to React</h2>
        </div>
        <p className="App-intro">
          To get started, edit <code>src/App.js</code> and save to reload.
        </p>
      </div>
    );
  }
}

export default App;
```

Sample Output:
<img width="1440" alt="screenshot 2016-08-04 07 48 00" src="https://cloud.githubusercontent.com/assets/208544/17387697/d00e8b1e-5a17-11e6-9889-d99d141f3073.png">
