### PR TITLE
Allow projects to customize Jest configs. Fixes #338.

### DIFF
--- a/.jestrc
+++ b/.jestrc
@@ -1,0 +1,5 @@
+{
+  "automock": false,
+  "rootDir": "./scripts",
+  "testEnvironment": "node"
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "create-react-app": "node global-cli/index.js --scripts-version \"$PWD/`npm pack`\"",
     "e2e": "tasks/e2e.sh",
     "start": "node scripts/start.js --debug-template",
-    "test": "node scripts/test.js --debug-template"
+    "test": "node scripts/test.js --debug-template",
+    "test-scripts": "jest --config='.jestrc'"
   },
   "files": [
     "PATENTS",

--- a/scripts/eject.js
+++ b/scripts/eject.js
@@ -105,6 +105,7 @@ prompt(
 
   appPackage.scripts.test = 'jest';
   appPackage.jest = createJestConfig(
+    appPackage.jest,
     filePath => path.join('<rootDir>', filePath)
   );
 

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -14,6 +14,7 @@ const jest = require('jest');
 const path = require('path');
 const paths = require('../config/paths');
 
+const appJestConfig = require(paths.appPackageJson).jest;
 const argv = process.argv.slice(2);
 
 const index = argv.indexOf('--debug-template');
@@ -22,6 +23,7 @@ if (index !== -1) {
 }
 
 argv.push('--config', JSON.stringify(createJestConfig(
+  appJestConfig,
   relativePath => path.resolve(__dirname, '..', relativePath),
   path.resolve(paths.appSrc, '..')
 )));

--- a/scripts/utils/__tests__/__snapshots__/create-jest-config-test.js.snap
+++ b/scripts/utils/__tests__/__snapshots__/create-jest-config-test.js.snap
@@ -1,0 +1,33 @@
+exports[`create-jest-config creates a config object 1`] = `
+Object {
+  "automock": false,
+  "moduleNameMapper": Object {
+    "^[./a-zA-Z0-9$_-]+\\.(jpg|png|gif|eot|svg|ttf|woff|woff2|mp4|webm)$": "<rootDir>/config/jest/FileStub.js",
+    "^[./a-zA-Z0-9$_-]+\\.css$": "<rootDir>/config/jest/CSSStub.js"
+  },
+  "persistModuleRegistryBetweenSpecs": true,
+  "scriptPreprocessor": "<rootDir>/config/jest/transform.js",
+  "setupFiles": Array [
+    "<rootDir>/config/polyfills.js"
+  ],
+  "testEnvironment": "node"
+}
+`;
+
+exports[`create-jest-config merges \`setupFiles\` and \`moduleNameMapper\` options 1`] = `
+Object {
+  "automock": false,
+  "moduleNameMapper": Object {
+    "^[./a-zA-Z0-9$_-]+\\.(jpg|png|gif|eot|svg|ttf|woff|woff2|mp4|webm)$": "config/jest/FileStub.js",
+    "^[./a-zA-Z0-9$_-]+\\.css$": "config/jest/CSSStub.js",
+    "b": "c"
+  },
+  "persistModuleRegistryBetweenSpecs": true,
+  "scriptPreprocessor": "config/jest/transform.js",
+  "setupFiles": Array [
+    "config/polyfills.js",
+    "a"
+  ],
+  "testEnvironment": "node"
+}
+`;

--- a/scripts/utils/__tests__/create-jest-config-test.js
+++ b/scripts/utils/__tests__/create-jest-config-test.js
@@ -1,0 +1,30 @@
+const createConfig = require('../create-jest-config');
+
+describe('create-jest-config', () => {
+
+  it('creates a config object', () => {
+    expect(createConfig({}, id => '<rootDir>/' + id)).toMatchSnapshot();
+  });
+
+  it('overwrites default options', () => {
+    expect(createConfig(
+      {
+        testEnvironment: 'jest-environment-jsdom',
+      },
+      id => id
+    ).testEnvironment).toBe('jest-environment-jsdom');
+  });
+
+  it('merges `setupFiles` and `moduleNameMapper` options', () => {
+    expect(createConfig(
+      {
+        setupFiles: ['a'],
+        moduleNameMapper: {
+          b: 'c',
+        },
+      },
+      id => id
+    )).toMatchSnapshot();
+  });
+
+});

--- a/scripts/utils/create-jest-config.js
+++ b/scripts/utils/create-jest-config.js
@@ -7,8 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-module.exports = (resolve, rootDir) => {
-  const config = {
+module.exports = (appConfig, resolve, rootDir) => {
+  const ownConfig = {
     automock: false,
     moduleNameMapper: {
       '^[./a-zA-Z0-9$_-]+\\.(jpg|png|gif|eot|svg|ttf|woff|woff2|mp4|webm)$': resolve('config/jest/FileStub.js'),
@@ -21,6 +21,22 @@ module.exports = (resolve, rootDir) => {
     ],
     testEnvironment: 'node'
   };
+
+  if (appConfig) {
+    // Merge user config into the default config.
+    if (appConfig.setupFiles) {
+      appConfig.setupFiles = ownConfig.setupFiles.concat(appConfig.setupFiles);
+    }
+    if (appConfig.moduleNameMapper) {
+      appConfig.moduleNameMapper = Object.assign(
+        {},
+        ownConfig.moduleNameMapper,
+        appConfig.moduleNameMapper
+      );
+    }
+  }
+
+  const config = Object.assign(ownConfig, appConfig);
   if (rootDir) {
     config.rootDir = rootDir;
   }

--- a/tasks/e2e.sh
+++ b/tasks/e2e.sh
@@ -48,8 +48,12 @@ cd ..
 # If you run it locally, you'll need to `git checkout -- package.json`.
 perl -i -p0e 's/bundledDependencies.*?]/bundledDependencies": []/s' package.json
 
-# Pack react-scripts
 npm install
+
+# Run tests
+npm run test-scripts
+
+# Pack react-scripts
 scripts_path=$PWD/`npm pack`
 
 # lint


### PR DESCRIPTION
This changes `create-jest-config` to take in the app's configuration so that people can decide to overwrite the defaults if they like.

I recommend people to use the node environment and not bother with jsdom, however people might have existing code that accesses DOM APIs. In such cases people can put 

```js
"jest": {
  "testEnvironment": "jest-environment-jsdom"
}
```

into their config and `npm run test` will merge the default config and the app config together. If someone decides to eject, the custom config will be kept in-tact when we write the default config into `package.json`.

I was unsure how to test my changes to test/eject so I figured I'll add a Jest test to `scripts` which can be invoked using `npm run test-scripts`. I used a snapshot test to lock in the Jest config and validated that it is correct. I also enjoy how meta it is to use snapshots in Jest to test a feature for Jest integration into a project that is promoting snapshot testing. Anyway, people can now write tests for stuff in `scripts/` to make sure we don't regress.

Fixes #338