### PR TITLE
add shebang to tasks scripts

### DIFF
--- a/tasks/e2e.sh
+++ b/tasks/e2e.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright (c) 2015-present, Facebook, Inc.
 # All rights reserved.
 #

--- a/tasks/release.sh
+++ b/tasks/release.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright (c) 2015-present, Facebook, Inc.
 # All rights reserved.
 #


### PR DESCRIPTION
`tasks/e2e.sh` and `tasks/release.sh` expect to be run with Bash (`function` etc) but fail in Dash (default Ubuntu `/bin/sh`) or Zsh (my default shell). Add shebangs so they run with the right shell.