### PR TITLE
Tweak Jest default settings

### DIFF
--- a/config/jest/environment.js
+++ b/config/jest/environment.js
@@ -1,0 +1,7 @@
+// Currently, Jest mocks setTimeout() and similar functions by default:
+// https://facebook.github.io/jest/docs/timer-mocks.html
+// We think this is confusing, so we disable this feature.
+// If you see value in it, run `jest.useFakeTimers()` in individual tests.
+beforeEach(() => {
+  jest.useRealTimers();
+});

--- a/scripts/eject.js
+++ b/scripts/eject.js
@@ -41,6 +41,7 @@ prompt(
     path.join('config', 'webpack.config.prod.js'),
     path.join('config', 'jest', 'CSSStub.js'),
     path.join('config', 'jest', 'FileStub.js'),
+    path.join('config', 'jest', 'environment.js'),
     path.join('config', 'jest', 'transform.js'),
     path.join('scripts', 'build.js'),
     path.join('scripts', 'start.js'),

--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -19,7 +19,9 @@ module.exports = (resolve, rootDir) => {
     setupFiles: [
       resolve('config/polyfills.js')
     ],
-    testEnvironment: 'node'
+    setupTestFrameworkScriptFile: resolve('config/jest/environment.js'),
+    testEnvironment: 'node',
+    verbose: true
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
Disable timer mocking and enable verbose output.
This makes my Mocha tests from another projects pass, and makes the output more obvious.