### PR TITLE
Added a root path in webpack to resolve long relative path imports

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -65,6 +65,7 @@ module.exports = {
     publicPath: '/'
   },
   resolve: {
+    root: paths.appSrc,
     // These are the reasonable defaults supported by the Node ecosystem.
     extensions: ['.js', '.json', ''],
     alias: {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -60,6 +60,7 @@ module.exports = {
     publicPath: publicPath
   },
   resolve: {
+    root: paths.appSrc,
     // These are the reasonable defaults supported by the Node ecosystem.
     extensions: ['.js', '.json', ''],
     alias: {

--- a/template/src/App.js
+++ b/template/src/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import logo from './logo.svg';
-import './App.css';
+import logo from 'logo.svg';
+import 'App.css';
 
 class App extends Component {
   render() {

--- a/template/src/index.js
+++ b/template/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
-import './index.css';
+import App from 'App';
+import 'index.css';
 
 ReactDOM.render(
   <App />,


### PR DESCRIPTION
Here is my pull request for #388

Test Plan:
This solved relative path issues in my deeply nested folder structure as well as the create-react-app template folder.

This change does not disrupt imported node modules or existing relative paths 

These node commands are in good standing:
npm start
npm test
npm run build

Cheers :)
