### PR TITLE
Allowing .jsx extensions in webpack

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -66,7 +66,7 @@ module.exports = {
   },
   resolve: {
     // These are the reasonable defaults supported by the Node ecosystem.
-    extensions: ['.js', '.json', ''],
+    extensions: ['.js', '.jsx', '.json', ''],
     alias: {
       // This `alias` section can be safely removed after ejection.
       // We do this because `babel-runtime` may be inside `react-scripts`,
@@ -91,7 +91,7 @@ module.exports = {
     // It's important to do this before Babel processes the JS.
     preLoaders: [
       {
-        test: /\.js$/,
+        test: /\.(js)x?$/,
         loader: 'eslint',
         include: paths.appSrc,
       }
@@ -99,7 +99,7 @@ module.exports = {
     loaders: [
       // Process JS with Babel.
       {
-        test: /\.js$/,
+        test: /\.(js)x?$/,
         include: paths.appSrc,
         loader: 'babel',
         query: require('./babel.dev')

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -61,7 +61,7 @@ module.exports = {
   },
   resolve: {
     // These are the reasonable defaults supported by the Node ecosystem.
-    extensions: ['.js', '.json', ''],
+    extensions: ['.js', '.jsx', '.json', ''],
     alias: {
       // This `alias` section can be safely removed after ejection.
       // We do this because `babel-runtime` may be inside `react-scripts`,
@@ -86,7 +86,7 @@ module.exports = {
     // It's important to do this before Babel processes the JS.
     preLoaders: [
       {
-        test: /\.js$/,
+        test: /\.(js)x?$/,
         loader: 'eslint',
         include: paths.appSrc
       }
@@ -94,7 +94,7 @@ module.exports = {
     loaders: [
       // Process JS with Babel.
       {
-        test: /\.js$/,
+        test: /\.(js)x?$/,
         include: paths.appSrc,
         loader: 'babel',
         query: require('./babel.prod')


### PR DESCRIPTION
I don't know if this is wanted, but I've used .jsx to identify components in personal and work projects. 

We usually have it as a rule of thumb to have `.jsx` for files that export React Components and `.js` for files that do not include jsx syntax. This is both helpful to identify component files while scanning the project and is helpful when using editors that identify `.jsx` files to use JSX syntax highlighting instead of regular javascript highlight.

If this is not wanted feel free to close this 👍 