### PR TITLE
remove variations in Button example code

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -228,9 +228,11 @@ import './Button.css'; // Tell Webpack that Button.js uses these styles
 class Button extends Component {
   render() {
     // You can use them as regular CSS styles
-    return <div className="Button" />;
+    return <Button />;
   }
 }
+
+export default Button;
 ```
 
 **This is not required for React** but many people find this feature convenient. You can read about the benefits of this approach [here](https://medium.com/seek-ui-engineering/block-element-modifying-your-javascript-components-d7f99fcab52b). However you should be aware that this makes your code less portable to other build tools and environments than Webpack.


### PR DESCRIPTION
Small change that may help flatten some people's learning curve: button example code was different from the first instance to a subsequent instance. Similarly, the final example did not include the 'export' statement (which, as is pointed out earlier in the README, creates an issue that can be hard to troubleshoot). This small change proposes fixes to these two items to avoid possible confusion.