### PR TITLE
Disable dot rule of connect-history-api-fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-runtime": "6.11.6",
     "case-sensitive-paths-webpack-plugin": "1.1.3",
     "chalk": "1.1.3",
-    "connect-history-api-fallback": "1.2.0",
+    "connect-history-api-fallback": "1.3.0",
     "cross-spawn": "4.0.0",
     "css-loader": "0.23.1",
     "detect-port": "1.0.0",

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -173,6 +173,8 @@ function addMiddleware(devServer) {
   // Every unrecognized request will be forwarded to it.
   var proxy = require(paths.appPackageJson).proxy;
   devServer.use(historyApiFallback({
+    // Allow paths with dots in them to be loaded, reference issue #387
+    disableDotRule: true,
     // For single page apps, we generally want to fallback to /index.html.
     // However we also want to respect `proxy` for API calls.
     // So if `proxy` is specified, we need to decide which fallback to use.


### PR DESCRIPTION
Ref #387 

Verified by running `npm start` and opening `localhost:3000/page/test.com` in the browser as specified in the initial issue.