### PR TITLE
Add a hash to media files even in the devmode.

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -131,7 +131,7 @@ module.exports = {
         exclude: /\/favicon.ico$/,
         loader: 'file',
         query: {
-          name: 'static/media/[name].[ext]'
+          name: 'static/media/[name].[hash:8].[ext]'
         }
       },
       // A special case for favicon.ico to place it into build root directory.
@@ -151,7 +151,7 @@ module.exports = {
         loader: 'url',
         query: {
           limit: 10000,
-          name: 'static/media/[name].[ext]'
+          name: 'static/media/[name].[hash:8].[ext]'
         }
       },
       // "html" loader is used to process template page (index.html) to resolve


### PR DESCRIPTION
This will work correctly when there are duplicate filenames in different paths.
Fixes: #445