### PR TITLE
Deactivate the `new-cap` rule in ESLint

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -62,7 +62,6 @@ module.exports = {
     'dot-location': ['warn', 'property'],
     eqeqeq: ['warn', 'allow-null'],
     'guard-for-in': 'warn',
-    'new-cap': ['warn', { newIsCap: true }],
     'new-parens': 'warn',
     'no-array-constructor': 'warn',
     'no-caller': 'warn',


### PR DESCRIPTION
This rule is considered dangerous in certain situations. This is especially true for Immutable.js users. See the discussion at issue #465 for more information about this.

Fixes #465 