### PR TITLE
Made webpack respect NODE_PATH environment variable

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -12,6 +12,7 @@
 
 var REACT_APP = /^REACT_APP_/i;
 var NODE_ENV = JSON.stringify(process.env.NODE_ENV || 'development');
+var NODE_PATH = process.env.NODE_PATH || '';
 
 module.exports = Object
   .keys(process.env)
@@ -20,5 +21,6 @@ module.exports = Object
     env['process.env.' + key] = JSON.stringify(process.env[key]);
     return env;
   }, {
-    'process.env.NODE_ENV': NODE_ENV
+    'process.env.NODE_ENV': NODE_ENV,
+    'process.env.NODE_PATH': NODE_PATH
   });

--- a/config/env.js
+++ b/config/env.js
@@ -12,7 +12,6 @@
 
 var REACT_APP = /^REACT_APP_/i;
 var NODE_ENV = JSON.stringify(process.env.NODE_ENV || 'development');
-var NODE_PATH = process.env.NODE_PATH || '';
 
 module.exports = Object
   .keys(process.env)
@@ -21,6 +20,5 @@ module.exports = Object
     env['process.env.' + key] = JSON.stringify(process.env[key]);
     return env;
   }, {
-    'process.env.NODE_ENV': NODE_ENV,
-    'process.env.NODE_PATH': NODE_PATH
+    'process.env.NODE_ENV': NODE_ENV
   });

--- a/config/paths.js
+++ b/config/paths.js
@@ -11,6 +11,7 @@
 // and use those instead. This way we don't need to branch here.
 
 var path = require('path');
+var os = require('os');
 
 // True after ejecting, false when used as a dependency
 var isEjected = (
@@ -31,6 +32,16 @@ function resolveApp(relativePath) {
   return path.resolve(relativePath);
 }
 
+function resolveNodePath(paths) {
+  if (paths === '') {
+    return []
+  }
+  var separator = os.platform() === 'win32' ? ';' : ':';
+  return paths.split(separator).map(p => path.resolve(p));
+}
+
+var nodePath = resolveNodePath(process.env.NODE_PATH || '');
+
 if (isInCreateReactAppSource) {
   // create-react-app development: we're in ./config/
   module.exports = {
@@ -39,7 +50,8 @@ if (isInCreateReactAppSource) {
     appPackageJson: resolveOwn('../package.json'),
     appSrc: resolveOwn('../template/src'),
     appNodeModules: resolveOwn('../node_modules'),
-    ownNodeModules: resolveOwn('../node_modules')
+    ownNodeModules: resolveOwn('../node_modules'),
+    nodePath: nodePath
   };
 } else if (!isEjected) {
   // before eject: we're in ./node_modules/react-scripts/config/
@@ -50,7 +62,8 @@ if (isInCreateReactAppSource) {
     appSrc: resolveApp('src'),
     appNodeModules: resolveApp('node_modules'),
     // this is empty with npm3 but node resolution searches higher anyway:
-    ownNodeModules: resolveOwn('../node_modules')
+    ownNodeModules: resolveOwn('../node_modules'),
+    nodePath: nodePath
   };
 } else {
   // after eject: we're in ./config/
@@ -60,6 +73,7 @@ if (isInCreateReactAppSource) {
     appPackageJson: resolveApp('package.json'),
     appSrc: resolveApp('src'),
     appNodeModules: resolveApp('node_modules'),
-    ownNodeModules: resolveApp('node_modules')
+    ownNodeModules: resolveApp('node_modules'),
+    nodePath: nodePath
   };
 }

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -67,7 +67,7 @@ module.exports = {
   resolve: {
     // This allows you to set a root for where webpack should look for modules.
     // This enables you to use absolute imports from the root.
-    root: path.resolve(process.env.NODE_PATH || ''),
+    root: paths.nodePath,
     // These are the reasonable defaults supported by the Node ecosystem.
     extensions: ['.js', '.json', ''],
     alias: {

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -67,7 +67,7 @@ module.exports = {
   resolve: {
     // This allows you to set a root for where webpack should look for modules.
     // This enables you to use absolute imports from the root.
-    root: path.resolve(env['process.env.NODE_PATH']),
+    root: path.resolve(process.env.NODE_PATH || ''),
     // These are the reasonable defaults supported by the Node ecosystem.
     extensions: ['.js', '.json', ''],
     alias: {

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -65,6 +65,9 @@ module.exports = {
     publicPath: '/'
   },
   resolve: {
+    // This allows you to set a root for where webpack should look for modules.
+    // This enables you to use absolute imports from the root.
+    root: path.resolve(env['process.env.NODE_PATH']),
     // These are the reasonable defaults supported by the Node ecosystem.
     extensions: ['.js', '.json', ''],
     alias: {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -62,7 +62,7 @@ module.exports = {
   resolve: {
     // This allows you to set a root for where webpack should look for modules.
     // This enables you to use absolute imports from the root.
-    root: path.resolve(process.env.NODE_PATH || ''),
+    root: paths.nodePath,
     // These are the reasonable defaults supported by the Node ecosystem.
     extensions: ['.js', '.json', ''],
     alias: {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -60,6 +60,9 @@ module.exports = {
     publicPath: publicPath
   },
   resolve: {
+    // This allows you to set a root for where webpack should look for modules.
+    // This enables you to use absolute imports from the root.
+    root: path.resolve(env['process.env.NODE_PATH']),
     // These are the reasonable defaults supported by the Node ecosystem.
     extensions: ['.js', '.json', ''],
     alias: {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -62,7 +62,7 @@ module.exports = {
   resolve: {
     // This allows you to set a root for where webpack should look for modules.
     // This enables you to use absolute imports from the root.
-    root: path.resolve(env['process.env.NODE_PATH']),
+    root: path.resolve(process.env.NODE_PATH || ''),
     // These are the reasonable defaults supported by the Node ecosystem.
     extensions: ['.js', '.json', ''],
     alias: {


### PR DESCRIPTION
This addresses #253. Nothing should change by default, but you are able to set your NODE_PATH environment variable if you want absolute path imports.

## Test Plan

I tested this by changing `import App from './App';` to `import App from 'App';` in index.js. Without setting `NODE_PATH` run and build will now fail because it can't find the module. After setting the the `NODE_PATH` to `./template/src' the project both builds and runs. 

I also generated a new project, which you can find [here](https://github.com/jimmyhmiller/node-path-create-react-app-test) that uses this absolute import. I did the equivalent change in the tests directory and the tests pass.

Let me know if you have any questions or any suggestions.