### PR TITLE
Use most recent React version

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -10,6 +10,7 @@
 var fs = require('fs-extra');
 var path = require('path');
 var spawn = require('cross-spawn');
+var spawnSync = require('cross-spawn').sync;
 var pathExists = require('path-exists');
 var chalk = require('chalk');
 
@@ -23,7 +24,17 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
   appPackage.dependencies = appPackage.dependencies || {};
   appPackage.devDependencies = appPackage.devDependencies || {};
   ['react', 'react-dom'].forEach(function (key) {
-    appPackage.dependencies[key] = ownPackage.devDependencies[key];
+    var args = [
+      'view',
+      key,
+      'version',
+      verbose && '--verbose'
+    ].filter(function(e) { return e; });
+    var result = spawnSync('npm', args, {encoding: 'utf8'});
+
+    appPackage.dependencies[key] = result.status === 0 ?
+      '^' + result.stdout.trim() :
+      ownPackage.devDependencies[key];
   });
   ['react-test-renderer'].forEach(function (key) {
     appPackage.devDependencies[key] = ownPackage.devDependencies[key];

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -10,7 +10,6 @@
 var fs = require('fs-extra');
 var path = require('path');
 var spawn = require('cross-spawn');
-var spawnSync = spawn.sync;
 var pathExists = require('path-exists');
 var chalk = require('chalk');
 
@@ -62,28 +61,25 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
     }
   });
 
-  // Run npm installs for react and react-dom
+  // Run another npm install for react and react-dom
   console.log('Installing react and react-dom from npm...');
   console.log();
   // TODO: having to do two npm installs is bad, can we avoid it?
-
-  var installFailed;
-  ['react', 'react-dom', 'react-test-renderer'].forEach(function (pkg) {
-    var args = [
-      'install',
-      pkg,
-      pkg === 'react-test-renderer' ? '--save-dev' : '--save',
-      verbose && '--verbose'
-    ].filter(function(e) { return e; });
-    var result = spawnSync('npm', args, {stdio: 'inherit'});
-
-    if (result.status !== 0) {
+  var args = [
+    'install',
+    'react',
+    'react-dom',
+    'react-test-renderer',
+    '--save',
+    verbose && '--verbose'
+  ].filter(function(e) { return e; });
+  var proc = spawn('npm', args, {stdio: 'inherit'})
+  proc.on('close', function (code) {
+    if (code !== 0) {
       console.error('`npm ' + args.join(' ') + '` failed');
-      installFailed = true;
+      return;
     }
-  });
 
-  if (!installFailed) {
     // Display the most elegant way to cd.
     // This needs to handle an undefined originalDirectory for
     // backward compatibility with old global-cli's.
@@ -114,4 +110,4 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
     console.log();
     console.log('Happy hacking!');
   }
-};
+});

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -73,7 +73,7 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
     '--save',
     verbose && '--verbose'
   ].filter(function(e) { return e; });
-  var proc = spawn('npm', args, {stdio: 'inherit'})
+  var proc = spawn('npm', args, {stdio: 'inherit'});
   proc.on('close', function (code) {
     if (code !== 0) {
       console.error('`npm ' + args.join(' ') + '` failed');
@@ -109,5 +109,5 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
     }
     console.log();
     console.log('Happy hacking!');
-  }
-});
+  });
+}

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -110,4 +110,4 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
     console.log();
     console.log('Happy hacking!');
   });
-}
+};


### PR DESCRIPTION
Fixes #473. I thought the best approach would be calling `npm view react[-dom] version` and then using the output. If it fails, it falls back to the old method of getting the version. The other alternative I considered was just doing a separate install of react and react-dom, but then you'd end up with more extra npm installs.

Test plan: I ran `init` and the new app had version `^15.3.1` in the package.json, instead of `^15.3.0`, which is how it is in the `create-react-app` repo and when creating a new app off of master.