### PR TITLE
Fix default package version added by global CLI

### DIFF
--- a/global-cli/index.js
+++ b/global-cli/index.js
@@ -84,7 +84,7 @@ function createApp(name, verbose, version) {
 
   var packageJson = {
     name: appName,
-    version: '0.0.1',
+    version: '0.1.0',
     private: true,
   };
   fs.writeFileSync(


### PR DESCRIPTION
According to the official SemVer FAQ, versioning should start at 0.1.0 (http://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase)