### PR TITLE
Error 'ReferenceError: "window" is not defined' in browserless environment

### DIFF
--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -3,7 +3,9 @@ if (typeof Promise === 'undefined') {
   // inconsistent state due to an error, but it gets swallowed by a Promise,
   // and the user has no idea what causes React's erratic future behavior.
   require('promise/lib/rejection-tracking').enable();
-  window.Promise = require('promise/lib/es6-extensions.js');
+  if (typeof window !== 'undefined') {
+    window.Promise = require('promise/lib/es6-extensions.js');
+  }
 }
 
 // fetch() polyfill for making API calls.


### PR DESCRIPTION
An issue occurs when polyfills.js is being used in a browserless environment, such as being run directly using Node or Nashorn.