### PR TITLE
Added `proxyPaths` option to package.json

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -171,7 +171,11 @@ function openBrowser(port) {
 function addMiddleware(devServer) {
   // `proxy` lets you to specify a fallback server during development.
   // Every unrecognized request will be forwarded to it.
-  var proxy = require(paths.appPackageJson).proxy;
+  var pkg = require(paths.appPackageJson);
+
+  var proxy = pkg.proxy;
+  var proxyPaths = pkg.proxyPaths;
+
   devServer.use(historyApiFallback({
     // Allow paths with dots in them to be loaded, reference issue #387
     disableDotRule: true,
@@ -184,7 +188,12 @@ function addMiddleware(devServer) {
     // If this heuristic doesn’t work well for you, don’t use `proxy`.
     htmlAcceptHeaders: proxy ?
       ['text/html'] :
-      ['text/html', '*/*']
+      ['text/html', '*/*'],
+    // Pass `proxyPaths` directly to the proxy.
+    rewrites: proxyPaths && proxyPaths.map(path => ({
+      from: new RegExp(path),
+      to: context => context.parsedUrl.pathname,
+    }))
   }));
   if (proxy) {
     if (typeof proxy !== 'string') {

--- a/template/README.md
+++ b/template/README.md
@@ -496,6 +496,14 @@ Fetch API cannot load http://localhost:4000/api/todos. No 'Access-Control-Allow-
 
 Keep in mind that `proxy` only has effect in development (with `npm start`), and it is up to you to ensure that URLs like `/api/todos` point to the right thing in production. You don’t have to use the `/api` prefix. Any unrecognized request will be redirected to the specified `proxy`.
 
+By default, the development server will only attempt to send requests **without** a `text/html` accept header to the proxy. To pass html requests to the proxy, add a `proxyPaths` field to your `package.json`. For example:
+
+```js
+  "proxyPaths": [
+    "^/auth",
+  ],
+```
+
 Currently the `proxy` option only handles HTTP requests, and it won’t proxy WebSocket connections.  
 If the `proxy` option is **not** flexible enough for you, alternatively you can:
 


### PR DESCRIPTION
This allows `text/html` requests to be passed to the proxy.