### PR TITLE
Add a more prominent link to the guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ It correctly bundles React in production mode and optimizes the build for the be
 The build is minified and the filenames include the hashes.<br>
 Your app is ready to be deployed!
 
-## How Do I…?
+## User Guide
 
 The generated project will include a guide in its README.<br>
 You can also read its latest version [here](https://github.com/facebookincubator/create-react-app/blob/master/template/README.md).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Create React apps with no build configuration.
 
+* [Getting Started](#getting-started)
+* [Guide](https://github.com/facebookincubator/create-react-app/blob/master/template/README.md)
+
 ## tl;dr
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Create React apps with no build configuration.
 
-* [Getting Started](#getting-started)
-* [Guide](https://github.com/facebookincubator/create-react-app/blob/master/template/README.md)
+* [Getting Started](#getting-started) – How to create a new app.
+* [User Guide](https://github.com/facebookincubator/create-react-app/blob/master/template/README.md) – How to develop apps bootstrapped with Create React App.
 
 ## tl;dr
 


### PR DESCRIPTION
As a contributor, I know where to find the documentation/guide since know the codebase, but I've seen people miss the link to it in the README, because it's not very prominent. Let's try to make it more discoverable by including a link to it right on top of the page.