### PR TITLE
Enable watch implicitly unless on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "create-react-app": "node global-cli/index.js --scripts-version \"$PWD/`npm pack`\"",
     "e2e": "tasks/e2e.sh",
     "start": "node scripts/start.js --debug-template",
-    "test": "node scripts/test.js --debug-template --watch --env=jsdom"
+    "test": "node scripts/test.js --debug-template --env=jsdom"
   },
   "files": [
     "PATENTS",

--- a/scripts/eject.js
+++ b/scripts/eject.js
@@ -101,7 +101,7 @@ prompt(
   delete appPackage.scripts['eject'];
   Object.keys(appPackage.scripts).forEach(function (key) {
     appPackage.scripts[key] = appPackage.scripts[key]
-      .replace(/react-scripts test/g, 'jest')
+      .replace(/react-scripts test/g, 'jest --watch')
       .replace(/react-scripts (\w+)/g, 'node scripts/$1.js');
   });
 

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -26,7 +26,7 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
   appPackage.scripts = {
     'start': 'react-scripts start',
     'build': 'react-scripts build',
-    'test': 'react-scripts test --watch --env=jsdom',
+    'test': 'react-scripts test --env=jsdom',
     'eject': 'react-scripts eject'
   };
 

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -22,6 +22,11 @@ if (debugTemplateIndex !== -1) {
   argv.splice(debugTemplateIndex, 1);
 }
 
+// Watch unless on CI
+if (!process.env.CI) {
+  argv.push('--watch');
+}
+
 argv.push('--config', JSON.stringify(createJestConfig(
   relativePath => path.resolve(__dirname, '..', relativePath),
   path.resolve(paths.appSrc, '..')

--- a/tasks/e2e.sh
+++ b/tasks/e2e.sh
@@ -67,8 +67,8 @@ test -e build/static/css/*.css
 test -e build/static/media/*.svg
 test -e build/favicon.ico
 
-# Run tests, overriding watch option to disable it
-npm test -- --watch=no
+# Run tests with CI flag
+CI=true npm test
 # Uncomment when snapshot testing is enabled by default:
 # test -e template/src/__snapshots__/App.test.js.snap
 
@@ -101,8 +101,8 @@ test -e build/static/css/*.css
 test -e build/static/media/*.svg
 test -e build/favicon.ico
 
-# Run tests, overriding watch option to disable it
-npm test -- --watch=no
+# Run tests with CI flag
+CI=true npm test
 # Uncomment when snapshot testing is enabled by default:
 # test -e src/__snapshots__/App.test.js.snap
 
@@ -120,7 +120,8 @@ test -e build/static/css/*.css
 test -e build/static/media/*.svg
 test -e build/favicon.ico
 
-# Run tests, overriding watch option to disable it
+# Run tests, overring the watch option to disable it
+# TODO: make CI flag respected after ejecting as well
 npm test -- --watch=no
 # Uncomment when snapshot testing is enabled by default:
 # test -e src/__snapshots__/App.test.js.snap


### PR DESCRIPTION
Fixes #532.

By default project won’t have `--watch`.
We will always assume that `react-scripts test` launches the watcher.

However we offer an escape hatch. If `process.env.CI` is defined, we disable watching. This should satisfy most use cases, and people who really insist on not using a watcher can always `CI=true npm test`. However our intention is to keep improving the watcher and we will push for it to become the default workflow.