### PR TITLE
Disable react-constant-elements because of bugs

### DIFF
--- a/config/babel.prod.js
+++ b/config/babel.prod.js
@@ -33,6 +33,10 @@ module.exports = {
       regenerator: true
     }],
     // Optimization: hoist JSX that never changes out of render()
-    require.resolve('babel-plugin-transform-react-constant-elements')
+    // Disabled because of issues:
+    // * https://github.com/facebookincubator/create-react-app/issues/525
+    // * https://phabricator.babeljs.io/search/query/pCNlnC2xzwzx/
+    // TODO: Enable again when these issues are resolved.
+    // require.resolve('babel-plugin-transform-react-constant-elements')
   ]
 };


### PR DESCRIPTION
Disabled because of issues:

 * https://github.com/facebookincubator/create-react-app/issues/525
 * https://phabricator.babeljs.io/search/query/pCNlnC2xzwzx/

TODO: Enable again when these issues are resolved.