### PR TITLE
Resolve babel-runtime relative to the config

### DIFF
--- a/config/babel.dev.js
+++ b/config/babel.dev.js
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+var path = require('path');
+
 module.exports = {
   // Don't try to find .babelrc because we want to force this configuration.
   babelrc: false,
@@ -33,7 +35,10 @@ module.exports = {
     [require.resolve('babel-plugin-transform-runtime'), {
       helpers: false,
       polyfill: false,
-      regenerator: true
+      regenerator: true,
+      // Resolve the Babel runtime relative to the config.
+      // You can safely remove this after ejecting:
+      moduleName: path.dirname(require.resolve('babel-runtime/package'))
     }]
   ]
 };

--- a/config/babel.prod.js
+++ b/config/babel.prod.js
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+var path = require('path');
+
 module.exports = {
   // Don't try to find .babelrc because we want to force this configuration.
   babelrc: false,
@@ -30,7 +32,10 @@ module.exports = {
     [require.resolve('babel-plugin-transform-runtime'), {
       helpers: false,
       polyfill: false,
-      regenerator: true
+      regenerator: true,
+      // Resolve the Babel runtime relative to the config.
+      // You can safely remove this after ejecting:
+      moduleName: path.dirname(require.resolve('babel-runtime/package'))
     }],
     // Optimization: hoist JSX that never changes out of render()
     require.resolve('babel-plugin-transform-react-constant-elements')

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -68,15 +68,8 @@ module.exports = {
     // These are the reasonable defaults supported by the Node ecosystem.
     extensions: ['.js', '.json', ''],
     alias: {
-      // This `alias` section can be safely removed after ejection.
-      // We do this because `babel-runtime` may be inside `react-scripts`,
-      // so when `babel-plugin-transform-runtime` imports it, it will not be
-      // available to the app directly. This is a temporary solution that lets
-      // us ship support for generators. However it is far from ideal, and
-      // if we don't have a good solution, we should just make `babel-runtime`
-      // a dependency in generated projects.
-      // See https://github.com/facebookincubator/create-react-app/issues/255
-      'babel-runtime/regenerator': require.resolve('babel-runtime/regenerator'),
+      // Support React Native Web
+      // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web'
     }
   },

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -63,15 +63,8 @@ module.exports = {
     // These are the reasonable defaults supported by the Node ecosystem.
     extensions: ['.js', '.json', ''],
     alias: {
-      // This `alias` section can be safely removed after ejection.
-      // We do this because `babel-runtime` may be inside `react-scripts`,
-      // so when `babel-plugin-transform-runtime` imports it, it will not be
-      // available to the app directly. This is a temporary solution that lets
-      // us ship support for generators. However it is far from ideal, and
-      // if we don't have a good solution, we should just make `babel-runtime`
-      // a dependency in generated projects.
-      // See https://github.com/facebookincubator/create-react-app/issues/255
-      'babel-runtime/regenerator': require.resolve('babel-runtime/regenerator'),
+      // Support React Native Web
+      // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web'
     }
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-plugin-transform-react-constant-elements": "6.9.1",
     "babel-plugin-transform-regenerator": "6.14.0",
-    "babel-plugin-transform-runtime": "6.12.0",
+    "babel-plugin-transform-runtime": "6.15.0",
     "babel-preset-latest": "6.14.0",
     "babel-preset-react": "6.11.1",
     "babel-runtime": "6.11.6",


### PR DESCRIPTION
This makes generators work with Jest.

Fixes #255.
Replaces #262.