### PR TITLE
Ignore coverage folder generated by jest

### DIFF
--- a/template/gitignore
+++ b/template/gitignore
@@ -3,6 +3,9 @@
 # dependencies
 node_modules
 
+# testing
+coverage
+
 # production
 build
 


### PR DESCRIPTION
Thank you for create-react-app. Really amazing tools greatly packaged up.

I always run my tests with coverage to maintain 100% code coverage so I tried create-react-app 0.3.0 but noticed the coverage folder was not getting ignored by git.

So, this simply ignores the coverage folder since I don't think it belongs in source control.