### PR TITLE
Add missing breaking change description from 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ npm install --save-dev --save-exact react-scripts@0.3.1
 
 * Testing is [now supported](https://github.com/facebookincubator/create-react-app/blob/master/template/README.md#running-tests)! ([Jest project contributors](https://github.com/facebook/jest/pulls?q=is%3Apr+is%3Aclosed), [@cpojer](https://github.com/cpojer) in [#250](https://github.com/facebookincubator/create-react-app/pull/250), [@gaearon](https://github.com/gaearon) in [#378](https://github.com/facebookincubator/create-react-app/pull/378), [#530](https://github.com/facebookincubator/create-react-app/pull/530), [#533](https://github.com/facebookincubator/create-react-app/pull/533))
 * Static files such as CSS, images, and fonts, can now exist outside `src` directory. ([@fson](https://github.com/fson) in [#504](https://github.com/facebookincubator/create-react-app/pull/504))
-* Local paths in `<link href>` in `index.html` will now be correctly resolved, so deleting `favicon.ico` is not an error anymore. ([@andreypopp](https://github.com/andreypopp) in [#428](https://github.com/facebookincubator/create-react-app/pull/428))
+* **Breaking Change:** Local paths in `<link href>` in `index.html` will now be correctly resolved, so deleting `favicon.ico` is not an error anymore. ([@andreypopp](https://github.com/andreypopp) in [#428](https://github.com/facebookincubator/create-react-app/pull/428))
 * Removed an annoying lint rule that warned for `<div ref={node => this.node = node}>`. ([@mrscobbler](https://github.com/mrscobbler) in [#529](https://github.com/facebookincubator/create-react-app/pull/529))
 * Temporarily disabled `react-constant-elements` Babel transform because of its bugs. ([@gaearon](https://github.com/gaearon) in [#534](https://github.com/facebookincubator/create-react-app/pull/534))
 * Fixed a permission issue with Docker. ([@gaearon](https://github.com/gaearon) in [73c940](https://github.com/facebookincubator/create-react-app/commit/73c940a73205d761230f8d6bf81ecfd460ba28a9))
@@ -68,6 +68,17 @@ Inside any created project that has not been ejected, run:
 ```
 npm install --save-dev --save-exact react-scripts@0.3.0
 ```
+
+#### Breaking Change
+
+Now `favicon.ico` is not treated specially anymore.  
+If you use it, move it to `src` and add the following line to `<head>` in your HTML:
+
+```html
+<link rel="shortcut icon" href="./src/favicon.ico">
+```
+
+#### New Feature
 
 Since 0.3.0 added a test runner, we recommend that you add it to the `scripts` section of your `package.json` like this:
 


### PR DESCRIPTION
We missed this one, sorry!

----

#### Missing Breaking Change in 0.3.0

Now `favicon.ico` is not treated specially anymore.  
If you use it, move it to `src` and add the following line to `<head>` in your HTML:

```html
<link rel="shortcut icon" href="./src/favicon.ico">
```
