### PR TITLE
Warn about unsupported Node.js versions

### DIFF
--- a/global-cli/package.json
+++ b/global-cli/package.json
@@ -17,7 +17,7 @@
     "create-react-app": "./index.js"
   },
   "engines": {
-    "node" : ">=6"
+    "node": ">=6"
   },
   "dependencies": {
     "chalk": "^1.1.1",

--- a/global-cli/package.json
+++ b/global-cli/package.json
@@ -16,6 +16,9 @@
   "bin": {
     "create-react-app": "./index.js"
   },
+  "engines": {
+    "node" : ">=6"
+  },
   "dependencies": {
     "chalk": "^1.1.1",
     "cross-spawn": "^4.0.0",

--- a/global-cli/package.json
+++ b/global-cli/package.json
@@ -7,6 +7,9 @@
   "description": "Create React apps with no build configuration.",
   "repository": "facebookincubator/create-react-app",
   "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=4"
+  },
   "bugs": {
     "url": "https://github.com/facebookincubator/create-react-app/issues"
   },
@@ -15,9 +18,6 @@
   ],
   "bin": {
     "create-react-app": "./index.js"
-  },
-  "engines": {
-    "node": ">=6"
   },
   "dependencies": {
     "chalk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "facebookincubator/create-react-app",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=4"
   },
   "bugs": {
     "url": "https://github.com/facebookincubator/create-react-app/issues"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "facebookincubator/create-react-app",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "bugs": {
     "url": "https://github.com/facebookincubator/create-react-app/issues"
@@ -26,9 +26,6 @@
   ],
   "bin": {
     "react-scripts": "./bin/react-scripts.js"
-  },
-  "engines": {
-    "node" : ">=6"
   },
   "dependencies": {
     "autoprefixer": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "bin": {
     "react-scripts": "./bin/react-scripts.js"
   },
+  "engines": {
+    "node" : ">=6"
+  },
   "dependencies": {
     "autoprefixer": "6.4.0",
     "babel-core": "6.14.0",


### PR DESCRIPTION
Add the `engines` field to package.json so users of old Node.js versions
will at least get a warning when trying to install create-react-app:

```
npm WARN engine react-scripts@0.4.1: wanted: {"node":">=4"} (current: {"node":"2.5.0","npm":"2.13.2"})
```

Fixes the issue raised in #570.