### PR TITLE
Fix mocking assets with special characters in the file path

### DIFF
--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -21,8 +21,8 @@ module.exports = (resolve, rootDir) => {
   const config = {
     moduleFileExtensions: ['jsx', 'js', 'json'],
     moduleNameMapper: {
-      '^[./a-zA-Z0-9$_-]+\\.(jpg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm)$': resolve('config/jest/FileStub.js'),
-      '^[./a-zA-Z0-9$_-]+\\.css$': resolve('config/jest/CSSStub.js')
+      '^.+\\.(jpg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm)$': resolve('config/jest/FileStub.js'),
+      '^.+\\.css$': resolve('config/jest/CSSStub.js')
     },
     scriptPreprocessor: resolve('config/jest/transform.js'),
     setupFiles: setupFiles,


### PR DESCRIPTION
The regexes in the Jest `moduleNameMapper` configs were a bit too strict,
causing them to not pick up files with special characters like `@` in the
file path. Change them to match anything with the correct file extension.

Fixes #579.

Test plan:
* Created a file named `template/src/logo@2x.png`.
* Added `import './logo@2x.png';` to `App.js`.
* Ran `npm test`. Tests pass.