### PR TITLE
Add ES5 version of `path-exists` to CLI

### DIFF
--- a/global-cli/index.js
+++ b/global-cli/index.js
@@ -41,7 +41,6 @@ var spawn = require('cross-spawn');
 var chalk = require('chalk');
 var semver = require('semver');
 var argv = require('minimist')(process.argv.slice(2));
-var pathExists = require('path-exists');
 
 /**
  * Arguments:
@@ -69,7 +68,7 @@ createApp(commands[0], argv.verbose, argv['scripts-version']);
 
 function createApp(name, verbose, version) {
   var root = path.resolve(name);
-  if (!pathExists.sync(name)) {
+  if (!pathExists(name)) {
     fs.mkdirSync(root);
   } else if (!isSafeToCreateProjectIn(root)) {
     console.log('The directory `' + name + '` contains file(s) that could conflict. Aborting.');
@@ -178,4 +177,18 @@ function isSafeToCreateProjectIn(root) {
     .every(function(file) {
       return validFiles.indexOf(file) >= 0;
     });
+}
+
+// This is an ES5 version of https://github.com/sindresorhus/path-exists
+// The reason it exists is so that the CLI doesn't break before being able to
+// warn the user they're using an unsupported version of Node.
+//
+// See https://github.com/facebookincubator/create-react-app/issues/570
+function pathExists(fp) {
+  try {
+    fs.accessSync(fp);
+    return true;
+  } catch (err) {
+    return false;
+  }
 }


### PR DESCRIPTION
See https://github.com/facebookincubator/create-react-app/issues/570#issuecomment-244588738, though it may not be needed as the issue was closed.

I couldn't find a way to put it in its own file and have both `global-cli/index.js` and the stuff under `scripts/` use it (I kept getting errors that the file was not found in the CLI) so I just put in the file that needed it :p