### PR TITLE
Exempt variables prefixed with underscore from no-unused-vars rule

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -131,7 +131,10 @@ module.exports = {
     'no-unreachable': 'warn',
     'no-unused-expressions': 'warn',
     'no-unused-labels': 'warn',
-    'no-unused-vars': ['warn', { vars: 'local', args: 'none' }],
+    'no-unused-vars': ['warn', {
+      vars: 'local',
+      args: 'none'
+    }],
     'no-use-before-define': ['warn', 'nofunc'],
     'no-useless-computed-key': 'warn',
     'no-useless-concat': 'warn',

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -133,6 +133,7 @@ module.exports = {
     'no-unused-labels': 'warn',
     'no-unused-vars': ['warn', {
       vars: 'local',
+      varsIgnorePattern: '^_',
       args: 'none'
     }],
     'no-use-before-define': ['warn', 'nofunc'],


### PR DESCRIPTION
This is useful when e.g. using object spread operator to remove only a
certain field from the object.

For example, this can be used to ignore a property from React
component's `this.props`:

```js
class OpinionatedDebugger extends React.Component {
  render() {
    const { justIgnoreMe: _unused, ...rest } = this.props;
    return <pre>{ JSON.stringify(rest) }</pre>;
  }
}
```

This PR was asked by Dan via Twitter when he replied to [my tweet about ignoring unused variables with underscore prefix](https://twitter.com/valscion/status/775754615933501440): https://twitter.com/dan_abramov/status/775764929894809602

## Test plan:

Write this to any JS file in the project and observe no warnings are shown:

```js
var obj = { a: 1, b: 2 };
var { a: _unused, ...rest } = obj;
console.log(rest);
```

<img width="429" alt="screen shot 2016-09-13 at 22 45 01" src="https://cloud.githubusercontent.com/assets/482561/18488828/c777310c-7a03-11e6-91a1-d0b2a25081a8.png">


Then try to change it to this and observe warnings _are_ shown:

```js
var obj = { a: 1, b: 2 };
var { a, ...rest } = obj;
console.log(rest);
```

<img width="852" alt="screen shot 2016-09-13 at 22 45 14" src="https://cloud.githubusercontent.com/assets/482561/18488835/cdf62236-7a03-11e6-8ef5-1edf9dbae6bc.png">


## Same approach elsewhere

This approach is similar in nature to what `rubocop`, the de-facto linter in Ruby, specifies in its default config as well: https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars

>  Prefix with `_` unused block parameters and local variables. It's also acceptable to use just `_ `(although it's a bit less descriptive). This convention is recognized by the Ruby interpreter and tools like RuboCop and will suppress their unused variable warnings.