### PR TITLE
Resolve app paths from realpath of CWD, fix #637

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -12,6 +12,13 @@
 var path = require('path');
 var fs = require('fs');
 
+// Make sure any symlinks in the project folder are resolved:
+// https://github.com/facebookincubator/create-react-app/issues/637
+var appDirectory = fs.realpathSync(process.cwd());
+function resolveApp(relativePath) {
+  return path.resolve(appDirectory, relativePath);
+}
+
 // We support resolving modules according to `NODE_PATH`.
 // This lets you use absolute paths in imports inside large monorepos:
 // https://github.com/facebookincubator/create-react-app/issues/253.
@@ -26,11 +33,7 @@ var fs = require('fs');
 var nodePaths = (process.env.NODE_PATH || '')
   .split(process.platform === 'win32' ? ';' : ':')
   .filter(Boolean)
-  .map(p => path.resolve(p));
-
-function resolveApp(relativePath) {
-  return path.resolve(fs.realpathSync(process.cwd()), relativePath);
-}
+  .map(resolveApp);
 
 // config after eject: we're in ./config/
 module.exports = {

--- a/config/paths.js
+++ b/config/paths.js
@@ -10,6 +10,7 @@
 // @remove-on-eject-end
 
 var path = require('path');
+var fs = require('fs');
 
 // We support resolving modules according to `NODE_PATH`.
 // This lets you use absolute paths in imports inside large monorepos:
@@ -28,7 +29,7 @@ var nodePaths = (process.env.NODE_PATH || '')
   .map(p => path.resolve(p));
 
 function resolveApp(relativePath) {
-  return path.resolve(relativePath);
+  return path.resolve(fs.realpathSync(process.cwd()), relativePath);
 }
 
 // config after eject: we're in ./config/


### PR DESCRIPTION
This makes all paths returned from `resolveApp()` begin with the `realpath` of the app root, resolving any symlinks etc.

Note: `realpathSync` throws when its argument is a non-existing path, so this change only assumes that `process.cwd()` exists and does a plain `resolve` from there.

@guivho Can you try this in your newly created project? `npm install motiz88/create-react-app#resolve-symlink-cwd && npm start` (later you can do `npm install react-scripts` to restore things to normal).