### PR TITLE
Remove eslintConfig from package.json

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -30,11 +30,6 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
     'eject': 'react-scripts eject'
   };
 
-  // explicitly specify ESLint config path for editor plugins
-  appPackage.eslintConfig = {
-    extends: './node_modules/react-scripts/config/eslint.js',
-  };
-
   fs.writeFileSync(
     path.join(appPath, 'package.json'),
     JSON.stringify(appPackage, null, 2)

--- a/template/README.md
+++ b/template/README.md
@@ -157,7 +157,7 @@ You would need to install an ESLint plugin for your editor first.
 
 ><img src="http://i.imgur.com/yVNNHJM.png" width="300">
 
-Then make sure `package.json` of your project ends with this block:
+Then add this block to the `package.json` file of your project:
 
 ```js
 {
@@ -167,9 +167,6 @@ Then make sure `package.json` of your project ends with this block:
   }
 }
 ```
-
-Projects generated with `react-scripts@0.2.0` and higher should already have it.  
-If you don’t need ESLint integration with your editor, you can safely delete those three lines from your `package.json`.
 
 Finally, you will need to install some packages *globally*:
 


### PR DESCRIPTION
**tl;dr** The `eslintConfig` setting is used to make editor plugins such as `linter` use our ESLint configuration, but at the moment this requires additional packages and configuration to work, and we should not create the project with broken configuration. The configuration can still be added manually.

At the moment, when you create an app, the `eslintConfig` setting gets added to package.json. If you have an ESLint package (e.g. [linter](https://atom.io/packages/linter) with [linter-eslint](https://atom.io/packages/linter-eslint)) installed in your editor, you'll get a big error:

![screen shot 2016-09-14 at 18 32 55](https://cloud.githubusercontent.com/assets/497214/18519432/9c8d900e-7aac-11e6-82b4-a94a89ca9856.png)
This error is shown every time you save a file, so you're forced to figure out what to do, even if you were just starting out and didn't want to configure the integrations yet.

After a little digging you'll find the [instructions](https://github.com/facebookincubator/create-react-app/tree/edddc50af77298b0d9ed61d37263924d48af036c/template#displaying-lint-output-in-the-editor) for installing the ESLint integration. We instruct the user to install ESLint and all the ESLint plugins globally and to configure the editor plugin to use the global ESLint. This is less than ideal for a few reasons:
* The user now needs to track the ESLint plugins dependencies used by CRA and their versions manually and keep their global packages up-to-date.
* You can't have different projects with different ESLint or ESLint plugin versions. Opening a file from a (non-CRA) project using an incompatible version now creates an error because your editor tries to use the globally installed ESLint and plugins:
![screen shot 2016-09-14 at 16 37 36](https://cloud.githubusercontent.com/assets/497214/18519866/1c20b1a6-7aae-11e6-94ad-df54ea10a35f.png)

I've also seen people trying to edit the `eslintConfig` in package.json in order to use their own ESLint configuration, which doesn't work, which also makes having the configuration there misleading.

As we mention in the readme, having to rely on global ESlint will be fixed when [ESlint is going to add support for having plugins as dependencies in packages like react-scripts](https://github.com/eslint/eslint/issues/3458), so we can enable the integration by default at that point. But until this has been fixed, it's better to not add this configuration by default. People can still find the instructions and add it manually when they want it and they're ready to do the plugin setup, but we should not create a configuration that doesn't work out of the box.