### PR TITLE
Bump webpack-dev-server to version 1.15.2 to fix #574

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
     "webpack": "1.13.2",
-    "webpack-dev-server": "1.15.1",
+    "webpack-dev-server": "1.15.2",
     "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Tested it locally with HTTPS=true (and without). The "WDS Disconnected" message no longer appears, and both HTTP and HTTPS reload correctly when changes are made.