### PR TITLE
Add the GitHub issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+If you are reporting a bug, please fill in below. Otherwise feel to remove this template entirely.
+
+### Description
+
+What are you reporting?
+
+### Expected behavior
+
+Tell us what you think should happen
+
+### Actual behavior
+
+Tell us what actually happens
+
+### Environment
+
+1. `create-react-app`: version
+2. Node: version
+3. NPM: version
+4. Operating system:
+5. Browser & version:
+
+### Reproducible demo
+
+Please take the time to create a new CRA app that reproduces the issue.
+Alternatively, you could copy your app that experiences the problem and start removing things until you're left with the minimal reproducible demo.
+(Accidentially, you might get to the root of your problem during that process.)
+
+Push to GitHub and paste the link here.
+
+By doing this, you're helping the CRA contributors a big time!
+Demonstrable issues gets fixed faster.


### PR DESCRIPTION
Collecting all the relevant details early on means less back and forth between the poster and project contributors. Asking to create a small reproducible demo means less time wasted trying to repro the bug.

Brunch has been doing this for a while and it has really helped. There are people who deleted the template and went free-form in their bug reports but for the most part, people have actually been filling that in:
https://github.com/brunch/brunch/issues?q=is%3Aissue+is%3Aclosed

A lesser percentage of the people were creating the demos, but a few definitely were. The details, and the demos especially, led to faster resolution times, which a win for everyone.

---

I do see bugs account for about 13% of issues so there might be a bit less value of this than for Brunch, but the first few bug reports I picked from the list have @gaearon asking for env details/demo, which is a routine work that can be precisely removed with the issue template.