### PR TITLE
Provide empty Node mocks for fs, net, tls

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -203,5 +203,12 @@ module.exports = {
     // makes the discovery automatic so you don't have to restart.
     // See https://github.com/facebookincubator/create-react-app/issues/186
     new WatchMissingNodeModulesPlugin(paths.appNodeModules)
-  ]
+  ],
+  // Some libraries import Node modules but don't use them in the browser.
+  // Tell Webpack to provide empty mocks for them so importing them works.
+  node: {
+    fs: 'empty',
+    net: 'empty',
+    tls: 'empty'
+  }
 };

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -238,5 +238,12 @@ module.exports = {
     }),
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
     new ExtractTextPlugin('static/css/[name].[contenthash:8].css')
-  ]
+  ],
+  // Some libraries import Node modules but don't use them in the browser.
+  // Tell Webpack to provide empty mocks for them so importing them works.
+  node: {
+    fs: 'empty',
+    net: 'empty',
+    tls: 'empty'
+  }
 };


### PR DESCRIPTION
This is occasionally requested, e.g. for https://github.com/facebookincubator/create-react-app/issues/495. I checked, and `request()` works if I add these mocks.

The mocks are empty objects.
They don’t increase size normally because they are added lazily only if you import them.