### PR TITLE
Add notes on enabling Travis CI for created repo

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -770,7 +770,27 @@ Note that tests run much slower with coverage so it is recommended to run it sep
 
 By default `npm test` runs the watcher with interactive CLI. However, you can force it to run tests once and finish the process by setting an environment variable called `CI`. Popular CI servers already set it by default but you can do this yourself too:
 
-#### Windows (cmd.exe)
+### On CI servers
+#### Travis CI
+
+1. Following the [Travis Getting started](https://docs.travis-ci.com/user/getting-started/) guide for syncing your Github repository with Travis.  You may need to initialize some settings manually in your [profile](https://travis-ci.org/profile) page.
+1. Add a `.travis.yml` file to your git repository.
+```
+language: node_js
+node_js:
+  - 4
+  - 6
+cache:
+  directories:
+  - node_modules
+script
+  - npm test
+```
+1. Trigger your first build with a git push.
+1. [Customize your Travis CI Build](https://docs.travis-ci.com/user/customizing-the-build/) if needed.
+
+### On your own environment
+##### Windows (cmd.exe)
 
 ```cmd
 set CI=true&&npm test
@@ -778,7 +798,7 @@ set CI=true&&npm test
 
 (Note: the lack of whitespace is intentional.)
 
-#### Linux, OS X (Bash)
+##### Linux, OS X (Bash)
 
 ```bash
 CI=true npm test


### PR DESCRIPTION
As promised in #365 , adding notes on enabling Travis CI for a generated app.

### Demo
- [Demo Repo](https://github.com/Jiansen/CRA-Travis-Demo)
- [Travis Build](https://travis-ci.org/Jiansen/CRA-Travis-Demo)

### Effects of Change
In the generated app, users will see the note under the **Continuous Integration** section.

### Local verification
In a development branch, run `npm run create-react-app my-app` and check the README.md in the generated app (my-app).

### Note
[Build 3](https://travis-ci.org/Jiansen/CRA-Travis-Demo/builds/160884798) encounters the following error on the Node 4 test.  As the Node 6 build succeeds, the failure shall not be related to CRA.

```
> CRA-Travis-Demo@0.1.0 test /home/travis/build/Jiansen/CRA-Travis-Demo
> react-scripts test --env=jsdom
module.js:327
    throw err;
    ^
Error: Cannot find module 'lru-cache'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/travis/build/Jiansen/CRA-Travis-Demo/node_modules/react-scripts/node_modules/cross-spawn/lib/parse.js:4:11)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
npm ERR! Test failed.  See above for more details.
```