### PR TITLE
Update eslint-plugin-react and enable new rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint-plugin-flowtype": "2.18.1",
     "eslint-plugin-import": "1.12.0",
     "eslint-plugin-jsx-a11y": "2.2.2",
-    "eslint-plugin-react": "5.2.2",
+    "eslint-plugin-react": "6.3.0",
     "lerna": "2.0.0-beta.28"
   }
 }

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -189,11 +189,14 @@ module.exports = {
     }],
     'react/jsx-uses-react': 'warn',
     'react/jsx-uses-vars': 'warn',
+    'react/no-danger-with-children': 'warn',
     'react/no-deprecated': 'warn',
     'react/no-direct-mutation-state': 'warn',
+    'react/no-find-dom-node': 'warn',
     'react/no-is-mounted': 'warn',
     'react/react-in-jsx-scope': 'warn',
     'react/require-render-return': 'warn',
+    'react/style-prop-object': 'warn',
 
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
     'jsx-a11y/aria-role': 'warn',

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -192,7 +192,6 @@ module.exports = {
     'react/no-danger-with-children': 'warn',
     'react/no-deprecated': 'warn',
     'react/no-direct-mutation-state': 'warn',
-    'react/no-find-dom-node': 'warn',
     'react/no-is-mounted': 'warn',
     'react/react-in-jsx-scope': 'warn',
     'react/require-render-return': 'warn',

--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -16,6 +16,6 @@
     "eslint-plugin-flowtype": "2.18.1",
     "eslint-plugin-import": "1.12.0",
     "eslint-plugin-jsx-a11y": "2.2.2",
-    "eslint-plugin-react": "5.2.2"
+    "eslint-plugin-react": "6.3.0"
   }
 }

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-flowtype": "2.18.1",
     "eslint-plugin-import": "1.12.0",
     "eslint-plugin-jsx-a11y": "2.2.2",
-    "eslint-plugin-react": "5.2.2",
+    "eslint-plugin-react": "6.3.0",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",
     "filesize": "3.3.0",


### PR DESCRIPTION
Some new rules had been added that are a good fit for this project. All of these are either already runtime warnings in React (no-danger-with-children, style-prop-object) or React features that are going to be deprecated in the future (no-find-dom-node). The new rules:
* [`react/no-danger-with-children`](https://github.com/yannickcr/eslint-plugin-react/blob/v6.3.0/docs/rules/no-danger-with-children.md) (yannickcr/eslint-plugin-react#710)
* [`react/no-find-dom-node`](https://github.com/yannickcr/eslint-plugin-react/blob/v6.3.0/docs/rules/no-find-dom-node.md) (yannickcr/eslint-plugin-react#678)
* [`react/style-prop-object`](https://github.com/yannickcr/eslint-plugin-react/blob/v6.3.0/docs/rules/style-prop-object.md) (yannickcr/eslint-plugin-react#715)