### PR TITLE
Fix the e2e test

### DIFF
--- a/tasks/e2e.sh
+++ b/tasks/e2e.sh
@@ -96,13 +96,14 @@ clean_path=`mktemp -d 2>/dev/null || mktemp -d -t 'clean_path'`
 # Copy some of the react-scripts project files to the temporary folder.
 # Exclude folders that definitely won’t be part of the package from processing.
 # We will strip the dev-only code there, `npm pack`, and copy the package back.
-cd $root_path/packages/react-scripts
+cd $root_path
 rsync -av --exclude='.git' --exclude=$clean_path\
   --exclude='node_modules' --exclude='build'\
   './' $clean_path  >/dev/null
 
 # Open the clean folder
-cd $clean_path
+cd $clean_path/packages/react-scripts
+
 # Now remove all the code relevant to development of Create React App.
 files="$(find -L . -name "*.js" -type f)"
 for file in $files; do
@@ -110,9 +111,17 @@ for file in $files; do
   rm $file.bak
 done
 
+# Install all our packages
+cd $clean_path
+$root_path/node_modules/.bin/lerna bootstrap
+
+cd $clean_path/packages/react-scripts
+
+# This modifies $clean_path/package.json to copy all dependencies to bundledDependencies
+node ./node_modules/.bin/bundle-deps
+
 # Finally, pack react-scripts
-npm install
-scripts_path=$clean_path/`npm pack`
+scripts_path=$clean_path/packages/react-scripts/`npm pack`
 
 # ******************************************************************************
 # Now that we have packed them, create a clean app folder and install them.

--- a/tasks/e2e.sh
+++ b/tasks/e2e.sh
@@ -117,7 +117,7 @@ $root_path/node_modules/.bin/lerna bootstrap
 
 cd $clean_path/packages/react-scripts
 
-# This modifies $clean_path/package.json to copy all dependencies to bundledDependencies
+# This modifies package.json to copy all dependencies to bundledDependencies
 node ./node_modules/.bin/bundle-deps
 
 # Finally, pack react-scripts


### PR DESCRIPTION
In the end-to-end test, we want to test all the latest packages from
the monorepo instead of the versions from npm.

To do this we will now:
* run `lerna bootstrap` in the repo root folder before packaging react-scripts
* bundle the deps like we do for releases, so the e2e test uses those packages