### PR TITLE
Attempt to fix the e2e test

### DIFF
--- a/tasks/bundle-own-deps.js
+++ b/tasks/bundle-own-deps.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+// Like bundle-deps, this script modifies packages/react-scripts/package.json,
+// copying own dependencies (those in the `packages` dir) to bundledDependencies
+
+const fs = require('fs');
+const path = require('path');
+
+const packagesDir = path.join(__dirname, '../packages');
+const pkgFilename = path.join(packagesDir, 'react-scripts/package.json');
+const data = require(pkgFilename);
+
+data.bundledDependencies = fs.readdirSync(packagesDir)
+  .filter((name) => data.dependencies[name]);
+
+fs.writeFile(pkgFilename, JSON.stringify(data, null, 2), 'utf8', (err) => {
+  if (err) throw err;
+  console.log('bundled ' + data.bundledDependencies.length + ' dependencies.');
+});

--- a/tasks/e2e.sh
+++ b/tasks/e2e.sh
@@ -117,8 +117,9 @@ $root_path/node_modules/.bin/lerna bootstrap
 
 cd $clean_path/packages/react-scripts
 
-# This modifies package.json to copy all dependencies to bundledDependencies
-node ./node_modules/.bin/bundle-deps
+# Like bundle-deps, this script modifies packages/react-scripts/package.json,
+# copying own dependencies (those in the `packages` dir) to bundledDependencies
+node $clean_path/tasks/bundle-own-deps.js
 
 # Finally, pack react-scripts
 scripts_path=$clean_path/packages/react-scripts/`npm pack`


### PR DESCRIPTION
Only copy our own packages to bundledDependencies in the e2e test.

We previously (#699) added bundling all the dependencies to the e2e test, but this can crash Travis ([#701](https://github.com/facebookincubator/create-react-app/pull/701#issuecomment-248985286)), when it runs out of memory trying to bundle them.