### PR TITLE
openBrowser() causes docker-compose set ups to fail because of spawn EACCESS 

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -173,7 +173,7 @@ function openBrowser(port, protocol) {
   try {
     opn(protocol + '://localhost:' + port + '/');
   } catch (err) {
-    console.log('Unable to automatically open ' +protocol + '://localhost:' + port + '/ because ', err)
+    // Ignore errors.
   }
 }
 

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -170,7 +170,11 @@ function openBrowser(port, protocol) {
   }
   // Fallback to opn
   // (It will always open new tab)
-  opn(protocol + '://localhost:' + port + '/');
+  try {
+    opn(protocol + '://localhost:' + port + '/');
+  } catch (err) {
+    console.log('Unable to automatically open ' +protocol + '://localhost:' + port + '/ because ', err)
+  }
 }
 
 // We need to provide a custom onError function for httpProxyMiddleware.


### PR DESCRIPTION
closes #710