### PR TITLE
Preserve scripts/test.js after ejecting

### DIFF
--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -39,6 +39,7 @@ prompt(
     path.join('config', 'jest', 'FileStub.js'),
     path.join('scripts', 'build.js'),
     path.join('scripts', 'start.js'),
+    path.join('scripts', 'test.js'),
     path.join('scripts', 'utils', 'checkRequiredFiles.js'),
     path.join('scripts', 'utils', 'chrome.applescript'),
     path.join('scripts', 'utils', 'getClientEnvironment.js'),
@@ -98,7 +99,6 @@ prompt(
   delete appPackage.scripts['eject'];
   Object.keys(appPackage.scripts).forEach(function (key) {
     appPackage.scripts[key] = appPackage.scripts[key]
-      .replace(/react-scripts test/g, 'jest --watch')
       .replace(/react-scripts (\w+)/g, 'node scripts/$1.js');
   });
 

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -1,3 +1,4 @@
+// @remove-on-eject-begin
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
  * All rights reserved.
@@ -6,6 +7,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+// @remove-on-eject-end
 
 process.env.NODE_ENV = 'test';
 process.env.PUBLIC_URL = '';
@@ -16,7 +18,6 @@ process.env.PUBLIC_URL = '';
 // https://github.com/motdotla/dotenv
 require('dotenv').config({silent: true});
 
-const createJestConfig = require('./utils/createJestConfig');
 const jest = require('jest');
 const path = require('path');
 const paths = require('../config/paths');
@@ -28,10 +29,14 @@ if (!process.env.CI) {
   argv.push('--watch');
 }
 
+// @remove-on-eject-begin
+// This is not necessary after eject because we embed config into package.json.
+const createJestConfig = require('./utils/createJestConfig');
 argv.push('--config', JSON.stringify(createJestConfig(
   relativePath => path.resolve(__dirname, '..', relativePath),
   path.resolve(paths.appSrc, '..'),
   false
 )));
+// @remove-on-eject-end
 
 jest.run(argv);


### PR DESCRIPTION
Fixes #702.
Fixes inconsistencies introduced on eject (e.g. lack of handling of `CI` variable or `dotenv`).