### PR TITLE
Enable jsx-key rule

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -181,6 +181,7 @@ module.exports = {
 
     // https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules
     'react/jsx-equals-spacing': ['warn', 'never'],
+    'react/jsx-key': 'warn',
     'react/jsx-no-duplicate-props': ['warn', { ignoreCase: true }],
     'react/jsx-no-undef': 'warn',
     'react/jsx-pascal-case': ['warn', {


### PR DESCRIPTION
It enforces to check that all arrays within JSX tree have defined `key` property.

From Twitter thread: https://twitter.com/boriscoder/status/779312554996822016