### PR TITLE
Relaxed eslint rule no-unused-expressions

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -127,7 +127,10 @@ module.exports = {
     'no-undef': 'error',
     'no-unexpected-multiline': 'warn',
     'no-unreachable': 'warn',
-    'no-unused-expressions': 'warn',
+    'no-unused-expressions': ['warn', {
+      'allowShortCircuit': true,
+      'allowTernary': true
+    }],
     'no-unused-labels': 'warn',
     'no-unused-vars': ['warn', {
       vars: 'local',


### PR DESCRIPTION
Now allows the use of short circuit and ternary expressions.

Resolves #722.