### PR TITLE
Warns when the user is using special webpack syntax

### DIFF
--- a/packages/react-dev-utils/BlockUnsupportedWebpackLoaderSyntax.js
+++ b/packages/react-dev-utils/BlockUnsupportedWebpackLoaderSyntax.js
@@ -7,26 +7,25 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-// This Webpack plugin warns the user when using special webpack syntax
+// This Webpack plugin forbids usage of special webpack syntax
 // to disable loaders (https://webpack.github.io/docs/loaders.html#loader-order)
 // This makes it very coupled to webpack and might break in the future.
 // See https://github.com/facebookincubator/create-react-app/issues/733.
 
 'use strict';
 
-var chalk = require('chalk');
-
-class WarnAboutLoaderDisablingPlugin {
+class BlockUnsupportedWebpackLoaderSyntax {
   apply(compiler) {
     compiler.plugin('normal-module-factory', (normalModuleFactory) => {
       normalModuleFactory.plugin('before-resolve', (data, callback) => {
+        let error = null;
         if (data.request.match(/^-?!!?/)) {
-          chalk.yellow(`Warning: You are requesting '${data.request}'. Special Webpack Loaders syntax is not officially supported and makes you code very coupled to Webpack, which might break in the future, we recommend that you remove it. See `https://github.com/facebookincubator/create-react-app/issues/733`);
+          error = `You are requesting '${data.request}'. Special Webpack Loaders syntax is not officially supported and makes you code very coupled to Webpack, which might break in the future, we recommend that you remove it. See https://github.com/facebookincubator/create-react-app/issues/733`;
         }
-        callback(null, data);
-      })
+        callback(error, data);
+      });
     });
   }
 }
 
-module.exports = WarnAboutLoaderDisablingPlugin;
+module.exports = BlockUnsupportedWebpackLoaderSyntax;

--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -97,6 +97,9 @@ module.exports = {
   // ...
   plugins: [
     // ...
+    // This warns about using Webpack Special Loader syntax, which makes it
+    // very coupled to Webpack and might break in the future.
+    // See https://github.com/facebookincubator/create-react-app/issues/733
     new WarnAboutLoaderDisablingPlugin()
   ],
   // ...

--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -81,7 +81,7 @@ module.exports = {
 }
 ```
 
-#### `new WarnAboutDisablingPlugin()`
+#### `new BlockUnsupportedWebpackLoaderSyntax()`
 
 This Webpack plugin warns the user when using special webpack syntax for
 disabling loaders (like `!!file!./stuff`). This makes it very coupled
@@ -90,17 +90,17 @@ See [#733](https://github.com/facebookincubator/create-react-app/issues/733) for
 
 ```js
 var path = require('path');
-var WarnAboutLoaderDisablingPlugin = require('react-dev-utils/WarnAboutLoaderDisablingPlugin);
+var BlockUnsupportedWebpackLoaderSyntax = require('react-dev-utils/BlockUnsupportedWebpackLoaderSyntax');
 
 // Webpack config
 module.exports = {
   // ...
   plugins: [
     // ...
-    // This warns about using Webpack Special Loader syntax, which makes it
+    // This forbids usage of Webpack Special Loader syntax, which makes it
     // very coupled to Webpack and might break in the future.
     // See https://github.com/facebookincubator/create-react-app/issues/733
-    new WarnAboutLoaderDisablingPlugin()
+    new BlockUnsupportedWebpackLoaderSyntax()
   ],
   // ...
 }

--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -81,6 +81,28 @@ module.exports = {
 }
 ```
 
+#### `new WarnAboutDisablingPlugin()`
+
+This Webpack plugin warns the user when using special webpack syntax for
+disabling loaders (like `!!file!./stuff`). This makes it very coupled
+to webpack special syntax and might break in the future.
+See [#733](https://github.com/facebookincubator/create-react-app/issues/733) for details.
+
+```js
+var path = require('path');
+var WarnAboutLoaderDisablingPlugin = require('react-dev-utils/WarnAboutLoaderDisablingPlugin);
+
+// Webpack config
+module.exports = {
+  // ...
+  plugins: [
+    // ...
+    new WarnAboutLoaderDisablingPlugin()
+  ],
+  // ...
+}
+```
+
 #### `checkRequiredFiles(files: Array<string>): boolean`
 
 Makes sure that all passed files exist.  

--- a/packages/react-dev-utils/WarnAboutLoaderDisablingPlugin.js
+++ b/packages/react-dev-utils/WarnAboutLoaderDisablingPlugin.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+// This Webpack plugin warns the user when using special webpack syntax
+// to distable loaders (https://webpack.github.io/docs/loaders.html#loader-order)
+// This makes it very coupled to webpack and might break in the future.
+// See https://github.com/facebookincubator/create-react-app/issues/733.
+
+'use strict';
+
+var chalk = require('chalk');
+
+class WatchAboutLoaderDisablingPlugin {
+  apply(compiler) {
+    compiler.plugin('normal-module-factory', (normalModuleFactory) => {
+      normalModuleFactory.plugin('before-resolve', (data, callback) => {
+        if (data.request.match('!')) {
+          chalk.yellow(`Warning: You are requesting '${data.request}'. Special Webpack Loaders syntax is not officially supported and makes you code very coupled to Webpack, which might break in the future, we recommend that you remove it. See `https://github.com/facebookincubator/create-react-app/issues/733`);
+        }
+        callback(null, data);
+      })
+    });
+  }
+}
+
+module.exports = WatchMissingNodeModulesPlugin;

--- a/packages/react-dev-utils/WarnAboutLoaderDisablingPlugin.js
+++ b/packages/react-dev-utils/WarnAboutLoaderDisablingPlugin.js
@@ -8,7 +8,7 @@
  */
 
 // This Webpack plugin warns the user when using special webpack syntax
-// to distable loaders (https://webpack.github.io/docs/loaders.html#loader-order)
+// to disable loaders (https://webpack.github.io/docs/loaders.html#loader-order)
 // This makes it very coupled to webpack and might break in the future.
 // See https://github.com/facebookincubator/create-react-app/issues/733.
 
@@ -16,11 +16,11 @@
 
 var chalk = require('chalk');
 
-class WatchAboutLoaderDisablingPlugin {
+class WarnAboutLoaderDisablingPlugin {
   apply(compiler) {
     compiler.plugin('normal-module-factory', (normalModuleFactory) => {
       normalModuleFactory.plugin('before-resolve', (data, callback) => {
-        if (data.request.match('!')) {
+        if (data.request.match(/^-?!!?/)) {
           chalk.yellow(`Warning: You are requesting '${data.request}'. Special Webpack Loaders syntax is not officially supported and makes you code very coupled to Webpack, which might break in the future, we recommend that you remove it. See `https://github.com/facebookincubator/create-react-app/issues/733`);
         }
         callback(null, data);
@@ -29,4 +29,4 @@ class WatchAboutLoaderDisablingPlugin {
   }
 }
 
-module.exports = WatchMissingNodeModulesPlugin;
+module.exports = WarnAboutLoaderDisablingPlugin;

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -17,6 +17,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 var InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 var WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
+var WarnAboutLoaderDisablingPlugin = require('react-dev-utils/WarnAboutLoaderDisablingPlugin');
 var getClientEnvironment = require('./env');
 var paths = require('./paths');
 
@@ -217,6 +218,10 @@ module.exports = {
     // makes the discovery automatic so you don't have to restart.
     // See https://github.com/facebookincubator/create-react-app/issues/186
     new WatchMissingNodeModulesPlugin(paths.appNodeModules)
+    // This warns about using Webpack Special Loader syntax, which makes it
+    // very coupled to Webpack and might break in the future.
+    // See https://github.com/facebookincubator/create-react-app/issues/733
+    new WarnAboutLoaderDisablingPlugin()
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -17,7 +17,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 var InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 var WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
-var WarnAboutLoaderDisablingPlugin = require('react-dev-utils/WarnAboutLoaderDisablingPlugin');
+var BlockUnsupportedWebpackLoaderSyntax = require('react-dev-utils/BlockUnsupportedWebpackLoaderSyntax');
 var getClientEnvironment = require('./env');
 var paths = require('./paths');
 
@@ -217,11 +217,11 @@ module.exports = {
     // to restart the development server for Webpack to discover it. This plugin
     // makes the discovery automatic so you don't have to restart.
     // See https://github.com/facebookincubator/create-react-app/issues/186
-    new WatchMissingNodeModulesPlugin(paths.appNodeModules)
-    // This warns about using Webpack Special Loader syntax, which makes it
+    new WatchMissingNodeModulesPlugin(paths.appNodeModules),
+    // This forbids usage of Webpack Special Loader syntax, which makes it
     // very coupled to Webpack and might break in the future.
     // See https://github.com/facebookincubator/create-react-app/issues/733
-    new WarnAboutLoaderDisablingPlugin()
+    new BlockUnsupportedWebpackLoaderSyntax()
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.


### PR DESCRIPTION
This should solve #733 

**I haven't tested it yet** as I'm in a hurry, so if you can, please do (:

Instead of throwing an error I am showing a warning because I didn't want to block users to use a feature just because it *might* break *in the future*, and force them to eject just because of a minor plugin.