### PR TITLE
Bump recursive-readdir

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -58,7 +58,7 @@
     "postcss-loader": "0.13.0",
     "promise": "7.1.1",
     "react-dev-utils": "^0.2.0",
-    "recursive-readdir": "2.0.0",
+    "recursive-readdir": "2.1.0",
     "rimraf": "2.5.4",
     "strip-ansi": "3.0.1",
     "style-loader": "0.13.1",


### PR DESCRIPTION
Removes a deprecation warning:
```
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

See: https://github.com/jergason/recursive-readdir/pull/39