### PR TITLE
Fix the right and bottom padding of the error overlay

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -60,6 +60,7 @@ function addOverlayDivTo(iframe) {
   var div =  iframe.contentDocument.createElement('div');
   div.id = 'react-dev-utils-webpack-hot-dev-client-overlay-div';
   div.style.position = 'fixed';
+  div.style.boxSizing = 'border-box';
   div.style.left = 0;
   div.style.top = 0;
   div.style.right = 0;


### PR DESCRIPTION
Minor CSS tweak to the error overlay: fix the right and bottom padding by adding `box-sizing: border-box`.

Before:
![screen shot 2016-09-26 at 3 22 06](https://cloud.githubusercontent.com/assets/497214/18819511/aebaee10-839a-11e6-9537-36ac12beaae3.png)

After:
![screen shot 2016-09-26 at 3 22 38](https://cloud.githubusercontent.com/assets/497214/18819514/b4c39df2-839a-11e6-8073-dfe8e46bdbd7.png)
