### PR TITLE
Moved Babel and ESLint config to package.json after ejecting

### DIFF
--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -29,8 +29,6 @@ prompt(
   var ownPath = path.join(__dirname, '..');
   var appPath = path.join(ownPath, '..', '..');
   var files = [
-    '.babelrc',
-    '.eslintrc',
     path.join('config', 'env.js'),
     path.join('config', 'paths.js'),
     path.join('config', 'polyfills.js'),
@@ -76,6 +74,8 @@ prompt(
 
   var ownPackage = require(path.join(ownPath, 'package.json'));
   var appPackage = require(path.join(appPath, 'package.json'));
+  var babelConfig = JSON.parse(fs.readFileSync(path.join(ownPath, '.babelrc'), 'utf8'));
+  var eslintConfig = JSON.parse(fs.readFileSync(path.join(ownPath, '.eslintrc'), 'utf8'));
 
   var ownPackageName = ownPackage.name;
   console.log('Removing dependency: ' + ownPackageName);
@@ -103,6 +103,12 @@ prompt(
     null,
     true
   );
+
+  // Add Babel config
+  appPackage.babel = babelConfig;
+
+  // Add ESlint config
+  appPackage.eslintConfig = eslintConfig;
 
   console.log('Writing package.json');
   fs.writeFileSync(


### PR DESCRIPTION
Implements https://github.com/facebookincubator/create-react-app/issues/766

E2E test ran successfully on my computer.

While running it I discovered that https://github.com/facebookincubator/create-react-app/blob/master/tasks/e2e.sh#L187 does not work, the test ran in `watch` mode anyway.