### PR TITLE
added support for disabling test watch with more variable names

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -20,9 +20,11 @@ require('dotenv').config({silent: true});
 
 const jest = require('jest');
 const argv = process.argv.slice(2);
+// If any of these environment variables exist, don't add --watch to Jest args
+const ENV_WITHOUT_WATCH = ['CI', 'COVERAGE', 'NO_TEST_WATCH'];
 
 // Watch unless on CI
-if (!process.env.CI) {
+if (!ENV_WITHOUT_WATCH.some( eww => eww in process.env)) {
   argv.push('--watch');
 }
 


### PR DESCRIPTION
This is just a proof of concept for what I had in mind for https://github.com/facebookincubator/create-react-app/issues/784

Maybe using these environment variables will be sort of a configuration and will work against the main goal of the project. So feel free to reject the PR.

But I would love if `--watch` was opt-in rather than the default.