### PR TITLE
run linter on packages directory and compile it with babel

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -43,6 +43,7 @@ module.exports = {
   appIndexJs: resolveApp('src/index.js'),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
+  appPackages: resolveApp('packages'),
   testsSetup: resolveApp('src/setupTests.js'),
   appNodeModules: resolveApp('node_modules'),
   ownNodeModules: resolveApp('node_modules'),
@@ -62,6 +63,7 @@ module.exports = {
   appIndexJs: resolveApp('src/index.js'),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
+  appPackages: resolveApp('packages'),
   testsSetup: resolveApp('src/setupTests.js'),
   appNodeModules: resolveApp('node_modules'),
   // this is empty with npm3 but node resolution searches higher anyway:
@@ -78,6 +80,7 @@ module.exports = {
   appIndexJs: resolveOwn('../template/src/index.js'),
   appPackageJson: resolveOwn('../package.json'),
   appSrc: resolveOwn('../template/src'),
+  appPackages: resolveOwn('../template/packages'),
   testsSetup: resolveOwn('../template/src/setupTests.js'),
   appNodeModules: resolveOwn('../node_modules'),
   ownNodeModules: resolveOwn('../node_modules'),

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -107,14 +107,14 @@ module.exports = {
       {
         test: /\.(js|jsx)$/,
         loader: 'eslint',
-        include: paths.appSrc,
+        include: [paths.appSrc, paths.appPackages],
       }
     ],
     loaders: [
       // Process JS with Babel.
       {
         test: /\.(js|jsx)$/,
-        include: paths.appSrc,
+        include: [paths.appSrc, paths.appPackages],
         loader: 'babel',
         query: {
           // @remove-on-eject-begin


### PR DESCRIPTION
This allows user to implement https://github.com/facebookincubator/create-react-app/issues/741 (by symlinking the directories of packages manually to node_modules).

Not a complete solution, but I was refactoring my create-react-app to this structure, hoping that it could work manually as well, this is not the case, as webpack ignores the packages directory. This is all I need to make the refactoring work.