### PR TITLE
add logging of existing default port process on start

### DIFF
--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -144,7 +144,7 @@ compiler.plugin('done', function(stats) {
 
 #### `getProcessForPort(port: number): string`
 
-Finds the currently running process(es) on `port`.
+Finds the currently running process on `port`.
 Returns a string containing the name and directory, e.g.,
 
 ```

--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -142,6 +142,22 @@ compiler.plugin('done', function(stats) {
 });
 ```
 
+#### `getProcessForPort(port: number): string`
+
+Finds the currently running process(es) on `port`.
+Returns a string containing the name and directory, e.g.,
+
+```
+create-react-app
+in /Users/developer/create-react-app
+```
+
+```js
+var getProcessForPort = require('react-dev-utils/getProcessForPort');
+
+getProcessForPort(3000);
+```
+
 #### `openBrowser(url: string): boolean`
 
 Attempts to open the browser with a given URL.  

--- a/packages/react-dev-utils/getProcessForPort.js
+++ b/packages/react-dev-utils/getProcessForPort.js
@@ -2,7 +2,14 @@ var chalk = require('chalk');
 var execSync = require('child_process').execSync;
 var path = require('path');
 
-var execOptions = { encoding: 'utf8' };
+var execOptions = {
+  encoding: 'utf8',
+  stdio: [
+    'pipe', // stdin (default)
+    'pipe', // stdout (default)
+    'ignore' //stderr
+  ]
+};
 
 function isProcessAReactApp(processCommand) {
   return /^node .*react-scripts\/scripts\/start\.js\s?$/.test(processCommand);

--- a/packages/react-dev-utils/getProcessForPort.js
+++ b/packages/react-dev-utils/getProcessForPort.js
@@ -1,0 +1,40 @@
+var chalk = require('chalk');
+var execSync = require('child_process').execSync;
+
+var execOptions = { encoding: 'utf8' };
+
+function isProcessAReactApp(processCommand) {
+  return /^node .*react-scripts\/scripts\/start\.js\s?$/.test(processCommand);
+}
+
+function getProcessIdsOnPort(port) {
+  return execSync('lsof -i:' + port + ' -P -t', execOptions).match(/(\S+)/g);
+}
+
+function getProcessCommandById(processId) {
+  var command = execSync('ps -o command -p ' + processId + ' | sed -n 2p', execOptions);
+  return (isProcessAReactApp(command)) ? 'create-react-app\n' : command;
+}
+
+function getDirectoryOfProcessById(processId) {
+  return execSync('lsof -p '+ processId + ' | grep cwd | awk \'{print $9}\'', execOptions);
+}
+
+function getProcessForPort(port) {
+  try {
+    var processIds = getProcessIdsOnPort(port);
+
+    var processCommandsAndDirectories = processIds.map(function(processId) {
+      var command = getProcessCommandById(processId);
+      var directory = getDirectoryOfProcessById(processId);
+      return chalk.cyan(command) + chalk.blue('  in ') + chalk.cyan(directory);
+    });
+
+    return processCommandsAndDirectories.join('\n  ');
+  } catch(e) {
+    return null;
+  }
+}
+
+module.exports = getProcessForPort;
+

--- a/packages/react-dev-utils/getProcessForPort.js
+++ b/packages/react-dev-utils/getProcessForPort.js
@@ -8,8 +8,8 @@ function isProcessAReactApp(processCommand) {
   return /^node .*react-scripts\/scripts\/start\.js\s?$/.test(processCommand);
 }
 
-function getProcessIdsOnPort(port) {
-  return execSync('lsof -i:' + port + ' -P -t', execOptions).match(/(\S+)/g);
+function getProcessIdOnPort(port) {
+  return execSync('lsof -i:' + port + ' -P -t -sTCP:LISTEN', execOptions).trim();
 }
 
 function getPackageNameInDirectory(directory) {
@@ -36,20 +36,15 @@ function getProcessCommand(processId, processDirectory) {
 }
 
 function getDirectoryOfProcessById(processId) {
-  return execSync('lsof -p '+ processId + ' | grep cwd | awk \'{print $9}\'', execOptions);
+  return execSync('lsof -p '+ processId + ' | grep cwd | awk \'{print $9}\'', execOptions).trim();
 }
 
 function getProcessForPort(port) {
   try {
-    var processIds = getProcessIdsOnPort(port);
-
-    var processCommandsAndDirectories = processIds.map(function(processId) {
-      var directory = getDirectoryOfProcessById(processId);
-      var command = getProcessCommand(processId, directory);
-      return chalk.cyan(command) + chalk.blue('  in ') + chalk.cyan(directory);
-    });
-
-    return processCommandsAndDirectories.join('\n  ');
+    var processId = getProcessIdOnPort(port);
+    var directory = getDirectoryOfProcessById(processId);
+    var command = getProcessCommand(processId, directory);
+    return chalk.cyan(command) + chalk.blue('  in ') + chalk.cyan(directory);
   } catch(e) {
     return null;
   }

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -14,6 +14,7 @@
     "clearConsole.js",
     "checkRequiredFiles.js",
     "formatWebpackMessages.js",
+    "getProcessForPort.js",
     "InterpolateHtmlPlugin.js",
     "openChrome.applescript",
     "openBrowser.js",

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -18,7 +18,6 @@ process.env.NODE_ENV = 'development';
 require('dotenv').config({silent: true});
 
 var chalk = require('chalk');
-var execSync = require('child_process').execSync;
 var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var historyApiFallback = require('connect-history-api-fallback');
@@ -27,6 +26,7 @@ var detect = require('detect-port');
 var clearConsole = require('react-dev-utils/clearConsole');
 var checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
 var formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
+var getProcessForPort = require('react-dev-utils/getProcessForPort');
 var openBrowser = require('react-dev-utils/openBrowser');
 var prompt = require('react-dev-utils/prompt');
 var config = require('../config/webpack.config.dev');
@@ -257,31 +257,6 @@ function run(port) {
   var host = process.env.HOST || 'localhost';
   setupCompiler(host, port, protocol);
   runDevServer(host, port, protocol);
-}
-
-function isProcessAReactApp(processCommand) {
-  return /^node .*react-scripts\/scripts\/start\.js\s?$/.test(processCommand);
-}
-
-function getProcessForPort(port) {
-  var execOptions = { encoding: 'utf8' };
-
-  try {
-    var processIds = execSync('lsof -i:' + port + ' -P -t', execOptions).match(/(\S+)/g);
-
-    var processCommandsAndDirectories = processIds.map(function(processId) {
-      var processCommand = execSync('ps -o command -p ' + processId + ' | sed -n 2p', execOptions);
-      if (isProcessAReactApp(processCommand)) {
-        processCommand = 'create-react-app\n';
-      }
-      var processDirectory = execSync('lsof -p '+ processId + ' | grep cwd | awk \'{print $9}\'', execOptions);
-      return chalk.cyan(processCommand) + chalk.blue('  in ') + chalk.cyan(processDirectory);
-    });
-
-    return processCommandsAndDirectories.join('\n  ');
-  } catch(e) {
-    return null;
-  }
 }
 
 // We attempt to use the default port but if it is busy, we offer the user to

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -267,8 +267,8 @@ function getProcessNameOnPort(port) {
 
     var processCommandsAndDirectories = processIds.map(function(processId) {
       var processCommand = execSync('ps -o command -p ' + processId + ' | sed -n 2p', execOptions);
-      var processDirectory = execSync('lsof -p '+ processId + ' | grep cwd | awk \'{print "  in " $9}\'', execOptions);
-      return chalk.blue(processCommand) + chalk.cyan(processDirectory);
+      var processDirectory = execSync('lsof -p '+ processId + ' | grep cwd | awk \'{print $9}\'', execOptions);
+      return chalk.cyan(processCommand) + chalk.blue('  in ') + chalk.cyan(processDirectory);
     });
 
     return processCommandsAndDirectories.join('\n  ');

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -281,10 +281,9 @@ detect(DEFAULT_PORT).then(port => {
   clearConsole();
   var existingProcess = getProcessNameOnPort(DEFAULT_PORT);
   var question =
-    chalk.yellow('Something ' +
-      ((existingProcess) ? '(probably: ' + existingProcess +') ' : '') +
-      'is already running on port ' + DEFAULT_PORT + '.') +
-    '\n\nWould you like to run the app on another port instead?';
+    chalk.yellow('Something is already running on port ' + DEFAULT_PORT + '.' +
+      ((existingProcess) ? ' Probably:\n  ' + existingProcess : '')) +
+      '\n\nWould you like to run the app on another port instead?';
 
   prompt(question, true).then(shouldChangePort => {
     if (shouldChangePort) {

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -282,7 +282,7 @@ detect(DEFAULT_PORT).then(port => {
   var existingProcess = getProcessNameOnPort(DEFAULT_PORT);
   var question =
     chalk.yellow('Something is already running on port ' + DEFAULT_PORT + '.' +
-      ((existingProcess) ? ' Probably:\n  ' + existingProcess : '')) +
+      ((existingProcess) ? ' Probably:\n  ' + chalk.cyan(existingProcess) : '')) +
       '\n\nWould you like to run the app on another port instead?';
 
   prompt(question, true).then(shouldChangePort => {

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -259,7 +259,7 @@ function run(port) {
   runDevServer(host, port, protocol);
 }
 
-function getProcessNameOnPort(port) {
+function getProcessForPort(port) {
   var execOptions = { encoding: 'utf8' };
 
   try {
@@ -286,7 +286,7 @@ detect(DEFAULT_PORT).then(port => {
   }
 
   clearConsole();
-  var existingProcess = getProcessNameOnPort(DEFAULT_PORT);
+  var existingProcess = getProcessForPort(DEFAULT_PORT);
   var question =
     chalk.yellow('Something is already running on port ' + DEFAULT_PORT + '.' +
       ((existingProcess) ? ' Probably:\n  ' + existingProcess : '')) +

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -260,11 +260,18 @@ function run(port) {
 }
 
 function getProcessNameOnPort(port) {
-  var command = 'ps -o command -p "$(lsof -i:' + port + ' -P -t)" | sed -n 2p | tr -d "\n"';
   var execOptions = { encoding: 'utf8' };
+  var processesCommand = 'lsof -i:' + port + ' -P -t'
 
   try {
-    return execSync(command, execOptions);
+    var processIds = execSync(processesCommand, execOptions).match(/(\S+)/g);
+
+    var namedProcesses = processIds.map(function(processId) {
+      var command = 'ps -o command -p ' + processId + ' | sed -n 2p | tr -d "\n"';
+      return execSync(command, execOptions);
+    });
+
+    return namedProcesses.join(',\n  ');
   } catch(e) {
     return null;
   }

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -259,6 +259,10 @@ function run(port) {
   runDevServer(host, port, protocol);
 }
 
+function isProcessAReactApp(processCommand) {
+  return /^node .*react-scripts\/scripts\/start\.js\s?$/.test(processCommand);
+}
+
 function getProcessForPort(port) {
   var execOptions = { encoding: 'utf8' };
 
@@ -267,6 +271,9 @@ function getProcessForPort(port) {
 
     var processCommandsAndDirectories = processIds.map(function(processId) {
       var processCommand = execSync('ps -o command -p ' + processId + ' | sed -n 2p', execOptions);
+      if (isProcessAReactApp(processCommand)) {
+        processCommand = 'create-react-app\n';
+      }
       var processDirectory = execSync('lsof -p '+ processId + ' | grep cwd | awk \'{print $9}\'', execOptions);
       return chalk.cyan(processCommand) + chalk.blue('  in ') + chalk.cyan(processDirectory);
     });


### PR DESCRIPTION
Hello awesome contributors,

In #441, there are was a request to guess the name of the existing process running on the default port when starting CRA. So, building on the incomplete yet solid work done in #454, this PR aims to complete that feature.

### with a CRA app process found

![screen shot 2016-11-02 at 16 37 20](https://cloud.githubusercontent.com/assets/1494758/19946513/be392f94-a11a-11e6-844d-e1dc59076c80.png)

It shows the app's name and directory.

Note: `my-test-app` is the name of a CRA app in `~/dev/test2`

### with a non-CRA process found

![screen shot 2016-11-02 at 16 39 36](https://cloud.githubusercontent.com/assets/1494758/19946621/0f3f9f04-a11b-11e6-98ff-f067a678892d.png)

It shows the command name and directory.

### without a process found

<img width="607" alt="screen shot 2016-10-01 at 14 47 15" src="https://cloud.githubusercontent.com/assets/1494758/19016427/1f697c26-87e7-11e6-9c49-af0c527e2cd6.png">

It shows the original, generic message.
