### PR TITLE
docs(readme): eslint-plugin-react peer dependencies applied

### DIFF
--- a/packages/eslint-config-react-app/README.md
+++ b/packages/eslint-config-react-app/README.md
@@ -17,7 +17,7 @@ If you want to use this ESLint configuration in a project not built with Create 
 First, install this package, ESLint and the necessary plugins.
 
   ```sh
-  npm install --save-dev eslint-config-react-app babel-eslint@6.1.2 eslint@3.5.0 eslint-plugin-flowtype@2.18.1 eslint-plugin-import@1.12.0 eslint-plugin-jsx-a11y@2.2.2 eslint-plugin-react@5.2.2
+  npm install --save-dev eslint-config-react-app babel-eslint@6.1.2 eslint@3.5.0 eslint-plugin-flowtype@2.18.1 eslint-plugin-import@1.12.0 eslint-plugin-jsx-a11y@2.2.2 eslint-plugin-react@6.3.0
   ```
 
 Then create a file named `.eslintrc` with following contents in the root folder of your project:


### PR DESCRIPTION
I've changed [README.md](https://github.com/facebookincubator/create-react-app/tree/master/packages/eslint-config-react-app#usage-outside-of-create-react-app) of `eslint-config-react-app` package.

It seems #696 doesn't applied to file yet.
Thanks.