### PR TITLE
Promote "React must be in scope" to be an error

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -193,7 +193,7 @@ module.exports = {
     'react/no-deprecated': 'warn',
     'react/no-direct-mutation-state': 'warn',
     'react/no-is-mounted': 'warn',
-    'react/react-in-jsx-scope': 'warn',
+    'react/react-in-jsx-scope': 'error',
     'react/require-render-return': 'warn',
     'react/style-prop-object': 'warn',
 


### PR DESCRIPTION
I think this is better to surface early because it’s a common mistake and will lead to broken code in 100% cases.

Test plan:

1. Remove `React` from imports in `App.js`
2. See the overlay:

<img width="1152" alt="screen shot 2016-10-02 at 18 57 54" src="https://cloud.githubusercontent.com/assets/810438/19022581/308dff58-88d3-11e6-8b2b-2bc61aef1528.png">

The error is googleable and leads [here](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md).