### PR TITLE
Support passing scoped package names to --scripts-version arg

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -152,7 +152,7 @@ function getInstallPackage(version) {
 
 // Extract package name from tarball url or path.
 function getPackageName(installPackage) {
-  if (~installPackage.indexOf('.tgz')) {
+  if (installPackage.indexOf('.tgz') > 0) {
     return installPackage.match(/^.+\/(.+)-.+\.tgz$/)[1];
   } else if (installPackage.indexOf('@') > 0) {
     return installPackage.charAt(0) + installPackage.substr(1).split('@')[0];

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -152,9 +152,10 @@ function getInstallPackage(version) {
 
 // Extract package name from tarball url or path.
 function getPackageName(installPackage) {
-  if (installPackage.indexOf('.tgz') > 0) {
+  if (installPackage.indexOf('.tgz') > -1) {
     return installPackage.match(/^.+\/(.+)-.+\.tgz$/)[1];
   } else if (installPackage.indexOf('@') > 0) {
+    // Do not match @scope/ when stripping off @version or @tag
     return installPackage.charAt(0) + installPackage.substr(1).split('@')[0];
   }
   return installPackage;

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -154,8 +154,8 @@ function getInstallPackage(version) {
 function getPackageName(installPackage) {
   if (~installPackage.indexOf('.tgz')) {
     return installPackage.match(/^.+\/(.+)-.+\.tgz$/)[1];
-  } else if (~installPackage.indexOf('@')) {
-    return installPackage.split('@')[0];
+  } else if (installPackage.indexOf('@') > 0) {
+    return installPackage.charAt(0) + installPackage.substr(1).split('@')[0];
   }
   return installPackage;
 }


### PR DESCRIPTION
`create-react-app myApp --scripts-version=@myscope/react-scripts` fails since `getPackageName` currently assumes a match of "@" at any index denotes version and strips it from the str.
Minor change to fix.