### PR TITLE
Fix script name to open chrome

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -17,7 +17,7 @@ function openBrowser(url) {
       // on OS X Google Chrome with AppleScript
       execSync('ps cax | grep "Google Chrome"');
       execSync(
-        'osascript chrome.applescript ' + url,
+        'osascript openChrome.applescript ' + url,
         {cwd: __dirname, stdio: 'ignore'}
       );
       return true;


### PR DESCRIPTION
A previous commit renamed the apple script to open chrome from
`chrome.applescript` to `openChrome.applescript`. That created
a minor bug. Even when chrome was open with the client app,
`npm start` would open the client app in a new Safari tab on
macOS instead of re-using the open tab in chrome.