### PR TITLE
Make webpackHotDevClient support webpack 2 too

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -272,8 +272,7 @@ function tryApplyUpdates(onHotUpdateSuccess) {
     return;
   }
 
-  // https://webpack.github.io/docs/hot-module-replacement.html#check
-  module.hot.check(/* autoApply */true, function(err, updatedModules) {
+  var checkCallback = function(err, updatedModules) {
     if (err || !updatedModules) {
       window.location.reload();
       return;
@@ -288,5 +287,18 @@ function tryApplyUpdates(onHotUpdateSuccess) {
       // While we were updating, there was a new update! Do it again.
       tryApplyUpdates();
     }
-  });
+  }
+
+  // https://webpack.github.io/docs/hot-module-replacement.html#check
+  var result = module.hot.check(/* autoApply */true, checkCallback);
+
+  // webpack 2 support
+  if (result && result.then) {
+    result.then(
+      function(updatedModules) {
+        checkCallback(null, updatedModules);
+      },
+      checkCallback
+    );
+  }
 };

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -272,7 +272,7 @@ function tryApplyUpdates(onHotUpdateSuccess) {
     return;
   }
 
-  var checkCallback = function(err, updatedModules) {
+  function handleApplyUpdates(err, updatedModules) {
     if (err || !updatedModules) {
       window.location.reload();
       return;
@@ -290,15 +290,17 @@ function tryApplyUpdates(onHotUpdateSuccess) {
   }
 
   // https://webpack.github.io/docs/hot-module-replacement.html#check
-  var result = module.hot.check(/* autoApply */true, checkCallback);
+  var result = module.hot.check(/* autoApply */true, handleApplyUpdates);
 
-  // webpack 2 support
+  // // Webpack 2 returns a Promise instead of invoking a callback
   if (result && result.then) {
     result.then(
       function(updatedModules) {
-        checkCallback(null, updatedModules);
+        handleApplyUpdates(null, updatedModules);
       },
-      checkCallback
+      function(err) {
+        handleApplyUpdates(err, null);
+      }
     );
   }
 };


### PR DESCRIPTION
Support webpack 2 by `webpackHotDevClient`.

Closes #839 