### PR TITLE
Load setupTests file at setupTestFramework stage

### DIFF
--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -13,12 +13,9 @@ const pathExists = require('path-exists');
 const paths = require('../config/paths');
 
 module.exports = (resolve, rootDir, isEjecting) => {
-  const setupFiles = [resolve('config/polyfills.js')];
-  if (pathExists.sync(paths.testsSetup)) {
-    // Use this instead of `paths.testsSetup` to avoid putting
-    // an absolute filename into configuration after ejecting.
-    setupFiles.push('<rootDir>/src/setupTests.js');
-  }
+  // Use this instead of `paths.testsSetup` to avoid putting
+  // an absolute filename into configuration after ejecting.
+  const setupTestsFile = pathExists.sync(paths.testsSetup) ? '<rootDir>/src/setupTests.js' : undefined;
 
   const config = {
     moduleFileExtensions: ['jsx', 'js', 'json'],
@@ -26,7 +23,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
       '^.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': resolve('config/jest/FileStub.js'),
       '^.+\\.css$': resolve('config/jest/CSSStub.js')
     },
-    setupFiles: setupFiles,
+    setupFiles: [resolve('config/polyfills.js')],
+    setupTestFrameworkScriptFile: setupTestsFile,
     testPathIgnorePatterns: ['<rootDir>/(build|docs|node_modules)/'],
     testEnvironment: 'node',
     testRegex: '(/__tests__/.*|\\.(test|spec))\\.(js|jsx)$',


### PR DESCRIPTION
fixes facebookincubator/create-react-app#824

* `setupFiles` now contains only polyfills
* if `src/setupTests.js` file exists, it will be called after test framework initialization