### PR TITLE
Return correct package name when using a custom react-script scoped package

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -154,7 +154,7 @@ function getInstallPackage(version) {
 function getPackageName(installPackage) {
   if (~installPackage.indexOf('.tgz')) {
     return installPackage.match(/^.+\/(.+)-.+\.tgz$/)[1];
-  } else if (~installPackage.indexOf('@')) {
+  } else if (installPackage.indexOf('@') > 0) {
     return installPackage.split('@')[0];
   }
   return installPackage;


### PR DESCRIPTION
Currently the `getPackageName` method returns an empty string when attempting to use a custom react-scripts package that's a scoped package (e.g. `create-react-app my-test-app --scripts-version=@dpoineau/react-scripts`), which causes the final step of `create-react-app` to fail.

This slightly tweaks the condition so that it will work correctly with scoped packages too.