### PR TITLE
Add root imports with tilde prefix

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -34,6 +34,11 @@ module.exports = {
       regenerator: true,
       // Resolve the Babel runtime relative to the config.
       moduleName: path.dirname(require.resolve('babel-runtime/package'))
+    }],
+    // resolve imports beginning with ~ as /src/{import}
+    [require.resolve('babel-root-import'), {
+      'rootPathPrefix': '~',
+      'rootPathSuffix': 'src'
     }]
   ]
 };

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -20,6 +20,7 @@
     "babel-plugin-transform-runtime": "6.15.0",
     "babel-preset-latest": "6.14.0",
     "babel-preset-react": "6.11.1",
+    "babel-root-import": "^4.1.3",
     "babel-runtime": "6.11.6"
   }
 }


### PR DESCRIPTION
This commit adds `babel-plugin-root-import` to the default `.babelrc` file to define `~` as the absolute path to the `src/` folder.

This gives us the possibility to turn code like this:

```javascript
import SomeUtility from '../../utils/some-utility'
```

to this

```javascript
import SomeUtility from '~/utils/some-utility';
```

The main upside of using this pattern in contrary to the approaches suggested in #741 is that it highlights what is a local import and what is a `node_module` import. 

Fixes #849.