### PR TITLE
Dispose error overlay when linting errors have been corrected

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -123,6 +123,18 @@ function showErrorOverlay(message) {
   });
 }
 
+function destoryOverlay() {  
+  if(!overlayDiv) {
+    //linting from previous linting was successful
+    return;
+  }
+
+  document.body.removeChild(overlayIframe);
+  overlayDiv = null;
+  overlayIframe = null;
+  lastOnOverlayDivReady = null;
+}
+
 // Connect to WebpackDevServer via a socket.
 var connection = new SockJS(url.format({
   protocol: window.location.protocol,
@@ -156,6 +168,7 @@ function clearOutdatedErrors() {
 // Successful compilation.
 function handleSuccess() {
   clearOutdatedErrors();
+  destoryOverlay();
 
   var isHotUpdate = !isFirstCompilation;
   isFirstCompilation = false;
@@ -170,6 +183,7 @@ function handleSuccess() {
 // Compilation with warnings (e.g. ESLint).
 function handleWarnings(warnings) {
   clearOutdatedErrors();
+  destoryOverlay();
 
   var isHotUpdate = !isFirstCompilation;
   isFirstCompilation = false;

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -123,7 +123,7 @@ function showErrorOverlay(message) {
   });
 }
 
-function destoryOverlay() {  
+function destroyOverlay() {  
   if(!overlayDiv) {
     //linting from previous linting was successful
     return;
@@ -168,7 +168,7 @@ function clearOutdatedErrors() {
 // Successful compilation.
 function handleSuccess() {
   clearOutdatedErrors();
-  destoryOverlay();
+  destroyOverlay();
 
   var isHotUpdate = !isFirstCompilation;
   isFirstCompilation = false;
@@ -183,7 +183,7 @@ function handleSuccess() {
 // Compilation with warnings (e.g. ESLint).
 function handleWarnings(warnings) {
   clearOutdatedErrors();
-  destoryOverlay();
+  destroyOverlay();
 
   var isHotUpdate = !isFirstCompilation;
   isFirstCompilation = false;

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -123,12 +123,13 @@ function showErrorOverlay(message) {
   });
 }
 
-function destroyOverlay() {  
-  if(!overlayDiv) {
-    //linting from previous linting was successful
+function destroyErrorOverlay() {  
+  if (!overlayDiv) {
+    // It is not there in the first place.
     return;
   }
 
+  // Clean up and reset internal state.
   document.body.removeChild(overlayIframe);
   overlayDiv = null;
   overlayIframe = null;
@@ -168,7 +169,7 @@ function clearOutdatedErrors() {
 // Successful compilation.
 function handleSuccess() {
   clearOutdatedErrors();
-  destroyOverlay();
+  destroyErrorOverlay();
 
   var isHotUpdate = !isFirstCompilation;
   isFirstCompilation = false;
@@ -183,7 +184,7 @@ function handleSuccess() {
 // Compilation with warnings (e.g. ESLint).
 function handleWarnings(warnings) {
   clearOutdatedErrors();
-  destroyOverlay();
+  destroyErrorOverlay();
 
   var isHotUpdate = !isFirstCompilation;
   isFirstCompilation = false;


### PR DESCRIPTION
Remove error overlay when linting errors have been corrected and the next webpack linting is successful / contains only warnings. 