### PR TITLE
Exit production build if any errors are in build stats

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -128,6 +128,13 @@ function build(previousSizeMap) {
       process.exit(1);
     }
 
+    // Webpack may swallow uglify errors even with bail:true
+    if (stats.compilation.errors.length) {
+      console.error(chalk.red('Error(s) occurred during the production build:'));
+      stats.compilation.errors.forEach(err => console.error(chalk.red(err.message || err)));
+      process.exit(1);
+    }
+
     console.log(chalk.green('Compiled successfully.'));
     console.log();
 

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -118,20 +118,27 @@ function printFileSizes(stats, previousSizeMap) {
   });
 }
 
+// Print out errors
+function printErrors(summary, errors) {
+  console.log(chalk.red(summary));
+  console.log();
+  errors.forEach(err => {
+    console.log(err.message || err);
+    console.log();
+  });
+}
+
 // Create the production build and print the deployment instructions.
 function build(previousSizeMap) {
   console.log('Creating an optimized production build...');
   webpack(config).run((err, stats) => {
     if (err) {
-      console.error('Failed to create a production build. Reason:');
-      console.error(err.message || err);
+      printErrors('Failed to compile.', [err]);
       process.exit(1);
     }
 
-    // Webpack may swallow uglify errors even with bail:true
     if (stats.compilation.errors.length) {
-      console.error(chalk.red('Error(s) occurred during the production build:'));
-      stats.compilation.errors.forEach(err => console.error(chalk.red(err.message || err)));
+      printErrors('Failed to compile.', stats.compilation.errors);
       process.exit(1);
     }
 


### PR DESCRIPTION
Until https://github.com/webpack/webpack/issues/2390 is addressed and all errors trigger the `--bail` switch, would be helpful to manually surface them from the production build stats passed in the callback.

Sample output
```
> react-scripts build

Creating an optimized production build...
Error(s) occurred during the production build:
static/js/main.9a6b731a.js from UglifyJs
SyntaxError: Unexpected token: name .....
```