### PR TITLE
Remove duplicate transform-regenerator dependency

### DIFF
--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -16,7 +16,7 @@
     "babel-plugin-transform-react-constant-elements": "6.9.1",
     "babel-plugin-transform-react-jsx-self": "6.11.0",
     "babel-plugin-transform-react-jsx-source": "6.9.0",
-    "babel-plugin-transform-regenerator": "6.14.0",
+    "babel-plugin-transform-regenerator": "6.16.1",
     "babel-plugin-transform-runtime": "6.15.0",
     "babel-preset-latest": "6.14.0",
     "babel-preset-react": "6.11.1",


### PR DESCRIPTION
It looks like `babel-plugin-transform-regenerator` is already a dependency of ` babel-preset-es2015`  in a different version : 

```
$npm ls babel-plugin-transform-regenerator 
babel-preset-react-app@0.2.1 
├── babel-plugin-transform-regenerator@6.14.0
└─┬ babel-preset-latest@6.14.0
  └─┬ babel-preset-es2015@6.16.0
    └── babel-plugin-transform-regenerator@6.16.1
```

This can causes some trouble when using regeneratorRuntime but to ensure the older npm compatibility we have to keep this dependency. 
So I just updated its version to the same version found from babel-preset-es2015@6.16.0.