### PR TITLE
Fix using pre-release tags with a tarball url in `--scripts-version`

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -153,7 +153,7 @@ function getInstallPackage(version) {
 // Extract package name from tarball url or path.
 function getPackageName(installPackage) {
   if (installPackage.indexOf('.tgz') > -1) {
-    return installPackage.match(/^.+\/(.+)-.+\.tgz$/)[1];
+    return installPackage.match(/^.+\/(.+)-[0-9]+\.[0-9]+\.[0-9]+(?:[-+].+)?\.tgz$/)[1];
   } else if (installPackage.indexOf('@') > 0) {
     // Do not match @scope/ when stripping off @version or @tag
     return installPackage.charAt(0) + installPackage.substr(1).split('@')[0];

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -153,6 +153,8 @@ function getInstallPackage(version) {
 // Extract package name from tarball url or path.
 function getPackageName(installPackage) {
   if (installPackage.indexOf('.tgz') > -1) {
+    // The package name could be with or without semver version, e.g. react-scripts-0.2.0-alpha.1.tgz
+    // However, This function returns package name only wihout semver version.
     return installPackage.match(/^.+\/(.+)-[0-9]+\.[0-9]+\.[0-9]+(?:[-+].+)?\.tgz$/)[1];
   } else if (installPackage.indexOf('@') > 0) {
     // Do not match @scope/ when stripping off @version or @tag

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -154,8 +154,8 @@ function getInstallPackage(version) {
 function getPackageName(installPackage) {
   if (installPackage.indexOf('.tgz') > -1) {
     // The package name could be with or without semver version, e.g. react-scripts-0.2.0-alpha.1.tgz
-    // However, This function returns package name only wihout semver version.
-    return installPackage.match(/^.+\/(.+)-\d+.+\.tgz$/)[1];
+    // However, this function returns package name only wihout semver version.
+    return installPackage.match(/^.+\/(.+?)(?:-\d+.+)?\.tgz$/)[1];
   } else if (installPackage.indexOf('@') > 0) {
     // Do not match @scope/ when stripping off @version or @tag
     return installPackage.charAt(0) + installPackage.substr(1).split('@')[0];

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -155,7 +155,7 @@ function getPackageName(installPackage) {
   if (installPackage.indexOf('.tgz') > -1) {
     // The package name could be with or without semver version, e.g. react-scripts-0.2.0-alpha.1.tgz
     // However, This function returns package name only wihout semver version.
-    return installPackage.match(/^.+\/(.+)-[0-9]+\.[0-9]+\.[0-9]+(?:[-+].+)?\.tgz$/)[1];
+    return installPackage.match(/^.+\/(.+)-\d+.+\.tgz$/)[1];
   } else if (installPackage.indexOf('@') > 0) {
     // Do not match @scope/ when stripping off @version or @tag
     return installPackage.charAt(0) + installPackage.substr(1).split('@')[0];


### PR DESCRIPTION
For example, react-scripts version`0.2.0-alpha.1` with tarball url didn't works:

```sh
$ create-react-app --scripts-version=https://registry.npmjs.org/react-scripts/-/react-scripts-0.2.0-alpha.1.tgz test-app-tarball-url
Creating a new React app in /Users/archie/Repos/test-app-tarball-url.

Installing packages. This might take a couple minutes.
Installing react-scripts from npm...


> fsevents@1.0.14 install /Users/archie/Repos/test-app-tarball-url/node_modules/fsevents
> node-pre-gyp install --fallback-to-build

...

module.js:457
    throw err;
    ^

Error: Cannot find module '/Users/archie/Repos/test-app-tarball-url/node_modules/react-scripts-0.2.0/package.json'
    at Function.Module._resolveFilename (module.js:455:15)
    at Function.Module._load (module.js:403:25)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at checkNodeVersion (/Users/archie/.nvm/versions/node/v6.7.0/lib/node_modules/create-react-app/index.js:170:21)
    at ChildProcess.<anonymous> (/Users/archie/.nvm/versions/node/v6.7.0/lib/node_modules/create-react-app/index.js:127:5)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:877:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)

```

create-react-app version: 0.5.0