### PR TITLE
Disable ES2015 transforms based on node version using babel-preset-env

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -45,12 +45,21 @@ if (env !== 'development' && env !== 'test' && env !== 'production') {
   );
 }
 
+if (env === 'development' || env === 'test') {
+  plugins.push.apply(plugins, [
+    // Adds component stack to warning messages
+    require.resolve('babel-plugin-transform-react-jsx-source'),
+    // Adds __self attribute to JSX which React will use for some warnings
+    require.resolve('babel-plugin-transform-react-jsx-self')
+  ]);
+}
+
 if (env === 'test') {
   module.exports = {
     presets: [
       [require('babel-preset-env').default, {
         "targets": {
-        "node": process.version
+        "node": parseInt(process.versions.node),
         },
       }],
       // JSX, Flow
@@ -69,15 +78,6 @@ else {
     ],
     plugins: plugins
   };
-
-  if (env === 'development' || env === 'test') {
-    plugins.push.apply(plugins, [
-      // Adds component stack to warning messages
-      require.resolve('babel-plugin-transform-react-jsx-source'),
-      // Adds __self attribute to JSX which React will use for some warnings
-      require.resolve('babel-plugin-transform-react-jsx-self')
-    ]);
-  }
 
   if (env === 'production') {
     // Optimization: hoist JSX that never changes out of render()

--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -59,7 +59,7 @@ if (env === 'test') {
     presets: [
       [require('babel-preset-env').default, {
         "targets": {
-        "node": parseInt(process.versions.node),
+          "node": parseFloat(process.versions.node),
         },
       }],
       // JSX, Flow

--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -57,9 +57,10 @@ if (env === 'development' || env === 'test') {
 if (env === 'test') {
   module.exports = {
     presets: [
+      // ES features necessary for user's Node version
       [require('babel-preset-env').default, {
-        "targets": {
-          "node": parseFloat(process.versions.node),
+        targets: {
+          node: parseFloat(process.versions.node),
         },
       }],
       // JSX, Flow
@@ -67,8 +68,7 @@ if (env === 'test') {
     ],
     plugins: plugins
   };
-}
-else {
+} else {
   module.exports = {
     presets: [
       // Latest stable ECMAScript features

--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -10,14 +10,7 @@
 
 var path = require('path');
 
-module.exports = {
-  presets: [
-    // Latest stable ECMAScript features
-    require.resolve('babel-preset-latest'),
-    // JSX, Flow
-    require.resolve('babel-preset-react')
-  ],
-  plugins: [
+const plugins = [
     // class { handleClick = () => { } }
     require.resolve('babel-plugin-transform-class-properties'),
     // { ...todo, completed: true }
@@ -35,8 +28,7 @@ module.exports = {
       // Resolve the Babel runtime relative to the config.
       moduleName: path.dirname(require.resolve('babel-runtime/package'))
     }]
-  ]
-};
+  ];
 
 // This is similar to how `env` works in Babel:
 // https://babeljs.io/docs/usage/babelrc/#env-option
@@ -52,23 +44,51 @@ if (env !== 'development' && env !== 'test' && env !== 'production') {
     '"test", and "production". Instead, received: ' + JSON.stringify(env) + '.'
   );
 }
-var plugins = module.exports.plugins;
-if (env === 'development' || env === 'test') {
-  plugins.push.apply(plugins, [
-    // Adds component stack to warning messages
-    require.resolve('babel-plugin-transform-react-jsx-source'),
-    // Adds __self attribute to JSX which React will use for some warnings
-    require.resolve('babel-plugin-transform-react-jsx-self')
-  ]);
+
+if (env === 'test') {
+  module.exports = {
+    presets: [
+      [require('babel-preset-env').default, {
+        "targets": {
+        "node": process.version
+        },
+      }],
+      // JSX, Flow
+      require.resolve('babel-preset-react')
+    ],
+    plugins: plugins
+  };
 }
-if (env === 'production') {
-  // Optimization: hoist JSX that never changes out of render()
-  // Disabled because of issues:
-  // * https://github.com/facebookincubator/create-react-app/issues/525
-  // * https://phabricator.babeljs.io/search/query/pCNlnC2xzwzx/
-  // * https://github.com/babel/babel/issues/4516
-  // TODO: Enable again when these issues are resolved.
-  // plugins.push.apply(plugins, [
-  //   require.resolve('babel-plugin-transform-react-constant-elements')
-  // ]);
+else {
+  module.exports = {
+    presets: [
+      // Latest stable ECMAScript features
+      require.resolve('babel-preset-latest'),
+      // JSX, Flow
+      require.resolve('babel-preset-react')
+    ],
+    plugins: plugins
+  };
+
+  if (env === 'development' || env === 'test') {
+    plugins.push.apply(plugins, [
+      // Adds component stack to warning messages
+      require.resolve('babel-plugin-transform-react-jsx-source'),
+      // Adds __self attribute to JSX which React will use for some warnings
+      require.resolve('babel-plugin-transform-react-jsx-self')
+    ]);
+  }
+
+  if (env === 'production') {
+    // Optimization: hoist JSX that never changes out of render()
+    // Disabled because of issues:
+    // * https://github.com/facebookincubator/create-react-app/issues/525
+    // * https://phabricator.babeljs.io/search/query/pCNlnC2xzwzx/
+    // * https://github.com/babel/babel/issues/4516
+    // TODO: Enable again when these issues are resolved.
+    // plugins.push.apply(plugins, [
+    //   require.resolve('babel-plugin-transform-react-constant-elements')
+    // ]);
+  }
 }
+

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -18,6 +18,7 @@
     "babel-plugin-transform-react-jsx-source": "6.9.0",
     "babel-plugin-transform-regenerator": "6.14.0",
     "babel-plugin-transform-runtime": "6.15.0",
+    "babel-preset-env": "0.0.4",
     "babel-preset-latest": "6.14.0",
     "babel-preset-react": "6.11.1",
     "babel-runtime": "6.11.6"


### PR DESCRIPTION
Fixes #863 