### PR TITLE
Adds recipe for adding React Router (v4) to README template

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The [User Guide](https://github.com/facebookincubator/create-react-app/blob/mast
 - [Adding Images and Fonts](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-images-and-fonts)
 - [Using the `public` Folder](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#using-the-public-folder)
 - [Adding Bootstrap](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-bootstrap)
+- [Adding React Router](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-react-router)
 - [Adding Flow](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-flow)
 - [Adding Custom Environment Variables](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-custom-environment-variables)
 - [Can I Use Decorators?](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#can-i-use-decorators)

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -21,6 +21,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Adding Images and Fonts](#adding-images-and-fonts)
 - [Using the `public` Folder](#using-the-public-folder)
 - [Adding Bootstrap](#adding-bootstrap)
+- [Adding React Router](#adding-react-router)
 - [Adding Flow](#adding-flow)
 - [Adding Custom Environment Variables](#adding-custom-environment-variables)
 - [Can I Use Decorators?](#can-i-use-decorators)
@@ -408,6 +409,18 @@ import { Navbar, Jumbotron, Button } from 'react-bootstrap';
 ```
 
 Now you are ready to use the imported React Bootstrap components within your component hierarchy defined in the render method. Here is an example [`App.js`](https://gist.githubusercontent.com/gaearon/85d8c067f6af1e56277c82d19fd4da7b/raw/6158dd991b67284e9fc8d70b9d973efe87659d72/App.js) redone using React Bootstrap.
+
+## Adding React Router
+
+React Router is a popular solution for adding routing capabilities to your single-page applications. If your app needs routing, you can configure React Router to work with Create React app by following these steps:
+
+Install React Router v4 from NPM. _note: we are installing a pre-release version of React Router as of the time of this writing, but it functions very well for many needs._
+
+```
+npm install react-router@next --save
+```
+
+You can run the [basic React Router example](https://react-router.now.sh/basic) by replacing the contents of `src/App.js` with the example code they provide. Most of the documented React Router examples should function in this way.
 
 ## Adding Flow
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -412,7 +412,7 @@ Now you are ready to use the imported React Bootstrap components within your com
 
 ## Adding React Router
 
-React Router is a popular solution for adding routing capabilities to your single-page applications. If your app needs routing, you can configure React Router to work with Create React app by following these steps:
+React Router is a popular solution for adding routing capabilities to your single-page applications. If your app needs routing, you can configure React Router to work with Create React App by following these steps:
 
 Install React Router v4 from NPM. _note: we are installing a pre-release version of React Router as of the time of this writing, but it functions very well for many needs._
 


### PR DESCRIPTION
Addresses issue #641 by adding React Router recipe to the README files as appropriate.
