### PR TITLE
Create asset filenames mapping on the build output

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -252,6 +252,9 @@ module.exports = {
     }),
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
     new ExtractTextPlugin('static/css/[name].[contenthash:8].css'),
+    // Generate a manifest file which contains a mapping of all asset filenames
+    // to their corresponding output file so that tools can pick it up without
+    // having to parse `index.html`.
     new ManifestPlugin({
       fileName: 'asset-manifest.json'
     })

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -14,6 +14,7 @@ var autoprefixer = require('autoprefixer');
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var ManifestPlugin = require('webpack-manifest-plugin');
 var InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 var url = require('url');
 var paths = require('./paths');
@@ -250,7 +251,10 @@ module.exports = {
       }
     }),
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
-    new ExtractTextPlugin('static/css/[name].[contenthash:8].css')
+    new ExtractTextPlugin('static/css/[name].[contenthash:8].css'),
+    new ManifestPlugin({
+      fileName: 'asset-manifest.json'
+    })
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -65,7 +65,7 @@
     "url-loader": "0.5.7",
     "webpack": "1.13.2",
     "webpack-dev-server": "1.16.1",
-    "webpack-manifest-plugin": "^1.0.1",
+    "webpack-manifest-plugin": "1.0.1",
     "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -65,6 +65,7 @@
     "url-loader": "0.5.7",
     "webpack": "1.13.2",
     "webpack-dev-server": "1.16.1",
+    "webpack-manifest-plugin": "^1.0.1",
     "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To resolve #600

I use [webpack-manifest-plugin](https://www.npmjs.com/package/webpack-manifest-plugin) on Webpack production configuration to create a file named `asset-manifest.json` which contain a mapping of all asset filenames to their corresponding output file. `asset-manifest.json` will be located at the root of output folder.

Here's the example from a newly created project.
```json
{
  "main.css": "static/css/main.9a0fe4f1.css",
  "main.css.map": "static/css/main.9a0fe4f1.css.map",
  "main.js": "static/js/main.c9af8c27.js",
  "main.js.map": "static/js/main.c9af8c27.js.map",
  "static/media/logo.svg": "static/media/logo.5d5d9eef.svg"
}
```

You can see that it doesn't map those files from `public/`. What do you think?