### PR TITLE
remove guard-for-in eslint rule

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -61,7 +61,6 @@ module.exports = {
     'default-case': ['warn', { commentPattern: '^no default$' }],
     'dot-location': ['warn', 'property'],
     eqeqeq: ['warn', 'allow-null'],
-    'guard-for-in': 'warn',
     'new-parens': 'warn',
     'no-array-constructor': 'warn',
     'no-caller': 'warn',


### PR DESCRIPTION
Would be great to be able to write:

```js
for (let key in obj) {
  // ...
}
```

without having a eslint warning.