### PR TITLE
remove no-unused-expressions eslint rule

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -127,10 +127,6 @@ module.exports = {
     'no-undef': 'error',
     'no-unexpected-multiline': 'warn',
     'no-unreachable': 'warn',
-    'no-unused-expressions': ['warn', {
-      'allowShortCircuit': true,
-      'allowTernary': true
-    }],
     'no-unused-labels': 'warn',
     'no-unused-vars': ['warn', {
       vars: 'local',


### PR DESCRIPTION
For example if we want to push an item in an array only if this item exists:

```js
item && arr.push(item)
```

(currently we get a eslint warning with the code above)