### PR TITLE
pick up all files for coverage reporting

### DIFF
--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -23,6 +23,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
       '^.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': resolve('config/jest/FileStub.js'),
       '^.+\\.css$': resolve('config/jest/CSSStub.js')
     },
+    coveragePathIgnorePatterns: ['src/index.js', '<rootDir>/node_modules/', '<rootDir>/vendor/'],
+    collectCoverageFrom: ['src/**/*.{js,jsx}'],
     setupFiles: [resolve('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,
     testPathIgnorePatterns: ['<rootDir>/(build|docs|node_modules)/'],

--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -23,7 +23,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
       '^.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': resolve('config/jest/FileStub.js'),
       '^.+\\.css$': resolve('config/jest/CSSStub.js')
     },
-    coveragePathIgnorePatterns: ['src/index.js', '<rootDir>/node_modules/', '<rootDir>/vendor/'],
+    coveragePathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/vendor/'],
     collectCoverageFrom: ['src/**/*.{js,jsx}'],
     setupFiles: [resolve('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,


### PR DESCRIPTION
Previously coverage reporting was only done for js files that had an associated test file.  This change allows for coverage reporting on all js files(except for src/index.js), even if there is no test.

New example coverage output(auto.js is a new file with no tests):
![image](https://cloud.githubusercontent.com/assets/5582000/19400879/1bc6fad2-920d-11e6-8b35-6081c6361bf3.png)
