### PR TITLE
Fix Travis CI config in template README.md

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -802,8 +802,8 @@ node_js:
   - 6
 cache:
   directories:
-  - node_modules
-script
+    - node_modules
+script:
   - npm test
 ```
 1. Trigger your first build with a git push.


### PR DESCRIPTION
1. Added `:` after `script`.
2. Added extra indent as per the example [here](https://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies).

The config now passes YAML validation (was broken before) and I'm using it on Travis CI myself.