### PR TITLE
Add the 'src' directory as a fallback for module lookup.

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -29,10 +29,12 @@ function resolveApp(relativePath) {
 // We will export `nodePaths` as an array of absolute paths.
 // It will then be used by Webpack configs.
 // Jest doesn’t need this because it already handles `NODE_PATH` out of the box.
+// The code 'src' is appended automatically to allow for absolute paths in imports.
 
 var nodePaths = (process.env.NODE_PATH || '')
   .split(process.platform === 'win32' ? ';' : ':')
   .filter(Boolean)
+  .concat('src')
   .map(resolveApp);
 
 // config after eject: we're in ./config/

--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -27,6 +27,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupTestFrameworkScriptFile: setupTestsFile,
     testPathIgnorePatterns: ['<rootDir>/(build|docs|node_modules)/'],
     testEnvironment: 'node',
+    moduleDirectories: ['node_modules', 'src'],
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
The current started requires developers to use relative paths, leading to code such as:

    import '../../../something/else.js'

Since the `src` directory is defined as the root for the application, after this change if a module is not found in `node_modules` it will automatically search in `src`

    import 'something/else.js'

