### PR TITLE
PostCSS should run on @import statements.

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -137,7 +137,7 @@ module.exports = {
       // in development "style" loader enables hot editing of CSS.
       {
         test: /\.css$/,
-        loader: 'style!css!postcss'
+        loader: 'style!css?importLoaders=1!postcss'
       },
       // JSON is not enabled by default in Webpack but both Node and Browserify
       // allow it implicitly so we also enable it.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -150,7 +150,7 @@ module.exports = {
         // Webpack 1.x uses Uglify plugin as a signal to minify *all* the assets
         // including CSS. This is confusing and will be removed in Webpack 2:
         // https://github.com/webpack/webpack/issues/283
-        loader: ExtractTextPlugin.extract('style', 'css?-autoprefixer!postcss')
+        loader: ExtractTextPlugin.extract('style', 'css?importLoaders=1&-autoprefixer!postcss')
         // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
       },
       // JSON is not enabled by default in Webpack but both Node and Browserify


### PR DESCRIPTION
Looks like PostCSS isn't running on stylesheets included via `@import` within another stylesheet. The [postcss-loader docs use `?importLoaders=1` in there configuration](https://github.com/postcss/postcss-loader). Adding it fixed the issue.

**Steps to reproduce:**

1. Create a new app with `create-react-app`
2. Import `App.css` from `src/index.css`
3. Remove `import './App.css'` from `src/App.js`

The `-webkit-` prefix for the `animation` style rule is gone! I've pushed up an example here:

https://github.com/nhunzaker/no-autoprefixer-issue


