### PR TITLE
Crash the build during CI whenever linter warnings are encountered

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -142,6 +142,11 @@ function build(previousSizeMap) {
       process.exit(1);
     }
 
+    if (process.env.CI && stats.compilation.warnings.length) {
+     printErrors('Failed to compile. Note, the build has crashed because it is being run with the environment variable CI set to true. In this mode the build crashes when any warnings are encountered.', stats.compilation.warnings);
+     process.exit(1);
+   }
+
     console.log(chalk.green('Compiled successfully.'));
     console.log();
 

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -143,7 +143,7 @@ function build(previousSizeMap) {
     }
 
     if (process.env.CI && stats.compilation.warnings.length) {
-     printErrors('Failed to compile. Note, the build has crashed because it is being run with the environment variable CI set to true. In this mode the build crashes when any warnings are encountered.', stats.compilation.warnings);
+     printErrors('Failed to compile.', stats.compilation.warnings);
      process.exit(1);
    }
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -841,7 +841,7 @@ The test command will force Jest to run tests once instead of launching the watc
 
 >  If you find yourself doing this often in development, please [file an issue](https://github.com/facebookincubator/create-react-app/issues/new) to tell us about your use case because we want to make watcher the best experience and are open to changing how it works to accommodate more workflows.
 
-The build command will check for linter warning and fail the build if any are found.
+The build command will check for linter warning and fail if any are found.
 
 ### Disabling jsdom
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -788,7 +788,11 @@ Note that tests run much slower with coverage so it is recommended to run it sep
 
 ### Continuous Integration
 
-By default `npm test` runs the watcher with interactive CLI. However, you can force it to run tests once and finish the process by setting an environment variable called `CI`. Popular CI servers already set it by default but you can do this yourself too:
+By default `npm test` runs the watcher with interactive CLI. However, you can force it to run tests once and finish the process by setting an environment variable called `CI`.
+
+When creating a build of your application with `npm run build` linter warnings are not checked by default. Like `npm test`, you can force the build to perform a linter warning check by setting the environment variable `CI`. If any warnings are encountered then the build fails.
+
+Popular CI servers already set the environment variable `CI` by default but you can do this yourself too:
 
 ### On CI servers
 #### Travis CI
@@ -805,6 +809,7 @@ cache:
     - node_modules
 script:
   - npm test
+  - npm run build
 ```
 1. Trigger your first build with a git push.
 1. [Customize your Travis CI Build](https://docs.travis-ci.com/user/customizing-the-build/) if needed.
@@ -816,6 +821,10 @@ script:
 set CI=true&&npm test
 ```
 
+```cmd
+set CI=true&&npm run build
+```
+
 (Note: the lack of whitespace is intentional.)
 
 ##### Linux, OS X (Bash)
@@ -824,9 +833,15 @@ set CI=true&&npm test
 CI=true npm test
 ```
 
-This way Jest will run tests once instead of launching the watcher.
+```bash
+CI=true npm run build
+```
 
-If you find yourself doing this often in development, please [file an issue](https://github.com/facebookincubator/create-react-app/issues/new) to tell us about your use case because we want to make watcher the best experience and are open to changing how it works to accommodate more workflows.
+The test command will force Jest to run tests once instead of launching the watcher.
+
+>  If you find yourself doing this often in development, please [file an issue](https://github.com/facebookincubator/create-react-app/issues/new) to tell us about your use case because we want to make watcher the best experience and are open to changing how it works to accommodate more workflows.
+
+The build command will check for linter warning and fail the build if any are found.
 
 ### Disabling jsdom
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -841,7 +841,7 @@ The test command will force Jest to run tests once instead of launching the watc
 
 >  If you find yourself doing this often in development, please [file an issue](https://github.com/facebookincubator/create-react-app/issues/new) to tell us about your use case because we want to make watcher the best experience and are open to changing how it works to accommodate more workflows.
 
-The build command will check for linter warning and fail if any are found.
+The build command will check for linter warnings and fail if any are found.
 
 ### Disabling jsdom
 


### PR DESCRIPTION
Fixes issue #906.

Whenever someone runs the build script with the environmental variable `CI` set to true then it will crash when any linter warnings are encountered.

``` sh
CI=true npm run build
```

I have tested this locally by generating an app using `create-react-app` and the updated `react-scripts`. Is this enough or should there be an automated way of testing this functionality? If so, can anyone give some advice on how to go about testing this?

I am also struggling to find the best location to document this feature. I considered updating the   `npm run build` section of the README with this information however, I am afraid that explaining this feature in that location will only detract from the clarity to the reader. Perhaps I should create a new section in the user guide where this is explained, any thoughts?
