### PR TITLE
Add BuildProgressPlugin

### DIFF
--- a/packages/react-dev-utils/BuildProgressPlugin.js
+++ b/packages/react-dev-utils/BuildProgressPlugin.js
@@ -9,7 +9,14 @@
 
 'use strict';
 
-const ProgressPlugin = require('webpack').ProgressPlugin;
+const path = require('path');
+
+let ProgressPlugin;
+if (__dirname.indexOf(path.join('packages', 'react-dev-utils')) !== -1) {
+  ProgressPlugin = require('../react-scripts/node_modules/webpack').ProgressPlugin;
+} else {
+  ProgressPlugin = require('webpack').ProgressPlugin;
+}
 const ProgressBar = require('progress');
 const chalk = require('chalk');
 
@@ -22,7 +29,7 @@ function BuildProgressPlugin() {
   })
   return new ProgressPlugin(function(percent, msg) {
     if (percent === 1) msg = 'completed';
-    bar.update(percent, { msg: msg });
+    bar.update(percent, { msg });
     if (percent === 1) bar.terminate();
   });
 }

--- a/packages/react-dev-utils/BuildProgressPlugin.js
+++ b/packages/react-dev-utils/BuildProgressPlugin.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+const ProgressPlugin = require('webpack').ProgressPlugin;
+const ProgressBar = require('progress');
+const chalk = require('chalk');
+
+function BuildProgressPlugin() {
+  const bar = new ProgressBar(`  [:bar] ${chalk.bold(':percent')} ${chalk.yellow(':etas')} (${chalk.dim(':msg')})`, {
+    total: 100,
+    complete: '=',
+    incomplete: ' ',
+    width: 25
+  })
+  return new ProgressPlugin(function(percent, msg) {
+    if (percent === 1) msg = 'completed';
+    bar.update(percent, { msg: msg });
+    if (percent === 1) bar.terminate();
+  });
+}
+
+module.exports = BuildProgressPlugin;

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -29,7 +29,9 @@
     "opn": "4.0.2",
     "progress": "1.1.8",
     "sockjs-client": "1.0.3",
-    "strip-ansi": "3.0.1",
+    "strip-ansi": "3.0.1"
+  },
+  "peerDependencies": {
     "webpack": "^1.13.2"
   }
 }

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -27,10 +27,9 @@
     "escape-string-regexp": "1.0.5",
     "html-entities": "1.2.0",
     "opn": "4.0.2",
+    "progress": "1.1.8",
     "sockjs-client": "1.0.3",
-    "strip-ansi": "3.0.1"
-  },
-  "peerDependencies": {
+    "strip-ansi": "3.0.1",
     "webpack": "^1.13.2"
   }
 }

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -19,6 +19,7 @@ var InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 var url = require('url');
 var paths = require('./paths');
 var getClientEnvironment = require('./env');
+var BuildProgressPlugin = require('react-dev-utils/BuildProgressPlugin');
 
 function ensureSlash(path, needsSlash) {
   var hasSlash = path.endsWith('/');
@@ -257,7 +258,8 @@ module.exports = {
     // having to parse `index.html`.
     new ManifestPlugin({
       fileName: 'asset-manifest.json'
-    })
+    }),
+    new BuildProgressPlugin()
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.


### PR DESCRIPTION
I figured I'd take a stab at #935 since it seemed relatively easy.

I do have a concern though!
I created the plugin in `react-dev-utils` per suggestion in #935, however this resulted in adding `webpack` as a dependency 😱 -- it was listed as a peerDependency previously (which fails to resolve post lerna/lerna#318).
Would it be better to implement it in `react-scripts` and add `progress` as a dependency? Or would you rather explore a solution which doesn't use `progress`?

**edit**: read below

![](https://puu.sh/rTEou/cff45fb431.png)
