### PR TITLE
Check for presence of folders before continuing eject.

### DIFF
--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -30,6 +30,25 @@ prompt(
 
   var ownPath = path.join(__dirname, '..');
   var appPath = path.join(ownPath, '..', '..');
+
+  function verifyAbsent(file) {
+    if (fs.existsSync(path.join(appPath, file))) {
+      console.error(
+        '`' + file + '` already exists in your app folder. We cannot ' +
+        'continue as you would lose all the changes in that file or directory. ' +
+        'Please move or delete it (maybe make a copy for backup) and run this ' +
+        'command again.'
+      );
+      process.exit(1);
+    }
+  }
+
+  var folders = [
+    'config',
+    path.join('config', 'jest'),
+    'scripts'
+  ];
+
   var files = [
     path.join('config', 'env.js'),
     path.join('config', 'paths.js'),
@@ -44,22 +63,13 @@ prompt(
   ];
 
   // Ensure that the app folder is clean and we won't override any files
-  files.forEach(function(file) {
-    if (fs.existsSync(path.join(appPath, file))) {
-      console.error(
-        '`' + file + '` already exists in your app folder. We cannot ' +
-        'continue as you would lose all the changes in that file or directory. ' +
-        'Please delete it (maybe make a copy for backup) and run this ' +
-        'command again.'
-      );
-      process.exit(1);
-    }
-  });
+  folders.forEach(verifyAbsent);
+  files.forEach(verifyAbsent);
 
   // Copy the files over
-  fs.mkdirSync(path.join(appPath, 'config'));
-  fs.mkdirSync(path.join(appPath, 'config', 'jest'));
-  fs.mkdirSync(path.join(appPath, 'scripts'));
+  folders.forEach(function(folder) {
+    fs.mkdirSync(path.join(appPath, folder))
+  });
 
   console.log();
   console.log(cyan('Copying files into ' + appPath));


### PR DESCRIPTION
Verifies that the folders created during an eject (not just the files) do not exist. Exits with error if they do exist.

I tested this by creating `scripts` and `config/jest` folders in the app, then running `npm run eject`. The script failed early on both `scripts` and `config`, as expected. Removing these directories allowed the script to continue running and successfully create the required directories and copy the files over to them.

Closes #939.