### PR TITLE
Add IDE section to .gitignore template

### DIFF
--- a/packages/react-scripts/template/gitignore
+++ b/packages/react-scripts/template/gitignore
@@ -13,3 +13,6 @@ build
 .DS_Store
 .env
 npm-debug.log
+
+# ide
+.idea


### PR DESCRIPTION
Exclude files needed by WebStorm (IntelliJ Idea).
Most of the times the IDE configuration should not be included in the repository
