### PR TITLE
Always build before deploying to gh-pages

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -887,7 +887,7 @@ Open your `package.json` and add a `homepage` field:
 **The above step is important!**<br>
 Create React App uses the `homepage` field to determine the root URL in the built HTML file.
 
-Now, whenever you run `npm run build`, you will see a cheat sheet with instructions on how to deploy to GitHub pages.
+Now, whenever you run `npm run build`, you will see a cheat sheet with instructions on how to deploy to GitHub Pages.
 
 To publish it at [http://myusername.github.io/my-app](http://myusername.github.io/my-app), run:
 
@@ -905,17 +905,19 @@ Add the following script in your `package.json`:
   }
 ```
 
+(Note: the lack of whitespace is intentional.)
+
 Then run:
 
 ```sh
 npm run deploy
 ```
 
+You can configure a custom domain with GitHub Pages by adding a `CNAME` file to the `public/` folder.
+
 Note that GitHub Pages doesn't support routers that use the HTML5 `pushState` history API under the hood (for example, React Router using `browserHistory`). This is because when there is a fresh page load for a url like `http://user.github.io/todomvc/todos/42`, where `/todos/42` is a frontend route, the GitHub Pages server returns 404 because it knows nothing of `/todos/42`. If you want to add a router to a project hosted on GitHub Pages, here are a couple of solutions:
 * You could switch from using HTML5 history API to routing with hashes. If you use React Router, you can switch to `hashHistory` for this effect, but the URL will be longer and more verbose (for example, `http://user.github.io/todomvc/#/todos/42?_k=yknaj`). [Read more](https://github.com/reactjs/react-router/blob/master/docs/guides/Histories.md#histories) about different history implementations in React Router.
 * Alternatively, you can use a trick to teach GitHub Pages to handle 404 by redirecting to your `index.html` page with a special redirect parameter. You would need to add a `404.html` file with the redirection code to the `build` folder before deploying your project, and you’ll need to add code handling the redirect parameter to `index.html`. You can find a detailed explanation of this technique [in this guide](https://github.com/rafrex/spa-github-pages).
-
-You can configure a custom domain with GitHub pages by adding a `CNAME` file to the `public/` folder.
 
 ### Heroku
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -915,6 +915,8 @@ Note that GitHub Pages doesn't support routers that use the HTML5 `pushState` hi
 * You could switch from using HTML5 history API to routing with hashes. If you use React Router, you can switch to `hashHistory` for this effect, but the URL will be longer and more verbose (for example, `http://user.github.io/todomvc/#/todos/42?_k=yknaj`). [Read more](https://github.com/reactjs/react-router/blob/master/docs/guides/Histories.md#histories) about different history implementations in React Router.
 * Alternatively, you can use a trick to teach GitHub Pages to handle 404 by redirecting to your `index.html` page with a special redirect parameter. You would need to add a `404.html` file with the redirection code to the `build` folder before deploying your project, and you’ll need to add code handling the redirect parameter to `index.html`. You can find a detailed explanation of this technique [in this guide](https://github.com/rafrex/spa-github-pages).
 
+You can configure a custom domain with GitHub pages, by adding a `CNAME` file to the `public/` folder.
+
 ### Heroku
 
 Use the [Heroku Buildpack for Create React App](https://github.com/mars/create-react-app-buildpack).<br>

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -901,7 +901,7 @@ Add the following script in your `package.json`:
   // ...
   "scripts": {
     // ...
-    "deploy": "npm run build && gh-pages -d build"
+    "deploy": "npm run build&&gh-pages -d build"
   }
 ```
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -901,7 +901,7 @@ Add the following script in your `package.json`:
   // ...
   "scripts": {
     // ...
-    "deploy": "gh-pages -d build"
+    "deploy": "npm run build && gh-pages -d build"
   }
 ```
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -915,7 +915,7 @@ Note that GitHub Pages doesn't support routers that use the HTML5 `pushState` hi
 * You could switch from using HTML5 history API to routing with hashes. If you use React Router, you can switch to `hashHistory` for this effect, but the URL will be longer and more verbose (for example, `http://user.github.io/todomvc/#/todos/42?_k=yknaj`). [Read more](https://github.com/reactjs/react-router/blob/master/docs/guides/Histories.md#histories) about different history implementations in React Router.
 * Alternatively, you can use a trick to teach GitHub Pages to handle 404 by redirecting to your `index.html` page with a special redirect parameter. You would need to add a `404.html` file with the redirection code to the `build` folder before deploying your project, and you’ll need to add code handling the redirect parameter to `index.html`. You can find a detailed explanation of this technique [in this guide](https://github.com/rafrex/spa-github-pages).
 
-You can configure a custom domain with GitHub pages, by adding a `CNAME` file to the `public/` folder.
+You can configure a custom domain with GitHub pages by adding a `CNAME` file to the `public/` folder.
 
 ### Heroku
 


### PR DESCRIPTION
Pretty simple docs change:

Recommendations for `package.json` `scripts` for deploying to Github Pages:

```diff
+"deploy": "npm run build && gh-pages -d build"
-"deploy": "gh-pages -d build"
```

It seems very unlikely the user would want to deploy without rebuilding and can be confusing since the dev server automatically rebuilds.

This also adds a line to these deploy docs instructing where to put the `CNAME` file:

```diff
+You can configure a custom domain with GitHub pages, by adding a `CNAME` file to the `public/` folder.
```

This fixes https://github.com/facebookincubator/create-react-app/issues/654