### PR TITLE
Add collectCoverageFrom option to collect coverage on files without any tests

### DIFF
--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -18,6 +18,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
   const setupTestsFile = pathExists.sync(paths.testsSetup) ? '<rootDir>/src/setupTests.js' : undefined;
 
   const config = {
+    collectCoverageFrom: ['src/**/*.{js,jsx}'],
     moduleFileExtensions: ['jsx', 'js', 'json'],
     moduleNameMapper: {
       '^.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': resolve('config/jest/FileStub.js'),


### PR DESCRIPTION
Adding collectCoverageFrom option to the config to cover files that have no tests. This is set to look for any file under the `src/` directory. 

Below is the coverage report prior to the change:
<img width="530" alt="screen shot 2016-10-25 at 15 46 11" src="https://cloud.githubusercontent.com/assets/17095658/19690878/0af2628a-9aca-11e6-8d3b-3bfc6d3f068f.png">

And here is the coverage after the change with the same tests:
<img width="594" alt="screen shot 2016-10-25 at 15 46 42" src="https://cloud.githubusercontent.com/assets/17095658/19690879/0afe43e8-9aca-11e6-8ecd-3dcc91a63200.png">

It's worth noting this can currently be achieved by passing the arguments through 
`npm test -- --coverage --collectCoverageFrom='src/**/*.{js,jsx}'`. 
This change would make this the default behaviour. If a different path is required then passing it as an argument overrides the default. 

For example if I only cared about the actions folder I could run:
`npm test -- --coverage --collectCoverageFrom='src/actions/*.{js,jsx}'`
<img width="584" alt="screen shot 2016-10-25 at 16 11 13" src="https://cloud.githubusercontent.com/assets/17095658/19691971/1b2d53c2-9ace-11e6-968f-92aa185c24e9.png">

A similar PR was already submitted #905 but the author hasn't responded in a while. This is also without the ignore path as I feel its unnecessary.


