### PR TITLE
Allow webpack 2 as peerDependency in react-dev-utils

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -29,8 +29,5 @@
     "opn": "4.0.2",
     "sockjs-client": "1.0.3",
     "strip-ansi": "3.0.1"
-  },
-  "peerDependencies": {
-    "webpack": "^1.13.2 || <=2.1.0-beta.25"
   }
 }

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -31,6 +31,6 @@
     "strip-ansi": "3.0.1"
   },
   "peerDependencies": {
-    "webpack": "^1.13.2"
+    "webpack": "^1.13.2 || <=2.1.0-beta.25"
   }
 }


### PR DESCRIPTION
Now that [webpackHotDevClient support webpack 2](https://github.com/facebookincubator/create-react-app/pull/840), react-dev-utils should allow the most recent beta release to 🐱.
