### PR TITLE
Catch and noop call to open web browser.

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -28,7 +28,7 @@ function openBrowser(url) {
   // Fallback to opn
   // (It will always open new tab)
   try {
-    opn(url);
+    opn(url).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {
     return false;


### PR DESCRIPTION
Running `create-react-app` in a Docker container causes an unhandled rejection error in nodejs > 6.5 because the `opn` module tries to open a web browser in a system that doesn't have one. I figured this error could be safely ignored.