### PR TITLE
Allow configuring the webpackHotDevClient with a url

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -24,6 +24,15 @@ var formatWebpackMessages = require('./formatWebpackMessages');
 var Entities = require('html-entities').AllHtmlEntities;
 var entities = new Entities();
 
+var urlParts;
+var query = __resourceQuery; // eslint-disable-line
+
+if (typeof query === "string" && query) {
+  urlParts = url.parse(query.substr(1));
+} else {
+  urlParts = window.location;
+}
+
 // Color scheme inspired by https://github.com/glenjamin/webpack-hot-middleware
 var colors = {
   reset: ['transparent', 'transparent'],
@@ -138,9 +147,9 @@ function destroyErrorOverlay() {
 
 // Connect to WebpackDevServer via a socket.
 var connection = new SockJS(url.format({
-  protocol: window.location.protocol,
-  hostname: window.location.hostname,
-  port: window.location.port,
+  protocol: urlParts.protocol,
+  hostname: urlParts.hostname,
+  port: urlParts.port,
   // Hardcoded in WebpackDevServer
   pathname: '/sockjs-node'
 }));


### PR DESCRIPTION
This allows configuring the webpackHotClient with a URL. Currently, the hot client assumes that your frontend code is served from the same `window.location`, but this is often not true for server-rendered applications using the webpack-dev-server.

This can be configured like so:

```javascript
entry: [
  `${require.resolve('react-dev-utils/webpackHotDevClient')}?http://0.0.0.0:4001`,
  'your-entry.js'
]
```

See:
https://github.com/webpack/webpack-dev-server/blob/544d97bf4bee3853c84abb8690923bf93fda4fab/client/index.js#L22