### PR TITLE
Enable compression on webpack-dev-server (#966)

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -195,6 +195,8 @@ function addMiddleware(devServer) {
 
 function runDevServer(host, port, protocol) {
   var devServer = new WebpackDevServer(compiler, {
+    // Enable gzip compression of generated files.
+    compress: true,
     // Silence WebpackDevServer's own logs since they're generally not useful.
     // It will still show compile warnings and errors with this setting.
     clientLogLevel: 'none',


### PR DESCRIPTION
This enables compression of generated assets over webpack-dev-server. Especially useful if you're developing on a remote machine with subpar connection speed.

I couldn't think of any test cases but I'm open to suggestions.