### PR TITLE
Proof of concept: Plugin System

### DIFF
--- a/packages/react-scripts/config/plugins.js
+++ b/packages/react-scripts/config/plugins.js
@@ -1,0 +1,45 @@
+var paths = require('./paths');
+var packageJson = require(paths.appPackageJson);
+var chalk = require('chalk');
+
+// To build a plugin, write a module that exports a single function.
+// This function should takes a Webpack config and return the modified
+// Webpack config. Here's an example that adds a SASS loader:
+//
+// module.exports = function(webpackConfig) {
+//     webpackConfig.module.loaders.push({
+//       test: /\.scss$/,
+//       loaders: ["style", "css", "sass"]
+//     });
+//     return webpackConfig;
+// };
+function applyPlugins(webpackConfig) {
+  var plugins = packageJson.plugins;
+
+  if(!plugins) {
+    return webpackConfig;
+  }
+
+  if(!Array.isArray(plugins)) {
+    console.log(chalk.red('When specified, "plugins" in package.json must be an array.'));
+    console.log(chalk.red('Instead, the type of "plugins" was "' + typeof plugins + '".'));
+    console.log(chalk.red('Either remove "plugins" from package.json, or make it an array.'));
+    process.exit(1);
+  }
+
+  // Load the plugin modules
+  plugins = plugins.map(plugin => require(plugin));
+
+  // Pass the webpack config through the set of plugins, allowing
+  // each one to modify it as necessary
+  var initialConfig = Object.assign({}, webpackConfig);
+  var finalConfig = plugins.reduce(function(intermediateConfig, plugin) {
+    return plugin(Object.assign({}, intermediateConfig));
+  }, initialConfig);
+
+  return finalConfig;
+}
+
+module.exports = {
+  applyPlugins: applyPlugins
+};

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -30,11 +30,15 @@ var paths = require('../config/paths');
 var checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
 var recursive = require('recursive-readdir');
 var stripAnsi = require('strip-ansi');
+var plugins = require('../config/plugins');
 
 // Warn and crash if required files are missing
 if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
   process.exit(1);
 }
+
+// Apply plugins to the Webpack config
+config = plugins.applyPlugins(config);
 
 // Input: /User/dan/app/build/static/js/main.82be8.js
 // Output: /static/js/main.js

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -30,6 +30,7 @@ var openBrowser = require('react-dev-utils/openBrowser');
 var prompt = require('react-dev-utils/prompt');
 var config = require('../config/webpack.config.dev');
 var paths = require('../config/paths');
+var plugins = require('../config/plugins');
 
 // Warn and crash if required files are missing
 if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
@@ -53,6 +54,9 @@ if (isSmokeTest) {
     }
   };
 }
+
+// Apply plugins to the Webpack config
+config = plugins.applyPlugins(config);
 
 function setupCompiler(host, port, protocol) {
   // "Compiler" is a low-level interface to Webpack.


### PR DESCRIPTION
(This is related to issue #670)

This commit adds a "plugins" module and integrates it into the dev and prod build scripts.

The design and functionality is intentionally minimal, but it allows a user to write a plugin or series of plugins to manipulate the Webpack config as necessary. The example given in the `plugins.js` file shows a plugin that adds a SASS loader:

``` javascript
module.exports = function(webpackConfig) {
    webpackConfig.module.loaders.push({
      test: /\.scss$/,
      loaders: ["style", "css", "sass"]
    });
    return webpackConfig;
};
```

But conceivably any sort of Webpack config transformation could be done here.

Plugins are loaded and run, in order, from the `plugins` key in `package.json`. This would load a module named `cra-plugin-sass`, which would need to be `npm install`'d separately.

``` json
  "plugins": [
    "cra-plugin-sass"
  ]
```

We could also explore auto-discovery of plugins ala Babel or Karma, by searching for packages matching the "cra-plugin-*" prefix. However, the loading order does matter (since the config is transformed by every plugin in turn) and an array of plugins is more explicit.
