### PR TITLE
Explain the usage of react-jsx-source & react-jsx-self

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -54,6 +54,12 @@ if (env !== 'development' && env !== 'test' && env !== 'production') {
 }
 
 if (env === 'development' || env === 'test') {
+  // The following two plugins are currently necessary to make jsx developer
+  // friendly messages, if you wondering why it is added here seprately rather
+  // it comes with babel-preset-react see the below threads for more info
+  // https://github.com/babel/babel/issues/4702
+  // https://github.com/babel/babel/pull/3540#issuecomment-228673661
+  // https://github.com/facebookincubator/create-react-app/issues/989
   plugins.push.apply(plugins, [
     // Adds component stack to warning messages
     require.resolve('babel-plugin-transform-react-jsx-source'),
@@ -99,4 +105,3 @@ if (env === 'test') {
     // ]);
   }
 }
-

--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -54,9 +54,9 @@ if (env !== 'development' && env !== 'test' && env !== 'production') {
 }
 
 if (env === 'development' || env === 'test') {
-  // The following two plugins are currently necessary to make jsx developer
-  // friendly messages, if you wondering why it is added here seprately rather
-  // it comes with babel-preset-react see the below threads for more info
+  // The following two plugins are currently necessary to make React warnings
+  // include more valuable information. They are included here because they are
+  // currently not enabled in babel-preset-react. See the below threads for more info:
   // https://github.com/babel/babel/issues/4702
   // https://github.com/babel/babel/pull/3540#issuecomment-228673661
   // https://github.com/facebookincubator/create-react-app/issues/989


### PR DESCRIPTION
Hi,

This clears the usage of why we have added two plugins separately, rather than not using it via options in babel-preset-react. 
