### PR TITLE
Suggest jest-enzyme for simplifying test matchers

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -747,7 +747,7 @@ Additionally, you might find [jest-enzyme](https://github.com/blainekasten/enzym
 expect(wrapper).toContainReact(welcome)
 ```
 
-To setup jest-enzyme with Create React App, follow the instructions for [`src/setupTests.js`](#srcsetuptestsjs) and import `jest-enzyme`.
+To setup jest-enzyme with Create React App, follow the instructions for [initializing your test environment](#initializing-test-environment) to import `jest-enzyme`.
 
 ```js
 // src/setupTests.js

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -747,6 +747,14 @@ Additionally, you might find [jest-enzyme](https://github.com/blainekasten/enzym
 expect(wrapper).toContainReact(welcome)
 ```
 
+To setup jest-enzyme with Create React App, follow the instructions for [`src/setupTests.js`](#srcsetuptestsjs) and import `jest-enzyme`.
+
+```js
+// src/setupTests.js
+import 'jest-enzyme';
+```
+
+
 ### Using Third Party Assertion Libraries
 
 We recommend that you use `expect()` for assertions and `jest.fn()` for spies. If you are having issues with them please [file those against Jest](https://github.com/facebook/jest/issues/new), and we’ll fix them. We intend to keep making them better for React, supporting, for example, [pretty-printing React elements as JSX](https://github.com/facebook/jest/pull/1566).

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -741,6 +741,12 @@ it('renders welcome message', () => {
 All Jest matchers are [extensively documented here](http://facebook.github.io/jest/docs/api.html#expect-value).<br>
 Nevertheless you can use a third-party assertion library like [Chai](http://chaijs.com/) if you want to, as described below.
 
+Additionally, you might find [jest-enzyme](https://github.com/blainekasten/enzyme-matchers) helpful to simplify your tests with readable matchers. The above `contains` code can be written simpler with jest-enzyme.
+
+```js
+expect(wrapper).toContainReact(welcome)
+```
+
 ### Using Third Party Assertion Libraries
 
 We recommend that you use `expect()` for assertions and `jest.fn()` for spies. If you are having issues with them please [file those against Jest](https://github.com/facebook/jest/issues/new), and we’ll fix them. We intend to keep making them better for React, supporting, for example, [pretty-printing React elements as JSX](https://github.com/facebook/jest/pull/1566).


### PR DESCRIPTION
Add [`jest-enzyme`](https://github.com/blainekasten/enzyme-matchers) to documentation for simpler tests when using enzyme.