### PR TITLE
Remove redundant `function` from export statement

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -320,7 +320,7 @@ function Header() {
   return <img src={logo} alt="Logo" />;
 }
 
-export default function Header;
+export default Header;
 ```
 
 This ensures that when the project is built, Webpack will correctly move the images into the build folder, and provide us with correct paths.


### PR DESCRIPTION
It seems

```js
export default function Header;
```

should read

```js
export default Header;
```