### PR TITLE
display build duration

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -76,9 +76,12 @@ function setupCompiler(host, port, protocol) {
     // We have switched off the default Webpack output in WebpackDevServer
     // options so we are going to "massage" the warnings and errors and present
     // them in a readable focused way.
-    var messages = formatWebpackMessages(stats.toJson({}, true));
+    var jsonStats = stats.toJson({}, true);
+    var messages = formatWebpackMessages(jsonStats);
+    var seconds = jsonStats.time / 1000;
     if (!messages.errors.length && !messages.warnings.length) {
       console.log(chalk.green('Compiled successfully!'));
+      console.log('Duration: ' + seconds.toFixed(2) + 's');
       console.log();
       console.log('The app is running at:');
       console.log();


### PR DESCRIPTION
It's interesting to know and track the build time. This PR logs a build duration:

![image](https://cloud.githubusercontent.com/assets/2317341/19977773/0f80d2dc-a1f5-11e6-9248-4e8e7cb7e68a.png)
