### PR TITLE
Add SASS support documentation #1007

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -18,7 +18,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Importing a Component](#importing-a-component)
 - [Adding a Stylesheet](#adding-a-stylesheet)
 - [Post-Processing CSS](#post-processing-css)
-- [Adding SASS Support](#adding-sass-support)
+- [Adding CSS Preprocessor (SASS, Less etc.](#adding-sass-support)
 - [Adding Images and Fonts](#adding-images-and-fonts)
 - [Using the `public` Folder](#using-the-public-folder)
 - [Adding Bootstrap](#adding-bootstrap)
@@ -302,7 +302,7 @@ becomes this:
 
 There is currently no support for preprocessors such as Less, or for sharing variables across CSS files.
 
-## Adding SASS Support
+## Adding CSS Preprocessor (SASS, LESS etc.)
 
 CSS preprocessors have become a vital part of build processes. Using a preprocesssor of your choice in a project bootstrapped using create-react-app, is fairly straightforward to setup, even without having to eject.
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -18,7 +18,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Importing a Component](#importing-a-component)
 - [Adding a Stylesheet](#adding-a-stylesheet)
 - [Post-Processing CSS](#post-processing-css)
-- [Adding CSS Preprocessor (SASS, LESS etc.)](#adding-css-preprocessor-sass-less-etc)
+- [Adding CSS Preprocessor (Sass, Less etc.)](#adding-css-preprocessor-sass-less-etc)
 - [Adding Images and Fonts](#adding-images-and-fonts)
 - [Using the `public` Folder](#using-the-public-folder)
 - [Adding Bootstrap](#adding-bootstrap)
@@ -302,11 +302,11 @@ becomes this:
 
 There is currently no support for preprocessors such as Less, or for sharing variables across CSS files.
 
-## Adding CSS Preprocessor (SASS, LESS etc.)
+## Adding CSS Preprocessor (Sass, Less etc.)
 
 CSS preprocessors have become a vital part of build processes. Using a preprocesssor of your choice in a project bootstrapped using create-react-app, is fairly straightforward to setup, even without having to eject.
 
-First, install preprocessor of your choice. SASS seems the most popular weapon of choice at the moment, so we'll use it as an example.
+First, install preprocessor of your choice. Sass seems the most popular weapon of choice at the moment, so we'll use it as an example.
 
 ```
 npm install node-sass --save-dev

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -18,7 +18,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Importing a Component](#importing-a-component)
 - [Adding a Stylesheet](#adding-a-stylesheet)
 - [Post-Processing CSS](#post-processing-css)
-- [Adding CSS Preprocessor (Sass, Less etc.)](#adding-css-preprocessor-sass-less-etc)
+- [Adding a CSS Preprocessor (Sass, Less etc.)](#adding-a-css-preprocessor-sass-less-etc)
 - [Adding Images and Fonts](#adding-images-and-fonts)
 - [Using the `public` Folder](#using-the-public-folder)
 - [Adding Bootstrap](#adding-bootstrap)
@@ -302,46 +302,51 @@ becomes this:
 
 There is currently no support for preprocessors such as Less, or for sharing variables across CSS files.
 
-## Adding CSS Preprocessor (Sass, Less etc.)
+## Adding a CSS Preprocessor (Sass, Less etc.)
 
-Using a CSS preprocesssor in a project bootstrapped using create-react-app, is fairly straightforward to setup, even without having to eject.
+Generally, we recommend that you don’t reuse the same CSS classes across different components. For example, instead of using a `.Button` CSS class in `<AcceptButton>` and `<RejectButton>` components, we recommend creating a `<Button>` component with its own `.Button` styles, that both `<AcceptButton>` and `<RejectButton>` can render (but [not inherit](https://facebook.github.io/react/docs/composition-vs-inheritance.html)).
 
-First, install preprocessor of your choice. We will be using SASS in this example, but you can replace SASS with a preprocessor of your choice.
+Following this rule often makes CSS preprocessors less useful, as features like mixins and nesting are replaced by component composition. You can, however, integrate a CSS preprocessor if you find it valuable. In this walkthrough, we will be using Sass, but you can also use Less, or another alternative.
+
+First, let’s install the command-line interface for Sass:
 
 ```
 npm install node-sass --save-dev
 ```
 
-Then in `package.json` just add the following lines to `scripts`, replacing file paths accordingly.
-```
-  ...
-  "scripts": {
-    ...
-    "build-css": "node-sass src/sass/base.scss src/index.css",
-    "watch-css": "npm run build-css && node-sass src/sass/base.scss src/index.css -w",
-    ...
-  }
-  ...
-```
+Then in `package.json`, add the following lines to `scripts`:
 
-> To use a different preprocessor, replace `build-css` and `watch-css` scripts to match the one you're using.
-
-Add these scripts to the main scripts, by pasting `npm run watch-css &` to `start` script and `npm run build-css &&` to `build`.
-
-```
- ...
-  "scripts": {
-    "start": "npm run watch-css & react-scripts start",
-    "build": "npm run build-css && react-scripts build",
-    "build-css": "node-sass src/sass/base.scss src/index.css",
-    "watch-css": "npm run build-css && node-sass src/sass/base.scss src/index.css -w",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
-  }
-  ...
+```diff
+   "scripts": {
++    "build-css": "node-sass src/ -o src/",
++    "watch-css": "npm run build-css && node-sass src/ -o src/ --watch",
+     "start": "react-scripts start",
+     "build": "react-scripts build",
+     "test": "react-scripts test --env=jsdom",
 ```
 
-Finally, you can use `npm start` or `npm run build` as usual.
+>Note: To use a different preprocessor, replace `build-css` and `watch-css` commands according to your preprocessor’s documentation. 
+
+Now you can rename `src/App.css` to `src/App.scss` and run `npm run watch-css`. The watcher will find every Sass file in `src` subdirectories, and create a corresponding CSS file next to it, in our case overwriting `src/App.css`. Since `src/App.js` still imports `src/App.css`, the styles become a part of your application. You can now edit `src/App.scss`, and `src/App.css` will be regenerated.
+
+At this point you might want to remove all CSS files from the source control, and add `src/**/*.css` to your `.gitignore` file. It is generally a good practice to keep the build products outside of the source control.
+
+As a final step, you may find it convenient to run `watch-css` automatically with `npm start`, and run `build-css` as a part of `npm run build`. You can use `&` operator for executing scripts in parallel, and `&&` for executing them sequentially:
+
+```diff
+   "scripts": {
+     "build-css": "node-sass src/ -o src/",
+     "watch-css": "npm run build-css && node-sass src/ -o src/ --watch",
+-    "start": "react-scripts start",
+-    "build": "react-scripts build",
++    "start": "react-scripts start & npm run watch-css",
++    "build": "react-scripts build && npm run build-css",
+     "test": "react-scripts test --env=jsdom",
+     "eject": "react-scripts eject"
+   }
+```
+
+Now running `npm start` and `npm run build` also builds Sass files. Note that `node-sass` seems to have an [issue recognizing newly created files on some systems](https://github.com/sass/node-sass/issues/1891) so you might need to restart the watcher when you create a file until it’s resolved.
 
 ## Adding Images and Fonts
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -18,6 +18,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Importing a Component](#importing-a-component)
 - [Adding a Stylesheet](#adding-a-stylesheet)
 - [Post-Processing CSS](#post-processing-css)
+- [Adding SASS Support](#adding-sass-support)
 - [Adding Images and Fonts](#adding-images-and-fonts)
 - [Using the `public` Folder](#using-the-public-folder)
 - [Adding Bootstrap](#adding-bootstrap)
@@ -300,6 +301,47 @@ becomes this:
 ```
 
 There is currently no support for preprocessors such as Less, or for sharing variables across CSS files.
+
+## Adding SASS Support
+
+CSS preprocessors have become a vital part of build processes. Using a preprocesssor of your choice in a project bootstrapped using create-react-app, is fairly straightforward to setup, even without having to eject.
+
+First, install preprocessor of your choice. SASS seems the most popular weapon of choice at the moment, so we'll use it as an example.
+
+```
+npm install node-sass --save-dev
+```
+
+Then in `package.json` just add the following lines to `scripts`, replacing file paths accordingly.
+```
+  ...
+  "scripts": {
+    ...
+    "build-css": "node-sass src/sass/base.scss src/index.css",
+    "watch-css": "node-sass src/sass/base.scss src/index.css -w",
+    ...
+  }
+  ...
+```
+
+> Using a different preprocessor should be just a matter of replacing `build-css` and `watch-css` scripts to something that matches the preprocessor you're using.
+
+Add these scripts to the main scripts, by pasting `npm run watch-css &` to `start` script and `npm run build-css &&` to `build`.
+
+```
+ ...
+  "scripts": {
+    "start": "npm run watch-css & react-scripts start",
+    "build": "npm run build-css && react-scripts build",
+    "build-css": "node-sass src/sass/base.scss src/index.css",
+    "watch-css": "node-sass src/sass/base.scss src/index.css -w",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+  ...
+```
+
+Finally, you can use `npm start` or `npm run build` as usual.
 
 ## Adding Images and Fonts
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -18,7 +18,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Importing a Component](#importing-a-component)
 - [Adding a Stylesheet](#adding-a-stylesheet)
 - [Post-Processing CSS](#post-processing-css)
-- [Adding CSS Preprocessor (SASS, Less etc.](#adding-css-preprocessor-sass-less-etc)
+- [Adding CSS Preprocessor (SASS, LESS etc.)](#adding-css-preprocessor-sass-less-etc)
 - [Adding Images and Fonts](#adding-images-and-fonts)
 - [Using the `public` Folder](#using-the-public-folder)
 - [Adding Bootstrap](#adding-bootstrap)
@@ -318,7 +318,7 @@ Then in `package.json` just add the following lines to `scripts`, replacing file
   "scripts": {
     ...
     "build-css": "node-sass src/sass/base.scss src/index.css",
-    "watch-css": "node-sass src/sass/base.scss src/index.css -w",
+    "watch-css": "npm run build-css && node-sass src/sass/base.scss src/index.css -w",
     ...
   }
   ...
@@ -334,7 +334,7 @@ Add these scripts to the main scripts, by pasting `npm run watch-css &` to `star
     "start": "npm run watch-css & react-scripts start",
     "build": "npm run build-css && react-scripts build",
     "build-css": "node-sass src/sass/base.scss src/index.css",
-    "watch-css": "node-sass src/sass/base.scss src/index.css -w",
+    "watch-css": "npm run build-css && node-sass src/sass/base.scss src/index.css -w",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   }

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -304,9 +304,9 @@ There is currently no support for preprocessors such as Less, or for sharing var
 
 ## Adding CSS Preprocessor (Sass, Less etc.)
 
-CSS preprocessors have become a vital part of build processes. Using a preprocesssor of your choice in a project bootstrapped using create-react-app, is fairly straightforward to setup, even without having to eject.
+Using a CSS preprocesssor in a project bootstrapped using create-react-app, is fairly straightforward to setup, even without having to eject.
 
-First, install preprocessor of your choice. Sass seems the most popular weapon of choice at the moment, so we'll use it as an example.
+First, install preprocessor of your choice. We will be using SASS in this example, but you can replace SASS with a preprocessor of your choice.
 
 ```
 npm install node-sass --save-dev
@@ -324,7 +324,7 @@ Then in `package.json` just add the following lines to `scripts`, replacing file
   ...
 ```
 
-> Using a different preprocessor should be just a matter of replacing `build-css` and `watch-css` scripts to something that matches the preprocessor you're using.
+> To use a different preprocessor, replace `build-css` and `watch-css` scripts to match the one you're using.
 
 Add these scripts to the main scripts, by pasting `npm run watch-css &` to `start` script and `npm run build-css &&` to `build`.
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -18,7 +18,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Importing a Component](#importing-a-component)
 - [Adding a Stylesheet](#adding-a-stylesheet)
 - [Post-Processing CSS](#post-processing-css)
-- [Adding CSS Preprocessor (SASS, Less etc.](#adding-sass-support)
+- [Adding CSS Preprocessor (SASS, Less etc.](#adding-css-preprocessor-sass-less-etc)
 - [Adding Images and Fonts](#adding-images-and-fonts)
 - [Using the `public` Folder](#using-the-public-folder)
 - [Adding Bootstrap](#adding-bootstrap)


### PR DESCRIPTION
As pointed out in https://github.com/facebookincubator/create-react-app/issues/1007, adding a specific section about SASS in documentation could help users avoid ejecting in order to use `sass-loader`.

This is simpler in my opinion and more aligned to this project's way of thinking.