### PR TITLE
fix IE bugs for ES6 static method,eg Array.from

### DIFF
--- a/packages/react-scripts/config/polyfills.js
+++ b/packages/react-scripts/config/polyfills.js
@@ -20,6 +20,9 @@ if (typeof Promise === 'undefined') {
 // fetch() polyfill for making API calls.
 require('whatwg-fetch');
 
+// fix IE bugs for ES6 static method,eg Array.from
+require("babel-polyfill");
+
 // Object.assign() is commonly used with React.
 // It will use the native implementation if it's present and isn't buggy.
 Object.assign = require('object-assign');


### PR DESCRIPTION
Internet explorer, eg IE11 will throw JS error ,when using ES6 static method Array.from . see detail in https://babeljs.io/docs/usage/polyfill/