### PR TITLE
No Configuration -> Convention over Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Please refer to the [User Guide](https://github.com/facebookincubator/create-rea
 
 * **One Dependency:** There is just one build dependency. It uses Webpack, Babel, ESLint, and other amazing projects, but provides a cohesive curated experience on top of them.
 
-* **Zero Configuration:** There are no configuration files or command line options. Configuring both development and production builds is handled for you so you can focus on writing code.
+* **Convention over Configuration:** You don't need to configure anything by default. Reasonably good configuration of both development and production builds is handled for you so you can focus on writing code.
 
 * **No Lock-In:** You can “eject” to a custom setup at any time. Run a single command, and all the configuration and build dependencies will be moved directly into your project, so you can pick up right where you left off.
 


### PR DESCRIPTION
This rule seems to be limiting development of this package. While it's certainly better to provide ready-to-use module that one doesn't need to configure, preventing configuration all together is constraining developers, forcing them to develop workarounds.

Besides this rule is already broken with `NODE_ENV` and `proxy` configuration and will be with plugins and `PUBLIC_URL`, `BROWSER`, `browsers` in package.json, and many others.