### PR TITLE
Fix chrome tab reuse

### DIFF
--- a/packages/react-dev-utils/openChrome.applescript
+++ b/packages/react-dev-utils/openChrome.applescript
@@ -38,6 +38,7 @@ on run argv
       tell theTab to reload
       set index of theWindow to 1
       set theWindow's active tab index to theTabIndex
+      tell theWindow to activate
     else
       tell window 1
         activate

--- a/packages/react-dev-utils/openChrome.applescript
+++ b/packages/react-dev-utils/openChrome.applescript
@@ -23,7 +23,7 @@ on run argv
       set theTabIndex to 0
       repeat with theTab in every tab of theWindow
         set theTabIndex to theTabIndex + 1
-        if theTab's URL is theURL then
+        if theTab's URL as string contains theURL then
           set found to true
           exit repeat
         end if


### PR DESCRIPTION
When you start the development server it open a tab with your preferred browser with the site your developing. [The docs for `react-dev-utils/openBrowser` states](https://github.com/facebookincubator/create-react-app/tree/master/packages/react-dev-utils):
> Attempts to open the browser with a given URL.
On Mac OS X, attempts to reuse an existing Chrome tab via AppleScript.
Otherwise, falls back to opn behavior.

The reuse of tabs in Chrome does not work correctly because of a bug in the applescript which this PR provides a fix for. Additionally it now supports tab reuse even if you've navigated in your app with history API, and brings Chrome to the foreground focused after tab reuse.