### PR TITLE
Allow resolving imports from src

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -74,9 +74,12 @@ module.exports = {
     publicPath: publicPath
   },
   resolve: {
+    // allows importing from the 'src' folder
+    // to avoid having to type long relative paths to get back up the folder hierarchy
+    root: [ paths.appSrc ],
     // This allows you to set a fallback for where Webpack should look for modules.
     // We read `NODE_PATH` environment variable in `paths.js` and pass paths here.
-    // We use `fallback` instead of `root` because we want `node_modules` to "win"
+    // We use `fallback` because we want `node_modules` to "win"
     // if there any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
     fallback: paths.nodePaths,

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -80,9 +80,12 @@ module.exports = {
     publicPath: publicPath
   },
   resolve: {
+    // allows importing from the 'src' folder
+    // to avoid having to type long relative paths to get back up the folder hierarchy
+    root: [ paths.appSrc ],
     // This allows you to set a fallback for where Webpack should look for modules.
     // We read `NODE_PATH` environment variable in `paths.js` and pass paths here.
-    // We use `fallback` instead of `root` because we want `node_modules` to "win"
+    // We use `fallback` because we want `node_modules` to "win"
     // if there any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
     fallback: paths.nodePaths,

--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -18,7 +18,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
   const setupTestsFile = pathExists.sync(paths.testsSetup) ? '<rootDir>/src/setupTests.js' : undefined;
 
   const config = {
-  	modulePaths: ['<rootDir>/src'],
+    modulePaths: ['<rootDir>/src'],
     collectCoverageFrom: ['src/**/*.{js,jsx}'],
     moduleFileExtensions: ['jsx', 'js', 'json'],
     moduleNameMapper: {

--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -18,6 +18,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
   const setupTestsFile = pathExists.sync(paths.testsSetup) ? '<rootDir>/src/setupTests.js' : undefined;
 
   const config = {
+  	modulePaths: ['<rootDir>/src'],
     collectCoverageFrom: ['src/**/*.{js,jsx}'],
     moduleFileExtensions: ['jsx', 'js', 'json'],
     moduleNameMapper: {


### PR DESCRIPTION
Typing `import x from '../../../../'` has become quite cumbersome and error prone and a lot of people (including myself) have indicated a strong desire for a better solution, e.g. `import x from 'components/x.js'`. 

The following addition allows resolving imports from `src`.