### PR TITLE
Adding postcss-cssnext

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -10,7 +10,6 @@
 // @remove-on-eject-end
 
 var path = require('path');
-var autoprefixer = require('autoprefixer');
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
@@ -171,16 +170,10 @@ module.exports = {
   },
   // @remove-on-eject-end
   // We use PostCSS for autoprefixing only.
+  // And some cssnext because we want to future proof code
   postcss: function() {
     return [
-      autoprefixer({
-        browsers: [
-          '>1%',
-          'last 4 versions',
-          'Firefox ESR',
-          'not ie < 9', // React doesn't support IE8 anyway
-        ]
-      }),
+      require('postcss-cssnext')(),
     ];
   },
   plugins: [

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -10,7 +10,6 @@
 // @remove-on-eject-end
 
 var path = require('path');
-var autoprefixer = require('autoprefixer');
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
@@ -190,16 +189,10 @@ module.exports = {
   },
   // @remove-on-eject-end
   // We use PostCSS for autoprefixing only.
+  // And some cssnext because we want to future proof code
   postcss: function() {
     return [
-      autoprefixer({
-        browsers: [
-          '>1%',
-          'last 4 versions',
-          'Firefox ESR',
-          'not ie < 9', // React doesn't support IE8 anyway
-        ]
-      }),
+      require('postcss-cssnext')()
     ];
   },
   plugins: [

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -23,7 +23,6 @@
     "react-scripts": "./bin/react-scripts.js"
   },
   "dependencies": {
-    "autoprefixer": "6.5.1",
     "babel-core": "6.17.0",
     "babel-eslint": "7.0.0",
     "babel-jest": "16.0.0",
@@ -54,6 +53,7 @@
     "json-loader": "0.5.4",
     "object-assign": "4.1.0",
     "path-exists": "2.1.0",
+    "postcss-cssnext": "^2.8.0",
     "postcss-loader": "1.0.0",
     "promise": "7.1.1",
     "react-dev-utils": "^0.3.0",
@@ -76,7 +76,6 @@
     "fsevents": "1.0.14"
   },
   "bundledDependencies": [
-    "autoprefixer",
     "babel-core",
     "babel-eslint",
     "babel-jest",
@@ -108,6 +107,7 @@
     "json-loader",
     "object-assign",
     "path-exists",
+    "postcss-cssnext",
     "postcss-loader",
     "promise",
     "react-dev-utils",


### PR DESCRIPTION
Postcss-cssnext does the auto prefixing and no one should have to change their project in order to use it. It then means people can start using newer css