### PR TITLE
Update babel-present-env and use node: 'current' as target

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -68,7 +68,7 @@ if (env === 'test') {
       // ES features necessary for user's Node version
       [require('babel-preset-env').default, {
         targets: {
-          node: parseFloat(process.versions.node),
+          node: 'current',
         },
       }],
       // JSX, Flow

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -20,7 +20,7 @@
     "babel-plugin-transform-react-jsx-source": "6.9.0",
     "babel-plugin-transform-regenerator": "6.16.1",
     "babel-plugin-transform-runtime": "6.15.0",
-    "babel-preset-env": "0.0.6",
+    "babel-preset-env": "0.0.8",
     "babel-preset-latest": "6.16.0",
     "babel-preset-react": "6.16.0",
     "babel-runtime": "6.11.6"


### PR DESCRIPTION
This replaces the hand-rolled node version setup with a new feature that was introduced in `babel-preset-env@v0.0.7`: https://github.com/babel/babel-preset-env/blob/v0.0.7/CHANGELOG.md


Changes between 0.0.6 and 0.0.8 should be backwards compatible.
https://github.com/babel/babel-preset-env/blob/master/CHANGELOG.md