### PR TITLE
Remove unnecessary transform plugins for object spread to work

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -27,15 +27,7 @@ const plugins = [
       regenerator: true,
       // Resolve the Babel runtime relative to the config.
       moduleName: path.dirname(require.resolve('babel-runtime/package'))
-    }],
-    // The following two plugins are currently necessary to get
-    // babel-preset-env to work with rest/spread. More info here:
-    // https://github.com/babel/babel-preset-env#caveats
-    // https://github.com/babel/babel/issues/4074
-    // const { a, ...z } = obj;
-    require.resolve('babel-plugin-transform-es2015-destructuring'),
-    // const fn = ({ a, ...otherProps }) => otherProps;
-    require.resolve('babel-plugin-transform-es2015-parameters')
+    }]
   ];
 
 // This is similar to how `env` works in Babel:

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -12,8 +12,6 @@
   ],
   "dependencies": {
     "babel-plugin-transform-class-properties": "6.16.0",
-    "babel-plugin-transform-es2015-destructuring": "6.16.0",
-    "babel-plugin-transform-es2015-parameters": "6.17.0",
     "babel-plugin-transform-object-rest-spread": "6.19.0",
     "babel-plugin-transform-react-constant-elements": "6.9.1",
     "babel-plugin-transform-react-jsx-self": "6.11.0",

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -14,7 +14,7 @@
     "babel-plugin-transform-class-properties": "6.16.0",
     "babel-plugin-transform-es2015-destructuring": "6.16.0",
     "babel-plugin-transform-es2015-parameters": "6.17.0",
-    "babel-plugin-transform-object-rest-spread": "6.16.0",
+    "babel-plugin-transform-object-rest-spread": "6.19.0",
     "babel-plugin-transform-react-constant-elements": "6.9.1",
     "babel-plugin-transform-react-jsx-self": "6.11.0",
     "babel-plugin-transform-react-jsx-source": "6.9.0",


### PR DESCRIPTION
The `babel-plugin-transform-object-rest-spread ` v6.19.0 update made the other two plugins unnecessary as it contains the fixes done in https://github.com/babel/babel/pull/4755

https://github.com/babel/babel/blob/v6.19.0/CHANGELOG.md

Ref https://github.com/facebookincubator/create-react-app/issues/904#issuecomment-261077538 and #927

## Test plan

### 1. Use `node` v6.7.0

If you use [`nvm`](https://github.com/creationix/nvm), this is how:

```
nvm install v6.7.0
nvm use v6.7.0
```

### 2. (Optional, I think) Use npm v2

```
npm install -g npm@2.x
```

### 3. Modify `App.test.js`

Modify `packages/react-scripts/template/src/App.test.js` to look like this:

```js
import React from 'react';
import ReactDOM from 'react-dom';
import App from './App';

it('renders without crashing', () => {
  const fn = ({ a, ...otherProps }) => otherProps;

  fn({ a: 1, b: 2 });

  console.log(fn({ a: 1, b: 2 }));

  const div = document.createElement('div');
  ReactDOM.render(<App />, div);
});
```

### 4. Install all the packages and run the test script

```
npm install
npm test
```
