### PR TITLE
Add missing dev argument in build script message

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -165,7 +165,7 @@ function build(previousSizeMap) {
       console.log('To publish it at ' + chalk.green(homepagePath) + ', run:');
       console.log();
       if (useYarn) {
-        console.log('  ' + chalk.cyan('yarn') +  ' add gh-pages');
+        console.log('  ' + chalk.cyan('yarn') +  ' add --dev gh-pages');
       } else {
         console.log('  ' + chalk.cyan('npm') +  ' install --save-dev gh-pages');
       }


### PR DESCRIPTION
Add `--dev` argument to the `yarn add gh-pages` message to match the npm one.