### PR TITLE
Enable src/node_modules

### DIFF
--- a/packages/react-scripts/template/gitignore
+++ b/packages/react-scripts/template/gitignore
@@ -1,7 +1,7 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # dependencies
-node_modules
+/node_modules
 
 # testing
 coverage

--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -29,6 +29,9 @@ module.exports = (resolve, rootDir, isEjecting) => {
     testPathIgnorePatterns: ['<rootDir>/(build|docs|node_modules)/'],
     testEnvironment: 'node',
     preprocessorIgnorePatterns: ["<rootDir>/node_modules"],
+    haste: {
+        providesModuleNodeModules: [".*"],
+    },
   };
   if (rootDir) {
     config.rootDir = rootDir;

--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -28,6 +28,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupTestFrameworkScriptFile: setupTestsFile,
     testPathIgnorePatterns: ['<rootDir>/(build|docs|node_modules)/'],
     testEnvironment: 'node',
+    preprocessorIgnorePatterns: ["<rootDir>/node_modules"],
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
**[HOLD]** not particularly useful without changes in Jest 

Partially fixes https://github.com/facebookincubator/create-react-app/issues/607

These are the necessary changes in react-scripts to allow code to live in `src/node_modules` and allow Jest to run tests in that directory.

**However**, Jest cannot find these tests on its own -- all files in _any_ `node_modules` are filtered out even before the file matching patterns are applied. See issue https://github.com/facebook/jest/issues/2145.

Without changes in Jest, there are a few workarounds:

#### Import the package tests into a file that jest _can_ find
```js
// src/node_modules/Foo/Foo.test.js
it("does a thing", ()=> {
  expect(true).toBe(true)
})
```
```js
// src/index.js
import "Foo/Foo.test.js"
```

#### Whitelist the directories you want to test with the `haste.providesModuleNodeModules` option

This is not the intended use for this option, but its used as a whitelist for the haste module  resolution, and therefore Jest can find tests in these directories.

## TODO
- [ ] get related issue in facebook/jest resolved
- [ ] figure out how to test this
- [ ] rebase, clean up etc




