### PR TITLE
resolveApp() is moved to a separate file

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -10,14 +10,8 @@
 // @remove-on-eject-end
 
 var path = require('path');
-var fs = require('fs');
 
-// Make sure any symlinks in the project folder are resolved:
-// https://github.com/facebookincubator/create-react-app/issues/637
-var appDirectory = fs.realpathSync(process.cwd());
-function resolveApp(relativePath) {
-  return path.resolve(appDirectory, relativePath);
-}
+var resolveApp = require('../utils/resolveApp');
 
 // We support resolving modules according to `NODE_PATH`.
 // This lets you use absolute paths in imports inside large monorepos:

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -58,6 +58,7 @@ prompt(
     path.join('config', 'webpack.config.prod.js'),
     path.join('config', 'jest', 'CSSStub.js'),
     path.join('config', 'jest', 'FileStub.js'),
+    path.join('utils', 'resolveApp.js'),
     path.join('scripts', 'build.js'),
     path.join('scripts', 'start.js'),
     path.join('scripts', 'test.js')

--- a/packages/react-scripts/utils/resolveApp.js
+++ b/packages/react-scripts/utils/resolveApp.js
@@ -1,0 +1,13 @@
+var fs = require('fs');
+var path = require('path');
+
+// Make sure any symlinks in the project folder are resolved:
+// https://github.com/facebookincubator/create-react-app/issues/637
+var appDirectory = fs.realpathSync(process.cwd());
+function resolveApp(relativePath, defaultPath) {
+  return relativePath ?
+    path.resolve(appDirectory, relativePath) :
+    defaultPath;
+}
+
+module.exports = resolveApp;


### PR DESCRIPTION
It's just logical. This function may be required anywhere. At this change is based is another feature (#1103), but I thought it was the separate change.