### PR TITLE
Configure Jest to bail on first error

### DIFF
--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -27,6 +27,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupTestFrameworkScriptFile: setupTestsFile,
     testPathIgnorePatterns: ['<rootDir>/(build|docs|node_modules)/'],
     testEnvironment: 'node',
+    bail: true
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
Per default, Jest runs through all tests even if it encounters an error. This might be a sensible default for Jest in general (it's possibly nice in a CI setting) but I find it very annoying when actually developing, because the "PASS" messages obscure the test error in the console (especially if you have a small console window, which you often do when developing):

Failing test in small console window **(current behaviour)**:
![screenshot 2016-11-28 17 43 06](https://cloud.githubusercontent.com/assets/17815/20677328/fe75a83a-b592-11e6-86ed-4bb9cd4febe3.png)

The problem is here that the user has to scroll up to see the error. The problem can be postponed by having a larger terminal, but eventually your test suite will will grow so large that it obscured the entire window no matter how big it is. 

Same test failing **(with this pull request applied)**:
![screenshot 2016-11-28 17 42 05](https://cloud.githubusercontent.com/assets/17815/20677344/0edbef40-b593-11e6-8253-b35cd1eb024f.png)



