### PR TITLE
Add option to disabling clearing of terminal console

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -60,6 +60,12 @@ if (isSmokeTest) {
   };
 }
 
+// Disabling clearing of console
+var isVerbose = process.argv.some(arg => arg.indexOf('--verbose') > -1);
+if (isVerbose) {
+  clearConsole = function() { return; };
+}
+
 function setupCompiler(host, port, protocol) {
   // "Compiler" is a low-level interface to Webpack.
   // It lets us listen to some events and provide our own custom messages.

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -125,6 +125,8 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.<br>
 You will also see any lint errors in the console.
 
+If you don't want the console to be cleared on reload, you can invoke `npm start --verbose`
+
 ### `npm test`
 
 Launches the test runner in the interactive watch mode.<br>


### PR DESCRIPTION
Following the guide for [integrating with a node backend](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#integrating-with-a-node-backend), I found it a bit inconvenient having the `start` script clearing the console every time a file was saved when running everything through `foreman`.

This just adds the option to pass in a `--verbose`(not sure if this is the right flag name) option to the start script that won't clear the console. I've read the contributing guideline, and maybe this should be an option that is enabled by default whenever `proxy` is defined in `package.json`.