### PR TITLE
Add testURL to jest config

### DIFF
--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -27,6 +27,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupTestFrameworkScriptFile: setupTestsFile,
     testPathIgnorePatterns: ['<rootDir>/(build|docs|node_modules)/'],
     testEnvironment: 'node',
+    testURL: 'http://localhost',
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
In my tests, jsdom was throwing a "SecurityError" at HistoryImpl._sharedPushAndReplaceState (node_modules/react-scripts/node_modules/jsdom/lib/jsdom/living/window/History-impl.js:87:15)

This happens because document.URL defaults to "about:blank". Unfortunately, if you interact with the History object it tries and fails to parse the URL, causing a "SecurityError" to be thrown. Setting the default URL to "http://localhost" fixes this issue.