### PR TITLE
add support for installing react-scripts using npm link

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -58,7 +58,8 @@ function resolveOwn(relativePath) {
 // Set up module.exports depending on how react-scripts is run. The current
 // path will contain `packages/react-scripts` when running from create-react-app.
 // We don't make assumptions about the path when this package is installed from
-// another app since it could've be renamed.
+// another app since it could've been renamed.
+
 // Note that when installing this package using `npm link`, the current
 // directory path contains `packages/react-scripts` (instead of, for example,
 // `node_modules/react-scripts`). There is a specific condition to handle this

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -55,19 +55,20 @@ function resolveOwn(relativePath) {
   return path.resolve(__dirname, relativePath);
 }
 
-// We set up module.exports depending on how react-scripts is run. The current
-// directory path will contain `packages/react-scripts` when running from
-// create-react-app, and `node_modules/react-scripts` when installed from
-// another project. Note that when installing this package using `npm link`,
-// the current directory path contains `packages/react-scripts`. There is a
-// specific condition to handle this case so that it doesn't conflict with
-// other scripts (like `build` or  `publish`) or running the smoke test.
-var isRunningFromApp = __dirname.indexOf(path.join('node_modules', 'react-scripts', 'config')) !== -1;
+// Set up module.exports depending on how react-scripts is run. The current
+// path will contain `packages/react-scripts` when running from create-react-app.
+// We don't make assumptions about the path when this package is installed from
+// another app since it could've be renamed.
+// Note that when installing this package using `npm link`, the current
+// directory path contains `packages/react-scripts` (instead of, for example,
+// `node_modules/react-scripts`). There is a specific condition to handle this
+// case so that it doesn't conflict with other scripts (like `build` or
+// `publish`) or running the smoke test.
 var isRunningFromOwn = __dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1;
 var isSmokeTest = process.argv.some(arg => arg.indexOf('--smoke-test') > -1);
 var isRunningFromAppUsingLink = (process.env.npm_lifecycle_event === 'start') && isRunningFromOwn && !isSmokeTest
 
-if (isRunningFromApp || isRunningFromAppUsingLink) {
+if (!isRunningFromOwn || isRunningFromAppUsingLink) {
   module.exports = {
     appBuild: resolveApp('build'),
     appPublic: resolveApp('public'),

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -55,24 +55,34 @@ function resolveOwn(relativePath) {
   return path.resolve(__dirname, relativePath);
 }
 
-// config before eject: we're in ./node_modules/react-scripts/config/
-module.exports = {
-  appBuild: resolveApp('build'),
-  appPublic: resolveApp('public'),
-  appHtml: resolveApp('public/index.html'),
-  appIndexJs: resolveApp('src/index.js'),
-  appPackageJson: resolveApp('package.json'),
-  appSrc: resolveApp('src'),
-  yarnLockFile: resolveApp('yarn.lock'),
-  testsSetup: resolveApp('src/setupTests.js'),
-  appNodeModules: resolveApp('node_modules'),
-  // this is empty with npm3 but node resolution searches higher anyway:
-  ownNodeModules: resolveOwn('../node_modules'),
-  nodePaths: nodePaths
-};
+// We set up module.exports depending on how react-scripts is run. The current
+// directory path will contain `packages/react-scripts` when running from
+// create-react-app, and `node_modules/react-scripts` when installed from
+// another project. Note that when installing this package using `npm link`,
+// the current directory path contains `packages/react-scripts`. There is a
+// specific condition to handle this case so that it doesn't conflict with
+// other scripts (like `build` or  `publish`) or running the smoke test.
+var isRunningFromApp = __dirname.indexOf(path.join('node_modules', 'react-scripts', 'config')) !== -1;
+var isRunningFromOwn = __dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1;
+var isSmokeTest = process.argv.some(arg => arg.indexOf('--smoke-test') > -1);
+var isRunningFromAppUsingLink = (process.env.npm_lifecycle_event === 'start') && isRunningFromOwn && !isSmokeTest
 
-// config before publish: we're in ./packages/react-scripts/config/
-if (__dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1) {
+if (isRunningFromApp || isRunningFromAppUsingLink) {
+  module.exports = {
+    appBuild: resolveApp('build'),
+    appPublic: resolveApp('public'),
+    appHtml: resolveApp('public/index.html'),
+    appIndexJs: resolveApp('src/index.js'),
+    appPackageJson: resolveApp('package.json'),
+    appSrc: resolveApp('src'),
+    yarnLockFile: resolveApp('yarn.lock'),
+    testsSetup: resolveApp('src/setupTests.js'),
+    appNodeModules: resolveApp('node_modules'),
+    // this is empty with npm3 but node resolution searches higher anyway:
+    ownNodeModules: resolveOwn('../node_modules'),
+    nodePaths: nodePaths
+  };
+} else {
   module.exports = {
     appBuild: resolveOwn('../../../build'),
     appPublic: resolveOwn('../template/public'),


### PR DESCRIPTION
When using npm link to depend on a forked version of react-scripts, the paths are set up incorrectly such that the source files in the react-scripts template get used instead of the actual source files from the app.

Repro steps:
1. Create a package using the public version of `create-react-app`.
2. Clone `create-react-app` from GitHub and convert `packages/react-scripts` to a scoped package. For example, change this:
```
  "name": "react-scripts",
  "version": "0.7.0",
```
to this:
```
  "name": "@tabrezm/react-scripts",
  "version": "0.0.0",
```
3. Run `npm link` from `packages/react-scripts`.
3. Run `npm link @tabrezm/react-scripts` from the folder for the package created in step 1. Also, change the following lines in `package.json` from this:
```
  "devDependencies": {
    "react-scripts": "0.7.0"
  },
```
to this
```
  "devDependencies": {
    "@tabrezm/react-scripts": "0.0.0"
  },
```
5. Change something in `App.js` and run `npm start`.

Expected: see new content
Actual: see content from  template in `react-scripts` instead

Full discussion: https://github.com/facebookincubator/create-react-app/issues/682#issuecomment-263500172