### PR TITLE
Allow jasmine environment for files

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -27,6 +27,7 @@ module.exports = {
     browser: true,
     commonjs: true,
     es6: true,
+    jasmine: true,
     jest: true,
     node: true
   },


### PR DESCRIPTION
As Jest is based on Jasmine, so it's possible to use Jasmine globals in tests as well.
For example, want to use `jasmine.objectContaining` and `jasmine.any` declarations in my matchers.

```js
expect(myFunction).toBeCalledWith(
  jasmine.objectContaining({prop: 'that is important for me'}),
  jasmine.any(Function),
  jasmine.any(Object)
);
```

Currently it works, however, I am getting an error in the editor, that `"jasmine" is not defined. (no-undef)`.

According to [this @cpojer's comment](https://github.com/sindresorhus/globals/issues/106#issuecomment-263601494), Jest is going to support different test runners, so its global list should not be extended by Jasmine. Therefore we need to declare Jasmine environment explicitly 