### PR TITLE
Make PUBLIC_URL environment variable available at build time.

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -36,7 +36,7 @@ function ensureSlash(path, needsSlash) {
 // single-page apps that may serve index.html for nested URLs like /todos/42.
 // We can't use a relative path in HTML because we don't want to load something
 // like /todos/42/static/js/bundle.7289d.js. We have to know the root.
-var homepagePath = require(paths.appPackageJson).homepage;
+var homepagePath = process.env.PUBLIC_URL || require(paths.appPackageJson).homepage;
 var homepagePathname = homepagePath ? url.parse(homepagePath).pathname : '/';
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.


### PR DESCRIPTION
Previously PUBLIC_URL was read from package.json homepage entry. Webpack DefinePlugin then processed the PUBLIC_URL to be available at runtime. However setting the environment variable should have precedence over configuration. Currently setting the PUBLIC_URL has no effect. This can be very confusing for a developer. 

Fixed by looking into process.env.PUBLIC_URL before assigning a value from package.json.

Test plan:

``` $ export PUBLIC_URL=testing && npm run build ```

You should immediately see from the output if create-react-app picked it up.