### PR TITLE
Add an explicit root to webpack.resolve so it searchs there first

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -72,6 +72,7 @@ module.exports = {
     publicPath: publicPath
   },
   resolve: {
+    root: paths.ownNodeModules,
     // This allows you to set a fallback for where Webpack should look for modules.
     // We read `NODE_PATH` environment variable in `paths.js` and pass paths here.
     // We use `fallback` instead of `root` because we want `node_modules` to "win"

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -72,6 +72,11 @@ module.exports = {
     publicPath: publicPath
   },
   resolve: {
+    // This ensures that create-react-app's node_modules are first checked before
+    // other module locations (e.g. NODE_PATH). Without this, if NODE_PATH has
+    // the same module, webpack will use it before the dependency specified in our
+    // node modules.
+    // https://github.com/facebookincubator/create-react-app/issues/1023
     root: paths.ownNodeModules,
     // This allows you to set a fallback for where Webpack should look for modules.
     // We read `NODE_PATH` environment variable in `paths.js` and pass paths here.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -80,6 +80,12 @@ module.exports = {
     publicPath: publicPath
   },
   resolve: {
+    // This ensures that create-react-app's node_modules are first checked before
+    // other module locations (e.g. NODE_PATH). Without this, if NODE_PATH has
+    // the same module, webpack will use it before the dependency specified in our
+    // node modules.
+    // https://github.com/facebookincubator/create-react-app/issues/1023
+    root: paths.ownNodeModules,
     // This allows you to set a fallback for where Webpack should look for modules.
     // We read `NODE_PATH` environment variable in `paths.js` and pass paths here.
     // We use `fallback` instead of `root` because we want `node_modules` to "win"


### PR DESCRIPTION
This still needs (a lot) more work before it could be merged, but seems like a promising solution to #1023.