### PR TITLE
Configure which browser to open in npm start (#873)

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -28,7 +28,8 @@ function openBrowser(url) {
   // Fallback to opn
   // (It will always open new tab)
   try {
-    opn(url).catch(() => {}); // Prevent `unhandledRejection` error.
+    var option = {app: process.env.BROWSER};
+    opn(url, option).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {
     return false;


### PR DESCRIPTION
Use a 'BROWSER' environment variable with npm start to specify which
browser to open. if the value of 'BROWSER' is not valid executable file,
don't open any browser. 
