### PR TITLE
Revert Jest moduleNameMapper regex back to a whitelist

### DIFF
--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -20,7 +20,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
   const config = {
     collectCoverageFrom: ['src/**/*.{js,jsx}'],
     moduleNameMapper: {
-      '^.+\\.(?!(js|jsx|css|json)$)[^\\.]+$': resolve('config/jest/FileStub.js'),
+      '^.+\\.(ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': resolve('config/jest/FileStub.js'),
       '^.+\\.css$': resolve('config/jest/CSSStub.js')
     },
     setupFiles: [resolve('config/polyfills.js')],


### PR DESCRIPTION
Jest matches moduleNameMapper regexes with module names, not the full file path, so the negative lookahead doesn’t work for filtering out JS files, because they can be imported without the extension. So paths like `lodash.assign` and `../utils/range` were mislabeled as resources with unknown file extensions because they have a dot in the name.

As a stopgap measure, revert the moduleNameMapper regex added in #1077.

This will fix issues #1145 and #1147. However, since the behaviour will now differ for obscure file extensions not listed in the whitelist, we should try to find a way to support the same behaviour as we have for webpack loaders (map any unknown file type mapped to a stub).