### PR TITLE
Make build fail on ESLint warnings if running CI

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -178,17 +178,17 @@ module.exports = {
       }
     ]
   },
-  // @remove-on-eject-begin
   // Point ESLint to our predefined config.
   eslint: {
+    // @remove-on-eject-begin
     // TODO: consider separate config for production,
     // e.g. to enable no-console and no-debugger only in production.
     configFile: path.join(__dirname, '../.eslintrc'),
     useEslintrc: false,
+    // @remove-on-eject-end
     failOnWarning: !!process.env.CI,
     failOnError: true
   },
-  // @remove-on-eject-end
   // We use PostCSS for autoprefixing only.
   postcss: function() {
     return [

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -184,7 +184,9 @@ module.exports = {
     // TODO: consider separate config for production,
     // e.g. to enable no-console and no-debugger only in production.
     configFile: path.join(__dirname, '../.eslintrc'),
-    useEslintrc: false
+    useEslintrc: false,
+    failOnWarning: !!process.env.CI,
+    failOnError: true
   },
   // @remove-on-eject-end
   // We use PostCSS for autoprefixing only.

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -144,11 +144,6 @@ function build(previousSizeMap) {
       process.exit(1);
     }
 
-    if (process.env.CI && stats.compilation.warnings.length) {
-     printErrors('Failed to compile.', stats.compilation.warnings);
-     process.exit(1);
-   }
-
     console.log(chalk.green('Compiled successfully.'));
     console.log();
 


### PR DESCRIPTION
( Related to previous pull request #944 and issue #1150 that followed. )

This pull request reverts behaviour in `build` script and moves the responsibility to `eslint-loader`.

As a bonus, this change makes the build fail almost immediately compared to previous solution.

cc @excitement-engineer 

