### PR TITLE
Chrome 'open tab' reuse an empty tab when possible

### DIFF
--- a/packages/react-dev-utils/openChrome.applescript
+++ b/packages/react-dev-utils/openChrome.applescript
@@ -25,10 +25,10 @@ on run argv
     -- then return
     set found to my lookupTabWithUrl(theURL)
     if found then
-      tell targetTab to reload
-      set index of targetWindow to 1
       set targetWindow's active tab index to targetTabIndex
+      tell targetTab to reload
       tell targetWindow to activate
+      set index of targetWindow to 1
       return
     end if
 
@@ -37,9 +37,8 @@ on run argv
     -- We try to find an empty tab instead
     set found to my lookupTabWithUrl("chrome://newtab/")
     if found then
-      set URL of targetTab to theURL
-      set index of targetWindow to 1
       set targetWindow's active tab index to targetTabIndex
+      set URL of targetTab to theURL
       tell targetWindow to activate
       return
     end if
@@ -48,8 +47,8 @@ on run argv
     -- both debugging and empty tab were not found
     -- make a new tab with url
     tell window 1
-        activate
-        make new tab with properties {URL:theURL}
+      activate
+      make new tab with properties {URL:theURL}
     end tell
   end tell
 end run

--- a/packages/react-dev-utils/openChrome.applescript
+++ b/packages/react-dev-utils/openChrome.applescript
@@ -34,16 +34,49 @@ on run argv
       end if
     end repeat
 
+    -- Reload debugging tab if found
+    -- then return
     if found then
       tell theTab to reload
       set index of theWindow to 1
       set theWindow's active tab index to theTabIndex
       tell theWindow to activate
+      return
+    end if
+
+    -- In case debugging tab was not found
+    -- We try to find an empty tab instead
+    set foundEmpty to false
+    set theEmptyTabIndex to -1
+    repeat with theWindow in every window
+      set theEmptyTabIndex to 0
+      repeat with theTab in every tab of theWindow
+        set theEmptyTabIndex to theEmptyTabIndex + 1
+        if theTab's URL as string contains "chrome://newtab/" then
+          set foundEmpty to true
+          exit repeat
+        end if
+      end repeat
+
+      if foundEmpty then
+        exit repeat
+      end if
+    end repeat
+
+    -- if empty tab was found
+    if foundEmpty then
+      set URL of theTab to theURL
+      set index of theWindow to 1
+      set theWindow's active tab index to theEmptyTabIndex
+      tell theWindow to activate
     else
+      -- both debugging and empty tab were not found
+      -- make a new tab with url
       tell window 1
         activate
         make new tab with properties {URL:theURL}
       end tell
     end if
+
   end tell
 end run


### PR DESCRIPTION
> ~~Still WIP: need to clean up duplicated code and found some unexpected behavior (both in master and this branch)~~

on `start`script - If there're no debugging tab (localhost:3000) open, we will try to use empty tab instead of create new one. (fixes #1157)

**Test plan**

To invoke script, We can use both `npm/yarn start` or run `osascript openChrome.applescript localhost:3000` inside `/packages/react-dev-utils` folder .

- **No open chrome window**: When chrome open with an empty tab, use the empty tab instead of create new one.
- **Chrome window with debugging tab**: Reuse debugging tab.
- **Chrome window w/o debugging tab**: Create new tab with url.
- **Chrome window w/o debugging tab, but have an empty tab**: Use empty tab. 

```bash
# Setup
npm run create-react-app my-app
cd my-app
yarn start
```

**Test env**

- Browser: Google Chrome Version 54.0.2840.98
- OS: macOS Sierra 10.12.1