### PR TITLE
Fix end-to-end test on Yarn

### DIFF
--- a/tasks/e2e.sh
+++ b/tasks/e2e.sh
@@ -56,7 +56,7 @@ root_path=$PWD
 if [ "$USE_YARN" = "yes" ]
 then
   # Install Yarn so that the test can use it to install packages.
-  npm install -g yarn
+  npm install -g yarn@0.17.10 # TODO: remove version when https://github.com/yarnpkg/yarn/issues/2142 is fixed.
   yarn cache clean
 fi
 


### PR DESCRIPTION
Should fix https://github.com/facebookincubator/create-react-app/issues/1166.
Root cause is https://github.com/yarnpkg/yarn/issues/2142.