### PR TITLE
Add "npm run build silently fails" to Troubleshooting

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -57,7 +57,6 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Troubleshooting](#troubleshooting)
   - [`npm test` hangs on macOS Sierra](#npm-test-hangs-on-macos-sierra)
   - [`npm run build` silently fails](#npm-run-build-silently-fails)
-
 - [Something Missing?](#something-missing)
 
 ## Updating to New Releases

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -55,6 +55,9 @@ You can find the most recent version of this guide [here](https://github.com/fac
   - [S3 and CloudFront](#s3-and-cloudfront)
   - [Surge](#surge)
 - [Troubleshooting](#troubleshooting)
+  - [`npm test` hangs on macOS Sierra](#npm-test-hangs-on-macos-sierra)
+  - [`npm run build` silently fails](#npm-run-build-silently-fails)
+
 - [Something Missing?](#something-missing)
 
 ## Updating to New Releases
@@ -1117,6 +1120,10 @@ You can find [other installation methods](https://facebook.github.io/watchman/do
 If this still doesn't help, try running `launchctl unload -F ~/Library/LaunchAgents/com.github.facebook.watchman.plist`.
 
 There are also reports that *uninstalling* Watchman fixes the issue. So if nothing else helps, remove it from your system and try again.
+
+### `npm run build` silently fails
+
+It is reported that `npm run build` can fail on machines with no swap space, which is common in cloud environments. If [the symptoms are matching](https://github.com/facebookincubator/create-react-app/issues/1133#issuecomment-264612171), consider adding some swap space to the machine you’re building on, or build the project locally.
 
 ## Something Missing?
 


### PR DESCRIPTION
Based on info in https://github.com/facebookincubator/create-react-app/issues/1133#issuecomment-264612171.