### PR TITLE
Add Subresource Integrity support

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -15,6 +15,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var ManifestPlugin = require('webpack-manifest-plugin');
 var InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
+var SubresourceIntegrityPlugin = require('webpack-subresource-integrity');
 var url = require('url');
 var paths = require('./paths');
 var getClientEnvironment = require('./env');
@@ -259,6 +260,10 @@ module.exports = {
     // having to parse `index.html`.
     new ManifestPlugin({
       fileName: 'asset-manifest.json'
+    }),
+    // Generate and inject subresources hashes in the final `index.html`.
+    new SubresourceIntegrityPlugin({
+      hashFuncNames: ['sha256', 'sha384']
     })
   ],
   // Some libraries import Node modules but don't use them in the browser.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -64,7 +64,7 @@
     "webpack": "1.13.2",
     "webpack-dev-server": "1.16.2",
     "webpack-manifest-plugin": "1.1.0",
-    "webpack-subresource-integrity": "^0.7.0",
+    "webpack-subresource-integrity": "0.7.0",
     "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -64,6 +64,7 @@
     "webpack": "1.13.2",
     "webpack-dev-server": "1.16.2",
     "webpack-manifest-plugin": "1.1.0",
+    "webpack-subresource-integrity": "^0.7.0",
     "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request will add to `create-react-app` the ability to inject into the final html page the integrity hashes required to take advantage of [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (when the browser supports it)