### PR TITLE
Fix Babel issues in tests by applying the right transforms

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -23,11 +23,6 @@ const plugins = [
   [require.resolve('babel-plugin-transform-react-jsx'), {
     useBuiltIns: true
   }],
-  // function* () { yield 42; yield 43; }
-  [require.resolve('babel-plugin-transform-regenerator'), {
-    // Async functions are converted to generators by babel-preset-latest
-    async: false
-  }],
   // Polyfills the runtime needed for async/await and generators
   [require.resolve('babel-plugin-transform-runtime'), {
     helpers: false,
@@ -69,13 +64,10 @@ if (env === 'development' || env === 'test') {
 }
 
 if (env === 'test') {
-  // The following plugins are a temporary workaround because
-  // `babel-plugin-transform-regenerator` apparently needs them
-  // and `babel-preset-env` doesn't detect it.
-  // https://github.com/facebookincubator/create-react-app/issues/1156
   plugins.push.apply(plugins, [
-    require.resolve('babel-plugin-transform-es2015-arrow-functions'),
-    require.resolve('babel-plugin-transform-es2015-destructuring'),
+    // We always include this plugin regardless of environment
+    // because of a Babel bug that breaks object rest/spread without it:
+    // https://github.com/babel/babel/issues/4851
     require.resolve('babel-plugin-transform-es2015-parameters')
   ]);
 
@@ -100,7 +92,13 @@ if (env === 'test') {
       // JSX, Flow
       require.resolve('babel-preset-react')
     ],
-    plugins: plugins
+    plugins: plugins.concat([
+      // function* () { yield 42; yield 43; }
+      [require.resolve('babel-plugin-transform-regenerator'), {
+        // Async functions are converted to generators by babel-preset-latest
+        async: false
+      }],
+    ])
   };
 
   if (env === 'production') {

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -12,8 +12,6 @@
   ],
   "dependencies": {
     "babel-plugin-transform-class-properties": "6.16.0",
-    "babel-plugin-transform-es2015-arrow-functions": "6.8.0",
-    "babel-plugin-transform-es2015-destructuring": "6.19.0",
     "babel-plugin-transform-es2015-parameters": "6.18.0",
     "babel-plugin-transform-object-rest-spread": "6.19.0",
     "babel-plugin-transform-react-constant-elements": "6.9.1",


### PR DESCRIPTION
This is a followup to #1177 with a less aggressive fix.
For context, read threads #1156 and #1160.

Why this works:

* Babel has a bug where object/spread depends on parameters transform: https://github.com/babel/babel/issues/4851. So we have to enable parameters.
* Including regenerator transform in `test` environment was incorrect. Its `async: false` option only made sense for `development` and `production` configuration where we use `babel-preset-latest`, and so async functions are already being handled. But for `test` environment we use `babel-preset-env` instead of `babel-preset-latest`, and so including regenerator second time is redundant (and somehow breaks things—@hzoo could you clarify why this happened?)

I am remove `destructuring` and `arrow-functions` because they were added as stopgap measure in #1177 but turned out unnecessary per https://github.com/facebookincubator/create-react-app/issues/1156#issuecomment-265160544.

Fixes #1156 and #1160.