### PR TITLE
Set crossOriginLoading to anonymous in output

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -81,6 +81,10 @@ module.exports = {
     // We don't currently advertise code splitting but Webpack supports it.
     filename: 'static/js/[name].[chunkhash:8].js',
     chunkFilename: 'static/js/[name].[chunkhash:8].chunk.js',
+    // Given Webpack supports codesplit and production bundles are using 
+    // subresource integrity, it's important to make sure the attribute
+    // set on async-loaded chunks is set to anonymous.
+    crossOriginLoading: 'anonymous',
     // We inferred the "public path" (such as / or /my-project) from homepage.
     publicPath: publicPath
   },


### PR DESCRIPTION
@gaearon This is a follow up to #1176 - I discovered a small issue while making intensive tests till I landed here: https://github.com/waysact/webpack-subresource-integrity/issues/20