### PR TITLE
Update Webpack to fix source map issues

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -61,7 +61,7 @@
     "strip-ansi": "3.0.1",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
-    "webpack": "1.13.2",
+    "webpack": "1.14.0",
     "webpack-dev-server": "1.16.2",
     "webpack-manifest-plugin": "1.1.0",
     "webpack-subresource-integrity": "0.7.0",


### PR DESCRIPTION
Should fix #1186.

The fix works because Webpack dependency bumps `webpack-core` which bumps `source-list-map` which includes https://github.com/webpack/source-list-map/pull/2.

That fix was necessary because Babel started adding variable names to source maps in https://github.com/babel/babel/pull/3658 but Webpack didn't add support for this format.