### PR TITLE
Relax peerDependencies for ESLint preset

### DIFF
--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -11,11 +11,11 @@
     "index.js"
   ],
   "peerDependencies": {
-    "babel-eslint": "7.0.0",
-    "eslint": "3.8.1",
-    "eslint-plugin-flowtype": "2.21.0",
-    "eslint-plugin-import": "2.0.1",
-    "eslint-plugin-jsx-a11y": "2.2.3",
-    "eslint-plugin-react": "6.4.1"
+    "babel-eslint": "^7.0.0",
+    "eslint": "^3.8.1",
+    "eslint-plugin-flowtype": "^2.21.0",
+    "eslint-plugin-import": "^2.0.1",
+    "eslint-plugin-jsx-a11y": "^2.2.3",
+    "eslint-plugin-react": "^6.4.1"
   }
 }


### PR DESCRIPTION
Fixes #1110.
We still pin them in `react-scripts` itself but this should help people using the preset directly.