### PR TITLE
Only honor relative NODE_PATH

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -30,9 +30,14 @@ function resolveApp(relativePath) {
 // It will then be used by Webpack configs.
 // Jest doesn’t need this because it already handles `NODE_PATH` out of the box.
 
+// Note that unlike in Node, only *relative* paths from `NODE_PATH` are honored.
+// Otherwise, we risk importing Node.js core modules into an app instead of Webpack shims.
+// https://github.com/facebookincubator/create-react-app/issues/1023#issuecomment-265344421
+
 var nodePaths = (process.env.NODE_PATH || '')
   .split(process.platform === 'win32' ? ';' : ':')
   .filter(Boolean)
+  .filter(folder => !path.isAbsolute(folder))
   .map(resolveApp);
 
 // config after eject: we're in ./config/


### PR DESCRIPTION
We used to honor `NODE_PATH` because it provides a relatively convenient way to allow absolute imports for people who need them: `NODE_PATH=src npm start`.

However this backfired with #1023 and #815.
The best analysis is in https://github.com/facebookincubator/create-react-app/issues/1023#issuecomment-265344421.

Sometimes, a module (which may be inside a dependency) may depend on Node core modules like `events`. In this case Webpack attempts to shim it with [node-libs-browser](https://github.com/webpack/node-libs-browser). However it only attempts to shim it if it can't resolve the module name using the regular mechanism. The problem is that [some Linux distributions include Node sources into `NODE_PATH`](https://github.com/facebookincubator/create-react-app/issues/1023#issuecomment-264064040). Therefore, since we honor `NODE_PATH`, Webpack finds `events` in Node.js sources on those systems, and thus doesn't attempt to shim it. As a result you get the latest version from Node.js itself which is likely incompatible with the browsers.

To fix this, we need a way to *not* allow Node.js core modules to resolve to Node.js sources even if they exist in `NODE_PATH`. I don't see any easy way to do this. However we can sidestep the issue by **not respecting absolute paths in `NODE_PATH`**. The only reason we added `NODE_PATH` support is for absolute imports (`NODE_PATH=src npm start`), where `NODE_PATH` itself is relative. Any other uses of it are inherently dangerous (and won't work across systems anyway). So I think it should be safe to just stop honoring absolute `NODE_PATH` altogether, thus solving both issues.

It is technically a breaking change but for a use case we never intended to support. I have a hard time believing anyone could've intentionally relied on this, and if it breaks anyone, it will more likely uncover a bug. Therefore I think this is safe to go in 0.8.x, especially given that it fixes more egregious bugs that have been affecting people for months, and 0.8 has been out for just four days.