### PR TITLE
Instruct Jest to load native components from RNW instead of RN

### DIFF
--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -38,6 +38,9 @@ module.exports = (resolve, rootDir, isEjecting) => {
     transformIgnorePatterns: [
       '[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'
     ],
+    moduleNameMapper: {
+      '^react-native$': 'react-native-web'
+    }
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
This small change fixes #1085. Basically it includes @gaearon's suggested fix.