### PR TITLE
Track and compile tests in webpack

### DIFF
--- a/packages/react-dev-utils/WatchTestFilesPlugin.js
+++ b/packages/react-dev-utils/WatchTestFilesPlugin.js
@@ -18,7 +18,8 @@ function getGlobs(patterns, cwd) {
   return Promise.all(patterns.map(globPattern =>
     computeGlob(globPattern, {
       cwd: cwd,
-      ignore: 'node_modules/**',
+      ignore: 'node_modules/**/*',
+      nodir: true,
     })
   ))
   .then(globLists => [].concat.apply([], globLists))

--- a/packages/react-dev-utils/WatchTestFilesPlugin.js
+++ b/packages/react-dev-utils/WatchTestFilesPlugin.js
@@ -1,0 +1,39 @@
+var glob = require('glob');
+var path = require('path');
+
+function computeGlob(pattern, options) {
+  return new Promise((resolve, reject) => {
+    glob(pattern, options || {}, (err, matches) => {
+      if (err) {
+        return reject(err);
+      }
+      resolve(matches);
+    });
+  });
+}
+
+function WatchTestFilesPlugin(testGlobs) {
+  this.testGlobs = testGlobs || [];
+}
+
+WatchTestFilesPlugin.prototype.apply = function(compiler) {
+  compiler.plugin('emit', (compilation, callback) => {
+    console.log()
+    Promise.all(this.testGlobs.map(globPattern =>
+      computeGlob(globPattern, {
+        cwd: compiler.options.context,
+        ignore: 'node_modules/**',
+      })
+    ))
+    .then(globLists => [].concat.apply([], globLists))
+    .then(testFiles => {
+      testFiles.forEach(testFile => {
+        compilation.fileDependencies.push(path.join(compiler.options.context, testFile));
+      });
+    })
+    .then(callback)
+    .catch(console.error);
+  });
+};
+
+module.exports = WatchTestFilesPlugin;

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -32,5 +32,11 @@
     "opn": "4.0.2",
     "sockjs-client": "1.0.3",
     "strip-ansi": "3.0.1"
+  },
+  "devDependencies": {
+    "webpack": "1.14.0"
+  },
+  "peerDependencies": {
+    "webpack": "1.14.0"
   }
 }

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -20,12 +20,14 @@
     "openBrowser.js",
     "prompt.js",
     "WatchMissingNodeModulesPlugin.js",
+    "WatchTestFilesPlugin.js",
     "webpackHotDevClient.js"
   ],
   "dependencies": {
     "ansi-html": "0.0.5",
     "chalk": "1.1.3",
     "escape-string-regexp": "1.0.5",
+    "glob": "^7.1.1",
     "html-entities": "1.2.0",
     "opn": "4.0.2",
     "sockjs-client": "1.0.3",

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -232,8 +232,9 @@ module.exports = {
     // This plugin makes webpack aware of them without emitting them.
     // See https://github.com/facebookincubator/create-react-app/issues/1169
     new WatchTestFilesPlugin([
-      'src/**/__tests__/**',
-      'src/**/*.test.js',
+      'src/**/__tests__/**/*',
+      'src/**/*.test.*',
+      '__tests__/**/*',
     ]),
   ],
   // Some libraries import Node modules but don't use them in the browser.

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -15,6 +15,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 var InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 var WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
+var WatchTestFilesPlugin = require('react-dev-utils/WatchTestFilesPlugin');
 var getClientEnvironment = require('./env');
 var paths = require('./paths');
 
@@ -226,7 +227,14 @@ module.exports = {
     // to restart the development server for Webpack to discover it. This plugin
     // makes the discovery automatic so you don't have to restart.
     // See https://github.com/facebookincubator/create-react-app/issues/186
-    new WatchMissingNodeModulesPlugin(paths.appNodeModules)
+    new WatchMissingNodeModulesPlugin(paths.appNodeModules),
+    // Tests won't have any linting unless they go through webpack.
+    // This plugin makes webpack aware of them without emitting them.
+    // See https://github.com/facebookincubator/create-react-app/issues/1169
+    new WatchTestFilesPlugin([
+      '**/__tests__/**',
+      '**/*.test.js',
+    ]),
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -232,8 +232,8 @@ module.exports = {
     // This plugin makes webpack aware of them without emitting them.
     // See https://github.com/facebookincubator/create-react-app/issues/1169
     new WatchTestFilesPlugin([
-      '**/__tests__/**',
-      '**/*.test.js',
+      'src/**/__tests__/**',
+      'src/**/*.test.js',
     ]),
   ],
   // Some libraries import Node modules but don't use them in the browser.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -16,6 +16,7 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var ManifestPlugin = require('webpack-manifest-plugin');
 var InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 var SubresourceIntegrityPlugin = require('webpack-subresource-integrity');
+var WatchTestFilesPlugin = require('react-dev-utils/WatchTestFilesPlugin');
 var url = require('url');
 var paths = require('./paths');
 var getClientEnvironment = require('./env');
@@ -277,7 +278,14 @@ module.exports = {
     // Generate and inject subresources hashes in the final `index.html`.
     new SubresourceIntegrityPlugin({
       hashFuncNames: ['sha256', 'sha384']
-    })
+    }),
+    // Tests won't have any linting unless they go through webpack.
+    // This plugin makes webpack aware of them without emitting them.
+    // See https://github.com/facebookincubator/create-react-app/issues/1169
+    new WatchTestFilesPlugin([
+      'src/**/__tests__/**',
+      'src/**/*.test.js',
+    ])
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -283,8 +283,9 @@ module.exports = {
     // This plugin makes webpack aware of them without emitting them.
     // See https://github.com/facebookincubator/create-react-app/issues/1169
     new WatchTestFilesPlugin([
-      'src/**/__tests__/**',
-      'src/**/*.test.js',
+      'src/**/__tests__/**/*',
+      'src/**/*.test.*',
+      '__tests__/**/*',
     ])
   ],
   // Some libraries import Node modules but don't use them in the browser.


### PR DESCRIPTION
Should fix #1169.

<img width="970" alt="1__yarn_start__node_" src="https://cloud.githubusercontent.com/assets/246520/21020536/33f4d56e-bd75-11e6-8ad1-1b3ab5a63c57.png">

<img width="859" alt="react_app" src="https://cloud.githubusercontent.com/assets/246520/21021228/da5fa1f2-bd77-11e6-904f-6002301f2fc8.png">


## Why would I do that?

Right now CRA checks lint (and soon flow) errors through a webpack compilation process (for example, eslint checks are based on a loader). The issue with this is, this will not check non-imported files in the main app such as tests.

## How does this PR solves the problem?

This PR adds files matching a certain "glob" pattern (representing the tests) to the list of watched webpack files as well as triggering an independent child compilation (like [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin) does) for those files that will open and process the contents of the files through the available loaders (including eslint) to output them in a tmp dir.

## Shouldn't we add this to the `test` script?

Doing so would require to add a new way to run eslint on top of the jest watcher. I don't even know if that's possible, however webpack plugins are perfect for this kind of thing!
