### PR TITLE
Use a better clear console sequence

### DIFF
--- a/packages/react-dev-utils/clearConsole.js
+++ b/packages/react-dev-utils/clearConsole.js
@@ -7,12 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-var isFirstClear = true;
 function clearConsole() {
-  // On first run, clear completely so it doesn't show half screen on Windows.
-  // On next runs, use a different sequence that properly scrolls back.
-  process.stdout.write(isFirstClear ? '\x1bc' : '\x1b[2J\x1b[0f');
-  isFirstClear = false;
+  process.stdout.write(process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H');
 }
 
 module.exports = clearConsole;


### PR DESCRIPTION
Found this in https://github.com/facebook/jest/pull/2230.

I tried many different options before but this one seems to work most consistently and removes the annoying scrollback both on OS X and Windows.