### PR TITLE
Proxy rewrites Origin header to match the target server URL

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -201,6 +201,11 @@ function addMiddleware(devServer) {
     var hpm = httpProxyMiddleware(pathname => mayProxy.test(pathname), {
       target: proxy,
       logLevel: 'silent',
+      onProxyReq: function(proxyReq, req, res) {
+        if (proxyReq.getHeader('origin')) {
+          proxyReq.setHeader('origin', proxy);
+        }
+      },
       onError: onProxyError(proxy),
       secure: false,
       changeOrigin: true,

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -202,6 +202,9 @@ function addMiddleware(devServer) {
       target: proxy,
       logLevel: 'silent',
       onProxyReq: function(proxyReq, req, res) {
+        // Browers may send Origin headers even with same-origin
+        // requests. To prevent CORS issues, we have to change
+        // the Origin to match the target URL.
         if (proxyReq.getHeader('origin')) {
           proxyReq.setHeader('origin', proxy);
         }


### PR DESCRIPTION
The new proxy option introduced in #282 works well for GET requests but many browsers send Origin headers with same-origin POST/PUT/DELETE requests.

This pull request makes the http-proxy-middleware to overwrite the original Origin header (if set) to match the target server URL.