### PR TITLE
Bump babel-eslint version

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "autoprefixer": "6.5.1",
     "babel-core": "6.17.0",
-    "babel-eslint": "7.0.0",
+    "babel-eslint": "7.1.1",
     "babel-jest": "17.0.2",
     "babel-loader": "6.2.7",
     "babel-preset-react-app": "^2.0.1",


### PR DESCRIPTION
Codeframin':

![image](https://cloud.githubusercontent.com/assets/56288/21034485/c8f46794-bd7d-11e6-8d1f-425d3285554f.png)

Fixes #1206