### PR TITLE
Fix - openChrome won't open default browser (using Canary)

### DIFF
--- a/packages/react-dev-utils/openChrome.applescript
+++ b/packages/react-dev-utils/openChrome.applescript
@@ -14,7 +14,7 @@ property targetWindow: null
 on run argv
   set theURL to item 1 of argv
 
-  tell application "Google Chrome"
+  tell application "Chrome"
 
     if (count every window) = 0 then
       make new window
@@ -58,7 +58,7 @@ end run
 -- if found, store tab, index, and window in properties
 -- (properties were declared on top of file)
 on lookupTabWithUrl(lookupUrl)
-  tell application "Google Chrome"
+  tell application "Chrome"
     -- Find a tab with the given url
     set found to false
     set theTabIndex to -1


### PR DESCRIPTION
fixes #1213

I accidentally changed "Chrome" to "Google Chrome" in #1165. It forces to open Chrome Stable instead of default browser in system-wide (eg. Chrome Canary).

- Use “Chrome” instead of "Google Chrome", It will try to use current active browser. otherwise, use default.
- If no “Chrome” aren’t running, will fallback to opn(url)