### PR TITLE
Disable gh-page setup instruction if scripts.deploy has been added

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -158,7 +158,8 @@ function build(previousSizeMap) {
     console.log();
 
     var openCommand = process.platform === 'win32' ? 'start' : 'open';
-    var homepagePath = require(paths.appPackageJson).homepage;
+    var appPackage  = require(paths.appPackageJson);
+    var homepagePath = appPackage.homepage;
     var publicPath = config.output.publicPath;
     if (homepagePath && homepagePath.indexOf('.github.io/') !== -1) {
       // "homepage": "http://user.github.io/project"
@@ -167,22 +168,25 @@ function build(previousSizeMap) {
       console.log();
       console.log('The ' + chalk.cyan('build') + ' folder is ready to be deployed.');
       console.log('To publish it at ' + chalk.green(homepagePath) + ', run:');
-      console.log();
-      if (useYarn) {
-        console.log('  ' + chalk.cyan('yarn') +  ' add --dev gh-pages');
-      } else {
-        console.log('  ' + chalk.cyan('npm') +  ' install --save-dev gh-pages');
+      // If script deploy has been added to package.json, skip the instructions
+      if (typeof appPackage.scripts.deploy === 'undefined') {
+        console.log();
+        if (useYarn) {
+          console.log('  ' + chalk.cyan('yarn') +  ' add --dev gh-pages');
+        } else {
+          console.log('  ' + chalk.cyan('npm') +  ' install --save-dev gh-pages');
+        }
+        console.log();
+        console.log('Add the following script in your ' + chalk.cyan('package.json') + '.');
+        console.log();
+        console.log('    ' + chalk.dim('// ...'));
+        console.log('    ' + chalk.yellow('"scripts"') + ': {');
+        console.log('      ' + chalk.dim('// ...'));
+        console.log('      ' + chalk.yellow('"deploy"') + ': ' + chalk.yellow('"npm run build&&gh-pages -d build"'));
+        console.log('    }');
+        console.log();
+        console.log('Then run:');
       }
-      console.log();
-      console.log('Add the following script in your ' + chalk.cyan('package.json') + '.');
-      console.log();
-      console.log('    ' + chalk.dim('// ...'));
-      console.log('    ' + chalk.yellow('"scripts"') + ': {');
-      console.log('      ' + chalk.dim('// ...'));
-      console.log('      ' + chalk.yellow('"deploy"') + ': ' + chalk.yellow('"npm run build&&gh-pages -d build"'));
-      console.log('    }');
-      console.log();
-      console.log('Then run:');
       console.log();
       console.log('  ' + chalk.cyan(useYarn ? 'yarn' : 'npm') +  ' run deploy');
       console.log();


### PR DESCRIPTION
resolve #1221 

Disable github page setup instruction if `scripts.deploy` has been added to `package.json`


**No deploy script**
```bash
> yarn run build
The build folder is ready to be deployed.
To publish it at http://myname.github.io/myapp, run:

  yarn add --dev gh-pages

Add the following script in your package.json.

    // ...
    "scripts": {
      // ...
      "deploy": "npm run build&&gh-pages -d build"
    }

Then run:

  yarn run deploy

✨  Done in 7.45s.
```

**after added deploy**

```bash
The project was built assuming it is hosted at /myapp/.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
To publish it at http://myname.github.io/myapp, run:

  yarn run deploy

✨  Done in 7.08s.
```