### PR TITLE
Exit with an error code when npm/yarn install fails

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -157,10 +157,10 @@ function run(root, appName, version, verbose, originalDirectory) {
   var packageToInstall = getInstallPackage(version);
   var packageName = getPackageName(packageToInstall);
 
-  install(packageToInstall, verbose, function (code, command, args) {
+  install(packageToInstall, verbose, function(code, command, args) {
     if (code !== 0) {
       console.error('`' + command + ' ' + args.join(' ') + '` failed');
-      return;
+      process.exit(1);
     }
 
     checkNodeVersion(packageName);


### PR DESCRIPTION
Previously create-react-app exited with 0 after an installation error.