### PR TITLE
Fix weird lint output 

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -24,12 +24,6 @@ function isLikelyASyntaxError(message) {
 function formatMessage(message) {
   var lines = message.split('\n');
 
-  // line #0 is filename
-  // line #1 is the main error message
-  if (!lines[0] || !lines[1]) {
-    return message;
-  }
-
   // Remove webpack-specific loader notation from filename.
   // Before:
   // ./~/css-loader!./~/postcss-loader!./src/App.css
@@ -37,6 +31,12 @@ function formatMessage(message) {
   // ./src/App.css
   if (lines[0].lastIndexOf('!') !== -1) {
     lines[0] = lines[0].substr(lines[0].lastIndexOf('!') + 1);
+  }
+
+  // line #0 is filename
+  // line #1 is the main error message
+  if (!lines[0] || !lines[1]) {
+    return lines.join('\n');
   }
 
   // Cleans up verbose "module not found" messages for files and packages.


### PR DESCRIPTION
fixes #1218 

Since I can't reproduce it by myself, I use https://github.com/dtinth/pixelpaint to reproduce and verify. 

**Result**

```
Compiled with warnings.

Warning in ./src/App.js

/Users/n3tr/Code/js/pixelpaint/src/App.js
  45:49  warning  Unexpected mix of '&&' and '||'  no-mixed-operators
  46:44  warning  Unexpected mix of '&&' and '||'  no-mixed-operators

✖ 2 problems (0 errors, 2 warnings)


Warning in ./src/ReduxCanvasV3.js

/Users/n3tr/Code/js/pixelpaint/src/ReduxCanvasV3.js
  25:5  warning  Expected a default case  default-case

✖ 1 problem (0 errors, 1 warning)


You may use special comments to disable some warnings.
Use // eslint-disable-next-line to ignore the next line.
Use /* eslint-disable */ to ignore all warnings in a file.
```


