### PR TITLE
Disable jest watch mode when --coverage flag is present [#1207]

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -21,8 +21,8 @@ require('dotenv').config({silent: true});
 const jest = require('jest');
 const argv = process.argv.slice(2);
 
-// Watch unless on CI
-if (!process.env.CI) {
+// Watch unless on CI or in coverage mode
+if (!process.env.CI && argv.indexOf('--coverage') < 0) {
   argv.push('--watch');
 }
 


### PR DESCRIPTION
This PR adds the enhancement described in #1207.

I just added this condition to the addition of the '--watch' flag in the test script. I tested this on my computer and it seems to do the trick, i'm guessing the rest is handled by Jest (make all the tests run when not in watch mode, versus only run tests modified since last commit when watch mode is active).

If there's something I forgot, please let me know.

Also I ran the tasks/e2e.sh script, and it hangs on line 181
```npm run test -- --watch=no``` because it does, in fact, run in watch mode. You have to press 'q' for the script to continue. Is this normal or a regression I introduced ? This seems to be true even on master...

Finally, is there something to add to test the new behavior?