### PR TITLE
Disable subresource integrity temporarily

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -15,7 +15,6 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var ManifestPlugin = require('webpack-manifest-plugin');
 var InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
-var SubresourceIntegrityPlugin = require('webpack-subresource-integrity');
 var url = require('url');
 var paths = require('./paths');
 var getClientEnvironment = require('./env');
@@ -81,10 +80,6 @@ module.exports = {
     // We don't currently advertise code splitting but Webpack supports it.
     filename: 'static/js/[name].[chunkhash:8].js',
     chunkFilename: 'static/js/[name].[chunkhash:8].chunk.js',
-    // Given Webpack supports codesplit and production bundles are using 
-    // subresource integrity, it's important to make sure the attribute
-    // set on async-loaded chunks is set to anonymous.
-    crossOriginLoading: 'anonymous',
     // We inferred the "public path" (such as / or /my-project) from homepage.
     publicPath: publicPath
   },
@@ -273,10 +268,6 @@ module.exports = {
     // having to parse `index.html`.
     new ManifestPlugin({
       fileName: 'asset-manifest.json'
-    }),
-    // Generate and inject subresources hashes in the final `index.html`.
-    new SubresourceIntegrityPlugin({
-      hashFuncNames: ['sha256', 'sha384']
     })
   ],
   // Some libraries import Node modules but don't use them in the browser.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -64,7 +64,6 @@
     "webpack": "1.14.0",
     "webpack-dev-server": "1.16.2",
     "webpack-manifest-plugin": "1.1.0",
-    "webpack-subresource-integrity": "0.8.1",
     "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -60,7 +60,6 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Troubleshooting](#troubleshooting)
   - [`npm test` hangs on macOS Sierra](#npm-test-hangs-on-macos-sierra)
   - [`npm run build` silently fails](#npm-run-build-silently-fails)
-  - [Subresource integrity checks fail](#subresource-integrity-checks-fail)
 - [Something Missing?](#something-missing)
 
 ## Updating to New Releases
@@ -1239,17 +1238,6 @@ There are also reports that *uninstalling* Watchman fixes the issue. So if nothi
 ### `npm run build` silently fails
 
 It is reported that `npm run build` can fail on machines with no swap space, which is common in cloud environments. If [the symptoms are matching](https://github.com/facebookincubator/create-react-app/issues/1133#issuecomment-264612171), consider adding some swap space to the machine you’re building on, or build the project locally.
-
-### Subresource integrity checks fail
-
-[Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) digests are added to the build output files. For a particular scenario, these checks may fail when deployed. The files are built using `LF` characters, but if your deployment uses a Git repository for deployment (like Azure web sites) and the Git repository is set up to translate `LF` characters into `CR/LF` characters, then the checked out files will be different and the digests will be invalid.
-
-To fix this, just add a `.gitattributes` file to your deployment repository that will ensure the build files are not modified when checked out:
-
-```
-*.css text eol=lf
-*.js text eol=lf
-```
 
 ## Something Missing?
 


### PR DESCRIPTION
We need to disable subresource integrity for now due to discussion in https://github.com/facebookincubator/create-react-app/issues/1231.

SRI causes problems for users who don't serve their apps over HTTPS, and we need to disable this until we incorporate a work-around or make the behavior opt-in.