### PR TITLE
Clear scrollback in test mode

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -26,6 +26,18 @@ if (!process.env.CI && argv.indexOf('--coverage') < 0) {
   argv.push('--watch');
 }
 
+// A temporary hack to clear terminal correctly.
+// You can remove this after updating to Jest 18 when it's out.
+// https://github.com/facebook/jest/pull/2230
+var realWrite = process.stdout.write;
+var CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
+process.stdout.write = function(chunk, encoding, callback) {
+  if (chunk === '\x1B[2J\x1B[H') {
+    chunk = CLEAR;
+  }
+  return realWrite.call(this, chunk, encoding, callback);
+};
+
 // @remove-on-eject-begin
 // This is not necessary after eject because we embed config into package.json.
 const createJestConfig = require('../utils/createJestConfig');


### PR DESCRIPTION
Jest will release https://github.com/facebook/jest/pull/2230 in Jest 18 but I’d like to fix this asap so I’m monkeypatching this. We’ll remove it when Jest 18 is out and stable.