### PR TITLE
Don't assume window is defined when polyfilling Promise

### DIFF
--- a/packages/react-scripts/config/polyfills.js
+++ b/packages/react-scripts/config/polyfills.js
@@ -14,7 +14,7 @@ if (typeof Promise === 'undefined') {
   // inconsistent state due to an error, but it gets swallowed by a Promise,
   // and the user has no idea what causes React's erratic future behavior.
   require('promise/lib/rejection-tracking').enable();
-  window.Promise = require('promise/lib/es6-extensions.js');
+  (typeof window !== 'undefined' ? window : global).Promise = require('promise/lib/es6-extensions.js');
 }
 
 // fetch() polyfill for making API calls.


### PR DESCRIPTION
I know server-rendering isn't supported, but I was tinkering with loading the production bundle in Nashorn, Java 8's JavaScript engine, and found that the `Promise` polyfill assumes that `window` exists. This PR changes the polyfill to attempt to use `window` first, and `global` secondly.

For the interested reader, `global` isn't defined in Nashorn either, but it can be easily defined in order to bring it in-line with Node.

Testing steps:

    npm run create-react-app mytestapp
    cd mytestapp
    npm start
    # App starts OK and renders in the browser
    
    npm run build
    # App builds successfully.

    # Also need to change generated src/index.js to only mount React if document is defined
    vim src/index.js
    # Start Nashorn interpreter
    jjs
    > var global = {}
    > load('build/static/js/main.26610bf4.js')
    # File load without throwing an exception