### PR TITLE
Only gitignore dirs in root, not deep

### DIFF
--- a/packages/react-scripts/template/gitignore
+++ b/packages/react-scripts/template/gitignore
@@ -1,13 +1,13 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # dependencies
-node_modules
+/node_modules
 
 # testing
-coverage
+/coverage
 
 # production
-build
+/build
 
 # misc
 .DS_Store


### PR DESCRIPTION
hehe I spent far too long trying to figure out why my build would only work on my computer but not in CI, it was because we had a directory in src literally named `build` that silently not being included in source control (and some red herring errors mislead me into not realizing why). The current generated gitignore excludes all directories named `build | coverage | node_modules`, even ones that aren't in the root.

This changes it to only exclude those which I imagine was intended, only those in the root.