### PR TITLE
Downgrading to compatible version of SockJS-Client

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -28,7 +28,7 @@
     "escape-string-regexp": "1.0.5",
     "html-entities": "1.2.0",
     "opn": "4.0.2",
-    "sockjs-client": "1.0.3",
+    "sockjs-client": "1.0.1",
     "strip-ansi": "3.0.1"
   }
 }


### PR DESCRIPTION
As discussed on #1268 there are two incompatible versions of SockJS-Client being used which prevents hot reloads when websocket connections are unavailable (e.g. when a browser doesn't support websockets, or when a CRA app is being proxied by a server that doesn't support them -- the later being my use case).

Normally SockJS can recover from this because it can use AJAX etc., but with two different versions of SockJS-Client it gives up, and throws this error:

    Incompatibile SockJS! Main site uses: "1.0.3", the iframe: "1.0.1"

Specifically SockJS-Client 1.0.3 ([`packages/react-dev-tools/package.json`](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-dev-utils/package.json#L31) is incompatible with SockJS-Client 1.0.1 (`react-scripts@0.8.4` depends on [`webpack-dev-server@1.16.2`](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/package.json#L65) which depends on [`sockjs@^0.3.15`](https://github.com/webpack/webpack-dev-server/blob/v1.16.2/package.json#L16) which installs `sockjs@0.3.18` that [defaults to a CDN version of 1.0.1](https://github.com/sockjs/sockjs-node/blob/v0.3.18/src/sockjs.coffee#L146)).

It seems [this bug was solved properly in webpack-dev-server@2.1.0-beta.5 and later](https://github.com/webpack/webpack-dev-server/commit/bd976f217324bf6561010fa6c417271782b85c47) but afaik that's not yet released.

This PR is just a quick one-liner fix that reverts to 1.0.1 in the meantime.