### PR TITLE
Correctly Command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ npm install -g create-react-app
 
 create-react-app my-app
 cd my-app/
-yarn start
-
+npm start
 ```
 
 Then open [http://localhost:3000/](http://localhost:3000/) to see your app.<br>
@@ -70,7 +69,7 @@ my-app/
 No configuration or complicated folder structures, just the files you need to build your app.<br>
 Once the installation is done, you can run some commands inside the project folder:
 
-### `yarn start`
+### `npm start` or `yarn start`
 
 Runs the app in development mode.<br>
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
@@ -80,14 +79,14 @@ You will see the build errors and lint warnings in the console.
 
 <img src='https://camo.githubusercontent.com/41678b3254cf583d3186c365528553c7ada53c6e/687474703a2f2f692e696d6775722e636f6d2f466e4c566677362e706e67' width='600' alt='Build errors'>
 
-### `yarn test`
+### `npm test` or `yarn test`
 
 Runs the test watcher in an interactive mode.  
 By default, runs tests related to files changes since the last commit.
 
 [Read more about testing.](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)
 
-### `yarn build`
+### `npm run build` or `yarn build`
 
 Builds the app for production to the `build` folder.<br>
 It correctly bundles React in production mode and optimizes the build for the best performance.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install -g create-react-app
 
 create-react-app my-app
 cd my-app/
-npm start
+yarn start
 
 ```
 
@@ -70,7 +70,7 @@ my-app/
 No configuration or complicated folder structures, just the files you need to build your app.<br>
 Once the installation is done, you can run some commands inside the project folder:
 
-### `npm start`
+### `yarn start`
 
 Runs the app in development mode.<br>
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
@@ -80,14 +80,14 @@ You will see the build errors and lint warnings in the console.
 
 <img src='https://camo.githubusercontent.com/41678b3254cf583d3186c365528553c7ada53c6e/687474703a2f2f692e696d6775722e636f6d2f466e4c566677362e706e67' width='600' alt='Build errors'>
 
-### `npm test`
+### `yarn test`
 
 Runs the test watcher in an interactive mode.  
 By default, runs tests related to files changes since the last commit.
 
 [Read more about testing.](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)
 
-### `npm run build`
+### `yarn build`
 
 Builds the app for production to the `build` folder.<br>
 It correctly bundles React in production mode and optimizes the build for the best performance.


### PR DESCRIPTION
In the first time, I use create-react-app the instruction tell me to use yarn command. I saw the command README.md still use npm command. I already change it to yarn command.