### PR TITLE
Remove path-exists from dependencies and replace it with fs.existsSync

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -53,7 +53,6 @@
     "jest": "17.0.2",
     "json-loader": "0.5.4",
     "object-assign": "4.1.0",
-    "path-exists": "2.1.0",
     "postcss-loader": "1.0.0",
     "promise": "7.1.1",
     "react-dev-utils": "^0.4.2",

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -21,7 +21,6 @@ require('dotenv').config({silent: true});
 var chalk = require('chalk');
 var fs = require('fs-extra');
 var path = require('path');
-var pathExists = require('path-exists');
 var filesize = require('filesize');
 var gzipSize = require('gzip-size').sync;
 var webpack = require('webpack');
@@ -31,7 +30,7 @@ var checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
 var recursive = require('recursive-readdir');
 var stripAnsi = require('strip-ansi');
 
-var useYarn = pathExists.sync(paths.yarnLockFile);
+var useYarn = fs.existsSync(paths.yarnLockFile);
 
 // Warn and crash if required files are missing
 if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -10,7 +10,6 @@
 var createJestConfig = require('../utils/createJestConfig');
 var fs = require('fs-extra');
 var path = require('path');
-var pathExists = require('path-exists');
 var paths = require('../config/paths');
 var prompt = require('react-dev-utils/prompt');
 var spawnSync = require('cross-spawn').sync;
@@ -144,7 +143,7 @@ prompt(
   );
   console.log();
 
-  if (pathExists.sync(paths.yarnLockFile)) {
+  if (fs.existsSync(paths.yarnLockFile)) {
     console.log(cyan('Running yarn...'));
     fs.removeSync(ownPath);
     spawnSync('yarn', [], {stdio: 'inherit'});

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -10,14 +10,13 @@
 var fs = require('fs-extra');
 var path = require('path');
 var spawn = require('cross-spawn');
-var pathExists = require('path-exists');
 var chalk = require('chalk');
 
 module.exports = function(appPath, appName, verbose, originalDirectory) {
   var ownPackageName = require(path.join(__dirname, '..', 'package.json')).name;
   var ownPath = path.join(appPath, 'node_modules', ownPackageName);
   var appPackage = require(path.join(appPath, 'package.json'));
-  var useYarn = pathExists.sync(path.join(appPath, 'yarn.lock'));
+  var useYarn = fs.existsSync(path.join(appPath, 'yarn.lock'));
 
   // Copy over some of the devDependencies
   appPackage.dependencies = appPackage.dependencies || {};
@@ -36,7 +35,7 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
     JSON.stringify(appPackage, null, 2)
   );
 
-  var readmeExists = pathExists.sync(path.join(appPath, 'README.md'));
+  var readmeExists = fs.existsSync(path.join(appPath, 'README.md'));
   if (readmeExists) {
     fs.renameSync(path.join(appPath, 'README.md'), path.join(appPath, 'README.old.md'));
   }

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -29,11 +29,11 @@ var formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 var getProcessForPort = require('react-dev-utils/getProcessForPort');
 var openBrowser = require('react-dev-utils/openBrowser');
 var prompt = require('react-dev-utils/prompt');
-var pathExists = require('path-exists');
+var fs = require('fs');
 var config = require('../config/webpack.config.dev');
 var paths = require('../config/paths');
 
-var useYarn = pathExists.sync(paths.yarnLockFile);
+var useYarn = fs.existsSync(paths.yarnLockFile);
 var cli = useYarn ? 'yarn' : 'npm';
 var isInteractive = process.stdout.isTTY;
 

--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -9,13 +9,13 @@
 
 // Note: this file does not exist after ejecting.
 
-const pathExists = require('path-exists');
+const fs = require('fs');
 const paths = require('../config/paths');
 
 module.exports = (resolve, rootDir, isEjecting) => {
   // Use this instead of `paths.testsSetup` to avoid putting
   // an absolute filename into configuration after ejecting.
-  const setupTestsFile = pathExists.sync(paths.testsSetup) ? '<rootDir>/src/setupTests.js' : undefined;
+  const setupTestsFile = fs.existsSync(paths.testsSetup) ? '<rootDir>/src/setupTests.js' : undefined;
 
   // TODO: I don't know if it's safe or not to just use / as path separator
   // in Jest configs. We need help from somebody with Windows to determine this.


### PR DESCRIPTION
### Why
[path-exists](https://www.npmjs.com/package/path-exists) was originally created to support the semantics of deprecated [fs.exists](https://nodejs.org/api/fs.html#fs_fs_exists_path_callback) which is used to check if given path exists in the file system asynchronously.

> Because fs.exists() is being deprecated, but there's still a genuine use-case of being able to check if a path exists for other purposes than doing IO with it.

In Create React App [all of the uses](https://github.com/facebookincubator/create-react-app/search?utf8=%E2%9C%93&q=pathExists) of [path-exists](https://www.npmjs.com/package/path-exists) are synchronuous.

The original [fs.existsSync](https://nodejs.org/api/fs.html#fs_fs_existssync_path) is not deprecated, which makes [path-exists](https://www.npmjs.com/package/path-exists) obsolete for synchronuous checks.

> Note that fs.exists() is deprecated, but fs.existsSync() is not. (The callback parameter to fs.exists() accepts parameters that are inconsistent with other Node.js callbacks. fs.existsSync() does not use a callback.)

### What
This PR removes [path-exists](https://www.npmjs.com/package/path-exists) from Create React App and replaces all the uses of `pathExists.sync` with `fs.existsSync` :slightly_smiling_face: 