### PR TITLE
Make node version check more robust in e2e.sh

### DIFF
--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -68,7 +68,7 @@ root_path=$PWD
 npm install
 
 # If the node version is < 4, the script should just give an error.
-if [ `node --version | sed -e 's/^v//' -e 's/\..\+//g'` -lt 4 ]
+if [[ `node --version | sed -e 's/^v//' -e 's/\..*//g'` -lt 4 ]]
 then
   cd $temp_app_path
   err_output=`node "$root_path"/packages/create-react-app/index.js test-node-version 2>&1 > /dev/null || echo ''`


### PR DESCRIPTION
I noticed that when running `./tasks/e2e.sh`, the node version check was failing to execute properly due to bash complaining (version `3.2.57(1)-release` on my Mac OSX machine). Once I changed the test syntax to use `[[`, I found that sed wasn't stripping the node version correctly. I verified this with:

    nvm use 0.10
    ./tasks/e2e.sh

...which bombed out on a 'const' declaration'. It's probably down to some platform peculiarities, but good to fix them nonetheless.