### PR TITLE
Fix host environment variable bug

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -83,7 +83,7 @@ function run(port) {
   addWebpackMiddleware(devServer);
 
   // Launch WebpackDevServer.
-  devServer.listen(port, err => {
+  devServer.listen(port, host, err => {
     if (err) {
       return console.log(err);
     }


### PR DESCRIPTION
While writing docs for #1300 I found a bug with the `HOST` environment variable. When I set this variable, it uses the value I passed to print the link to the app in the console, but it doesn't actually use it.

### Steps to reproduce

Execute `npm start`.  The  console displays this message: 

```
Compiled successfully!

The app is running at:

  http://localhost:3000/
```

The app is can be viewed from your browser, and also from all the devices connected to your local network such as your mobile phone. Once you find your computer's IP address, you can open your phone's browser at something like `192.168.0.9:3000` to see the app. The `localhost` url is a bit misleading since the server is actually listening at `0.0.0.0` since that's the value that binds to all interfaces, not just the local loopback interface according to [webpack-dev-server's docs](https://webpack.github.io/docs/webpack-dev-server.html). In [this issue](https://github.com/webpack/webpack-dev-server/issues/80) it is mentioned that binding to `localhost` doesn't let other devices in the same network connect to the dev server.

If you use `127.0.0.1` as host, then other devices  should not be able to connect to the dev server since it is binding to the local interface. Try executing `HOST=127.0.0.1 npm start`. Mobile phones can still connect to it.  That's because the `HOST` environment variable isn't being properly used. It should be passed as an argument of dev server's `listen` function, along with the port.  This PR fixes it.

I also changed the default host from `localhost` to `0.0.0.0` since connections from other devices are currently allowed by default. `0.0.0.0` lets other devices connect to the server, `localhost` doesn't. Some user's may use this feature at work, so I don't want to break their setup.

This isn't a critical bug or anything like that, I don't think many users would worry about this. However it is still a bug. The other option is simply remove the `HOST` environment variable.
