### PR TITLE
Load markdown files through markdown-with-front-matter-loader

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -137,7 +137,8 @@ module.exports = {
           /\.(js|jsx)$/,
           /\.css$/,
           /\.json$/,
-          /\.svg$/
+          /\.svg$/,
+          /\.md$/
         ],
         loader: 'url-loader',
         options: {
@@ -201,6 +202,12 @@ module.exports = {
         options: {
           name: 'static/media/[name].[hash:8].[ext]'
         }
+      },
+      // Load Markdown files by converting them to JSON. It's then up to
+      // the consumer to render the result
+      {
+        test: /\.md$/,
+        loader: 'markdown-with-front-matter-loader'
       }
       // ** STOP ** Are you adding a new loader?
       // Remember to add the new extension(s) to the "url" loader exclusion list.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -144,7 +144,8 @@ module.exports = {
           /\.(js|jsx)$/,
           /\.css$/,
           /\.json$/,
-          /\.svg$/
+          /\.svg$/,
+          /\.md$/
         ],
         loader: 'url-loader',
         options: {
@@ -215,6 +216,12 @@ module.exports = {
         options: {
           name: 'static/media/[name].[hash:8].[ext]'
         }
+      },
+      // Load Markdown files by converting them to JSON. It's then up to
+      // the consumer to render the result
+      {
+        test: /\.md$/,
+        loader: 'markdown-with-front-matter-loader'
       }
       // ** STOP ** Are you adding a new loader?
       // Remember to add the new extension(s) to the "url" loader exclusion list.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -52,6 +52,7 @@
     "html-webpack-plugin": "2.28.0",
     "http-proxy-middleware": "0.17.3",
     "jest": "18.1.0",
+    "markdown-with-front-matter-loader": "^0.1.0",
     "object-assign": "4.1.1",
     "postcss-loader": "1.2.2",
     "promise": "7.1.1",


### PR DESCRIPTION
This PR adds support for loading `*.md` files through `markdown-with-front-matter-loader`. This makes it simple to load and render Markdown through CRA.

## Testing

1. Create a demo app with `./tasks/cra.sh my-app-test`
2. `cd my-app-test`
3. Create `src/_posts/hello-world.md`
<pre>
---
title: 'Hello world'
---
# Hello world

This is a test

```javascript
function() { }
```
</pre>
4. Modify `src/App.js` to load the file
```
import post from './_pages/hello-world.md';
```
5. Include the post in the page:
```
<p className="App-intro">
  To get started, edit <code>src/App.js</code> and save to reload.
</p>
<div dangerouslySetInnerHTML={{__html: post.__content}}></div>
```
6. Start dev mode and check the page renders as expected.
```
yarn start
```
7. Build a production bundle:
```
yarn run build
```
8. Check that the production build works as expected by serving it and browsing [http://localhost/](http://localhost/)
```
docker run -it --rm -v $PWD/build:/usr/share/nginx/html -p 80:80 nginx:alpine
```