### PR TITLE
Fixes duplicate "is" typo

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -205,7 +205,7 @@ We recognize that this is suboptimal, but it is currently required due to the wa
 
 You can find the source HTML file in the `public` folder of the generated project. You may edit the `<title>` tag in it to change the title from “React App” to anything else.
 
-Note that normally you wouldn't edit files in the `public` folder very often. For example, [adding a stylesheet](#adding-a-stylesheet) is is done without touching the HTML.
+Note that normally you wouldn't edit files in the `public` folder very often. For example, [adding a stylesheet](#adding-a-stylesheet) is done without touching the HTML.
 
 If you need to dynamically update the page title based on the content, you can use the browser [`document.title`](https://developer.mozilla.org/en-US/docs/Web/API/Document/title) API. For more complex scenarios when you want to change the title from React components, you can use [React Helmet](https://github.com/nfl/react-helmet), a third party library.
 


### PR DESCRIPTION
Removes the duplicate "is" from [the react scripts template README](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md), from when the [Changing the Page title](https://github.com/facebookincubator/create-react-app/commit/587b2f8b590b0854080b25ffc316eafd945f3417#diff-4e6ec56f74ee42069aac401a4fe448adR204) section was added.