### PR TITLE
Add verbosity to lerna bootstrap in CI

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.30",
+  "lerna": "2.0.0-beta.31",
   "version": "independent",
   "changelog": {
     "repo": "facebookincubator/create-react-app",
@@ -12,5 +12,8 @@
       "tag: internal": ":house: Internal"
     },
     "cacheDir": ".changelog"
-  }
+  },
+  "packages": [
+    "packages/*"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "changelog": "lerna-changelog",
     "create-react-app": "tasks/cra.sh",
     "e2e": "tasks/e2e.sh",
-    "postinstall": "lerna bootstrap",
+    "postinstall": "lerna bootstrap `[ \"$CI\" = true ] && echo --loglevel=verbose`",
     "publish": "tasks/release.sh",
     "start": "node packages/react-scripts/scripts/start.js",
     "test": "node packages/react-scripts/scripts/test.js --env=jsdom"
@@ -18,7 +18,7 @@
     "eslint-plugin-import": "1.12.0",
     "eslint-plugin-jsx-a11y": "2.2.2",
     "eslint-plugin-react": "6.3.0",
-    "lerna": "2.0.0-beta.30",
+    "lerna": "2.0.0-beta.31",
     "lerna-changelog": "^0.2.3"
   }
 }


### PR DESCRIPTION
A lot of travis CIs are failing due to `lerna bootstrap` being unresponsive for more than 10 mins with **node** v0.10.

I'm not completely sure this is going to fix that, obviously it will slow everything down, and produce an even longer CI output.

Moreover I had to upgrade **lerna** to v2.0.0-beta31 because the CLI opt `--loglevel` was introduced then.