### PR TITLE
Fix workflow if react-scripts package is linked via npm-link

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -97,7 +97,7 @@ function resolveOwn(relativePath) {
 // config before eject: we're in ./node_modules/react-scripts/config/
 module.exports = {
   appPath: resolveApp('.'),
-  ownPath: resolveOwn('.'),
+  ownPath: resolveApp('node_modules/react-scripts'),
   appBuild: resolveApp('build'),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -13,6 +13,10 @@ var path = require('path');
 var fs = require('fs');
 var url = require('url');
 
+// @remove-on-eject-begin
+var isReactScriptsLinked = require('../utils/isReactScriptsLinked');
+// @remove-on-eject-end
+
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebookincubator/create-react-app/issues/637
 var appDirectory = fs.realpathSync(process.cwd());
@@ -113,7 +117,7 @@ module.exports = {
 };
 
 // config before publish: we're in ./packages/react-scripts/config/
-if (__dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1) {
+if (!isReactScriptsLinked() && __dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1) {
   module.exports = {
     appBuild: resolveOwn('../../../build'),
     appPublic: resolveOwn('../template/public'),

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -114,7 +114,6 @@ module.exports = {
   servedPath: getServedPath(resolveApp('package.json'))
 };
 
-
 var reactScriptsPath = path.resolve('node_modules/react-scripts');
 var reactScriptsLinked = fs.existsSync(reactScriptsPath) && fs.lstatSync(reactScriptsPath).isSymbolicLink();
 

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -13,10 +13,6 @@ var path = require('path');
 var fs = require('fs');
 var url = require('url');
 
-// @remove-on-eject-begin
-var isReactScriptsLinked = require('../utils/isReactScriptsLinked');
-// @remove-on-eject-end
-
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebookincubator/create-react-app/issues/637
 var appDirectory = fs.realpathSync(process.cwd());
@@ -95,11 +91,13 @@ module.exports = {
 
 // @remove-on-eject-begin
 function resolveOwn(relativePath) {
-  return path.resolve(__dirname, relativePath);
+  return path.resolve(__dirname, '..', relativePath);
 }
 
 // config before eject: we're in ./node_modules/react-scripts/config/
 module.exports = {
+  appPath: resolveApp('.'),
+  ownPath: resolveOwn('.'),
   appBuild: resolveApp('build'),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),
@@ -110,28 +108,34 @@ module.exports = {
   testsSetup: resolveApp('src/setupTests.js'),
   appNodeModules: resolveApp('node_modules'),
   // this is empty with npm3 but node resolution searches higher anyway:
-  ownNodeModules: resolveOwn('../node_modules'),
+  ownNodeModules: resolveOwn('node_modules'),
   nodePaths: nodePaths,
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json'))
 };
 
+
+var reactScriptsPath = path.resolve('node_modules/react-scripts');
+var reactScriptsLinked = fs.existsSync(reactScriptsPath) && fs.lstatSync(reactScriptsPath).isSymbolicLink();
+
 // config before publish: we're in ./packages/react-scripts/config/
-if (!isReactScriptsLinked() && __dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1) {
+if (!reactScriptsLinked && __dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1) {
   module.exports = {
-    appBuild: resolveOwn('../../../build'),
-    appPublic: resolveOwn('../template/public'),
-    appHtml: resolveOwn('../template/public/index.html'),
-    appIndexJs: resolveOwn('../template/src/index.js'),
-    appPackageJson: resolveOwn('../package.json'),
-    appSrc: resolveOwn('../template/src'),
-    yarnLockFile: resolveOwn('../template/yarn.lock'),
-    testsSetup: resolveOwn('../template/src/setupTests.js'),
-    appNodeModules: resolveOwn('../node_modules'),
-    ownNodeModules: resolveOwn('../node_modules'),
+    appPath: resolveApp('.'),
+    ownPath: resolveOwn('.'),
+    appBuild: resolveOwn('../../build'),
+    appPublic: resolveOwn('template/public'),
+    appHtml: resolveOwn('template/public/index.html'),
+    appIndexJs: resolveOwn('template/src/index.js'),
+    appPackageJson: resolveOwn('package.json'),
+    appSrc: resolveOwn('template/src'),
+    yarnLockFile: resolveOwn('template/yarn.lock'),
+    testsSetup: resolveOwn('template/src/setupTests.js'),
+    appNodeModules: resolveOwn('node_modules'),
+    ownNodeModules: resolveOwn('node_modules'),
     nodePaths: nodePaths,
-    publicUrl: getPublicUrl(resolveOwn('../package.json')),
-    servedPath: getServedPath(resolveOwn('../package.json'))
+    publicUrl: getPublicUrl(resolveOwn('package.json')),
+    servedPath: getServedPath(resolveOwn('package.json'))
   };
 }
 // @remove-on-eject-end

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -11,11 +11,14 @@ var createJestConfig = require('../utils/createJestConfig');
 var fs = require('fs-extra');
 var path = require('path');
 var paths = require('../config/paths');
+var isReactScriptsLinked = require('../utils/isReactScriptsLinked');
 var prompt = require('react-dev-utils/prompt');
 var spawnSync = require('cross-spawn').sync;
 var chalk = require('chalk');
 var green = chalk.green;
 var cyan = chalk.cyan;
+
+var reactScriptsLinked = isReactScriptsLinked();
 
 prompt(
   'Are you sure you want to eject? This action is permanent.',
@@ -28,8 +31,15 @@ prompt(
 
   console.log('Ejecting...');
 
+  // NOTE: get ownPath and appPath from config/paths.js ?
   var ownPath = path.join(__dirname, '..');
-  var appPath = path.join(ownPath, '..', '..');
+  var appPath;
+
+  if (reactScriptsLinked) {
+    appPath = path.resolve('.');
+  } else {
+    appPath = path.join(ownPath, '..', '..');
+  }
 
   function verifyAbsent(file) {
     if (fs.existsSync(path.join(appPath, file))) {
@@ -135,7 +145,6 @@ prompt(
   );
 
   // Add Babel config
-
   console.log('  Adding ' + cyan('Babel') + ' preset');
   appPackage.babel = babelConfig;
 
@@ -151,11 +160,15 @@ prompt(
 
   if (fs.existsSync(paths.yarnLockFile)) {
     console.log(cyan('Running yarn...'));
-    fs.removeSync(ownPath);
+    if (!reactScriptsLinked) {
+      fs.removeSync(ownPath);
+    }
     spawnSync('yarnpkg', [], {stdio: 'inherit'});
   } else {
     console.log(cyan('Running npm install...'));
-    fs.removeSync(ownPath);
+    if (!reactScriptsLinked) {
+      fs.removeSync(ownPath);
+    }
     spawnSync('npm', ['install'], {stdio: 'inherit'});
   }
   console.log(green('Ejected successfully!'));

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -150,15 +150,11 @@ prompt(
 
   if (fs.existsSync(paths.yarnLockFile)) {
     console.log(cyan('Running yarn...'));
-    if (ownPath.indexOf(appPath) !== -1) {
-      fs.removeSync(ownPath);
-    }
+    fs.removeSync(ownPath);
     spawnSync('yarnpkg', [], {stdio: 'inherit'});
   } else {
     console.log(cyan('Running npm install...'));
-    if (ownPath.indexOf(appPath) !== -1) {
-      fs.removeSync(ownPath);
-    }
+    fs.removeSync(ownPath);
     spawnSync('npm', ['install'], {stdio: 'inherit'});
   }
   console.log(green('Ejected successfully!'));

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -11,7 +11,6 @@ var createJestConfig = require('../utils/createJestConfig');
 var fs = require('fs-extra');
 var path = require('path');
 var paths = require('../config/paths');
-var reactScriptsLinked = require('../utils/isReactScriptsLinked')();
 var prompt = require('react-dev-utils/prompt');
 var spawnSync = require('cross-spawn').sync;
 var chalk = require('chalk');
@@ -29,9 +28,8 @@ prompt(
 
   console.log('Ejecting...');
 
-  // NOTE: get ownPath and appPath from config/paths.js ?
-  var ownPath = path.join(__dirname, '..');
-  var appPath = reactScriptsLinked ? path.resolve('.') : path.join(ownPath, '..', '..');
+  var ownPath = paths.ownPath;
+  var appPath = paths.appPath;
 
   function verifyAbsent(file) {
     if (fs.existsSync(path.join(appPath, file))) {
@@ -152,13 +150,13 @@ prompt(
 
   if (fs.existsSync(paths.yarnLockFile)) {
     console.log(cyan('Running yarn...'));
-    if (!reactScriptsLinked) {
+    if (ownPath.indexOf(appPath) !== -1) {
       fs.removeSync(ownPath);
     }
     spawnSync('yarnpkg', [], {stdio: 'inherit'});
   } else {
     console.log(cyan('Running npm install...'));
-    if (!reactScriptsLinked) {
+    if (ownPath.indexOf(appPath) !== -1) {
       fs.removeSync(ownPath);
     }
     spawnSync('npm', ['install'], {stdio: 'inherit'});

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -11,14 +11,12 @@ var createJestConfig = require('../utils/createJestConfig');
 var fs = require('fs-extra');
 var path = require('path');
 var paths = require('../config/paths');
-var isReactScriptsLinked = require('../utils/isReactScriptsLinked');
+var reactScriptsLinked = require('../utils/isReactScriptsLinked')();
 var prompt = require('react-dev-utils/prompt');
 var spawnSync = require('cross-spawn').sync;
 var chalk = require('chalk');
 var green = chalk.green;
 var cyan = chalk.cyan;
-
-var reactScriptsLinked = isReactScriptsLinked();
 
 prompt(
   'Are you sure you want to eject? This action is permanent.',
@@ -33,13 +31,7 @@ prompt(
 
   // NOTE: get ownPath and appPath from config/paths.js ?
   var ownPath = path.join(__dirname, '..');
-  var appPath;
-
-  if (reactScriptsLinked) {
-    appPath = path.resolve('.');
-  } else {
-    appPath = path.join(ownPath, '..', '..');
-  }
+  var appPath = reactScriptsLinked ? path.resolve('.') : path.join(ownPath, '..', '..');
 
   function verifyAbsent(file) {
     if (fs.existsSync(path.join(appPath, file))) {

--- a/packages/react-scripts/utils/isReactScriptsLinked.js
+++ b/packages/react-scripts/utils/isReactScriptsLinked.js
@@ -1,0 +1,7 @@
+var path = require('path');
+var fs = require('fs');
+
+module.exports = () => {
+  var localReactScriptsPath = path.resolve('node_modules/react-scripts');
+  return fs.existsSync(localReactScriptsPath) && fs.lstatSync(localReactScriptsPath).isSymbolicLink();
+};

--- a/packages/react-scripts/utils/isReactScriptsLinked.js
+++ b/packages/react-scripts/utils/isReactScriptsLinked.js
@@ -1,7 +1,0 @@
-var path = require('path');
-var fs = require('fs');
-
-module.exports = () => {
-  var localReactScriptsPath = path.resolve('node_modules/react-scripts');
-  return fs.existsSync(localReactScriptsPath) && fs.lstatSync(localReactScriptsPath).isSymbolicLink();
-};


### PR DESCRIPTION
It is very useful to use [npm-link](https://docs.npmjs.com/cli/link)  for `react-scripts` package when want to test new (local) developed features on existing application.

```
$ cd create-react-app/packages/react-scripts
$ npm link

$ cd ~/any-existing-app
$ npm link react-scripts

$ npm start
``` 

Related to #1107