### PR TITLE
Adding support for custom babel configuration

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -42,6 +42,7 @@ var nodePaths = (process.env.NODE_PATH || '')
 
 // config after eject: we're in ./config/
 module.exports = {
+  babelrc: resolveApp('.babelrc'),
   appBuild: resolveApp('build'),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),
@@ -62,6 +63,7 @@ function resolveOwn(relativePath) {
 
 // config before eject: we're in ./node_modules/react-scripts/config/
 module.exports = {
+  babelrc: resolveApp('.babelrc'),
   appBuild: resolveApp('build'),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),
@@ -79,6 +81,7 @@ module.exports = {
 // config before publish: we're in ./packages/react-scripts/config/
 if (__dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1) {
   module.exports = {
+    babelrc: resolveOwn('../template/.babelrc'),
     appBuild: resolveOwn('../../../build'),
     appPublic: resolveOwn('../template/public'),
     appHtml: resolveOwn('../template/public/index.html'),

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -23,6 +23,11 @@ var paths = require('./paths');
 var path = require('path');
 // @remove-on-eject-end
 
+// @remove-on-eject-begin
+var isLocalBabelExists = require('../utils/isLocalBabelExists');
+var localBabelExists = isLocalBabelExists();
+// @remove-on-eject-end
+
 // Webpack uses `publicPath` to determine where the app is being served from.
 // In development, we always serve from the root. This makes config easier.
 var publicPath = '/';
@@ -147,8 +152,8 @@ module.exports = {
         loader: 'babel',
         query: {
           // @remove-on-eject-begin
-          babelrc: false,
-          presets: [require.resolve('babel-preset-react-app')],
+          babelrc: localBabelExists,
+          presets: !localBabelExists ? [require.resolve('babel-preset-react-app')] : null,
           // @remove-on-eject-end
           // This is a feature of `babel-loader` for webpack (not Babel itself).
           // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -24,6 +24,11 @@ var getClientEnvironment = require('./env');
 var path = require('path');
 // @remove-on-eject-end
 
+// @remove-on-eject-begin
+var isLocalBabelExists = require('../utils/isLocalBabelExists');
+var localBabelExists = isLocalBabelExists();
+// @remove-on-eject-end
+
 function ensureSlash(path, needsSlash) {
   var hasSlash = path.endsWith('/');
   if (hasSlash && !needsSlash) {
@@ -153,8 +158,8 @@ module.exports = {
         loader: 'babel',
         // @remove-on-eject-begin
         query: {
-          babelrc: false,
-          presets: [require.resolve('babel-preset-react-app')],
+          babelrc: localBabelExists,
+          presets: !localBabelExists ? [require.resolve('babel-preset-react-app')] : null,
         },
         // @remove-on-eject-end
       },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -57,6 +57,7 @@
     "promise": "7.1.1",
     "react-dev-utils": "^0.4.2",
     "recursive-readdir": "2.1.0",
+    "semver": "^5.3.0",
     "strip-ansi": "3.0.1",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -11,6 +11,7 @@ var createJestConfig = require('../utils/createJestConfig');
 var fs = require('fs-extra');
 var path = require('path');
 var paths = require('../config/paths');
+var isLocalBabelExists = require('../utils/isLocalBabelExists');
 var prompt = require('react-dev-utils/prompt');
 var spawnSync = require('cross-spawn').sync;
 var chalk = require('chalk');
@@ -128,10 +129,11 @@ prompt(
     true
   );
 
-  // Add Babel config
-
-  console.log('  Adding ' + cyan('Babel') + ' preset');
-  appPackage.babel = babelConfig;
+  // Add Babel config if there is no local babel config
+  if (isLocalBabelExists()) {
+    console.log('  Adding ' + cyan('Babel') + ' preset');
+    appPackage.babel = babelConfig;
+  }
 
   // Add ESlint config
   console.log('  Adding ' + cyan('ESLint') +' configuration');

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -130,7 +130,7 @@ prompt(
   );
 
   // Add Babel config if there is no local babel config
-  if (isLocalBabelExists()) {
+  if (!isLocalBabelExists()) {
     console.log('  Adding ' + cyan('Babel') + ' preset');
     appPackage.babel = babelConfig;
   }

--- a/packages/react-scripts/template/.babelrc
+++ b/packages/react-scripts/template/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react-app"]
+}

--- a/packages/react-scripts/template/.babelrc
+++ b/packages/react-scripts/template/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["react-app"]
-}

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -28,6 +28,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Using Global Variables](#using-global-variables)
 - [Adding Bootstrap](#adding-bootstrap)
 - [Adding Flow](#adding-flow)
+- [Adding Custom Babel Configuration](#adding-custom-babel-configuration)
 - [Adding Custom Environment Variables](#adding-custom-environment-variables)
 - [Can I Use Decorators?](#can-i-use-decorators)
 - [Integrating with a Node Backend](#integrating-with-a-node-backend)
@@ -493,6 +494,18 @@ You can optionally use an IDE like [Nuclide](https://nuclide.io/docs/languages/f
 In the future we plan to integrate it into Create React App even more closely.
 
 To learn more about Flow, check out [its documentation](https://flowtype.org/).
+
+## Adding Custom Babel Configuration
+
+You can override builtin babel presets and plugins [via .babelrc or package.json](https://babeljs.io/docs/usage/babelrc/).
+
+>Note: Don't forget to install babel-preset-react-app and include "react-app" preset into your .babelrc or package.json babel configuration section.
+
+```js
+{
+  "presets": ["react-app", "stage-0"]
+}
+```
 
 ## Adding Custom Environment Variables
 

--- a/packages/react-scripts/utils/isLocalBabelExists.js
+++ b/packages/react-scripts/utils/isLocalBabelExists.js
@@ -1,0 +1,8 @@
+var fse = require('fs-extra');
+var fs = require('fs');
+var paths = require('../config/paths');
+
+module.exports = () => {
+  var appPackageJson = fse.readJsonSync(paths.appPackageJson);
+  return appPackageJson.hasOwnProperty('babel') || fs.existsSync(paths.babelrc);
+};


### PR DESCRIPTION
With this PR It is possible to override builtin babel presets and plugins [via .babelrc or package.json](https://babeljs.io/docs/usage/babelrc/).

>Note: Don't forget to install "babel-preset-react-app" and include "react-app" preset into your .babelrc or package.json babel configuration section.

via `.babelrc`
```js
{
  "presets": ["react-app", "stage-0"]
}
```

or via `package.json`

```js
...
"babel": {
    "presets": ["react-app", "stage-0"]
  }
...
```

Now is possible to use:

- [Decorators](https://www.npmjs.com/package/babel-plugin-transform-decorators )
- Features from [stage-0 preset](https://babeljs.io/docs/plugins/preset-stage-0/)
- Any new babel features and presets

>NOTE: If using custom babel with "babel-preset-react-app" preset - you will get warning message if "babel-preset-react-app"  latest version is not range of your local version
