### PR TITLE
Fix importing npm linked libraries

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -81,7 +81,7 @@ module.exports = {
     // We placed these paths second because we want `node_modules` to "win"
     // if there are any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
-    modules: ['node_modules'].concat(paths.nodePaths),
+    modules: [paths.appNodeModules].concat(paths.nodePaths),
     // These are the reasonable defaults supported by the Node ecosystem.
     // We also include JSX as a common component filename extension to support
     // some tools, although we do not recommend using it, see:

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -81,7 +81,7 @@ module.exports = {
     // We placed these paths second because we want `node_modules` to "win"
     // if there are any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
-    modules: [paths.appNodeModules].concat(paths.nodePaths),
+    modules: ['node_modules', paths.appNodeModules].concat(paths.nodePaths),
     // These are the reasonable defaults supported by the Node ecosystem.
     // We also include JSX as a common component filename extension to support
     // some tools, although we do not recommend using it, see:

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -86,7 +86,7 @@ module.exports = {
     // We placed these paths second because we want `node_modules` to "win"
     // if there are any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
-    modules: [paths.appNodeModules].concat(paths.nodePaths),
+    modules: ['node_modules', paths.appNodeModules].concat(paths.nodePaths),
     // These are the reasonable defaults supported by the Node ecosystem.
     // We also include JSX as a common component filename extension to support
     // some tools, although we do not recommend using it, see:

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -86,7 +86,7 @@ module.exports = {
     // We placed these paths second because we want `node_modules` to "win"
     // if there are any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
-    modules: ['node_modules'].concat(paths.nodePaths),
+    modules: [paths.appNodeModules].concat(paths.nodePaths),
     // These are the reasonable defaults supported by the Node ecosystem.
     // We also include JSX as a common component filename extension to support
     // some tools, although we do not recommend using it, see:


### PR DESCRIPTION
Looking through the `npm link` issues, I see two use cases:
1. (#1356) using `npm link` to test `react-scripts`
2. using `npm link` for libraries your app depends on.

This PR solves the 2nd case. Webpack's official solution for `npm link` is to [add your project's node_modules to `resolve.fallback` on the config](https://webpack.github.io/docs/troubleshooting.html#npm-linked-modules-don-t-find-their-dependencies).

To verify the issue and fix create a small library to link:

```
cd /tmp
git clone https://gist.github.com/f40e1bad454626691097b4cc4651208c.git link-example
cd link-example
npm link
# to clean this up when you're done, return and run `npm unlink`
```

Then create your app and link the library.

```
create-react-app my-app
cd my-app
npm link link-example
echo 'import "link-example"' > src/index.js
npm run build
```

With the current published version, the build will fail:

```
> my-app@0.1.0 build /tmp/my-app
> react-scripts build

Creating an optimized production build...
Failed to compile.

Module not found: Error: Cannot resolve module 'react' in /tmp/link-example
```

Even though `my-app` imported `./node_modules/link-example/index.js`, the symlink causes webpack to treat it like you required `/tmp/link-example/index.js`.


