### PR TITLE
Use yarnpkg alias to run Yarn

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -138,7 +138,7 @@ function createApp(name, verbose, version) {
 
 function shouldUseYarn() {
   try {
-    execSync('yarn --version', {stdio: 'ignore'});
+    execSync('yarnpkg --version', {stdio: 'ignore'});
     return true;
   } catch (e) {
     return false;
@@ -149,7 +149,7 @@ function install(packageToInstall, verbose, callback) {
   var command;
   var args;
   if (shouldUseYarn()) {
-    command = 'yarn';
+    command = 'yarnpkg';
     args = [ 'add', '--dev', '--exact', packageToInstall];
   } else {
     command = 'npm';

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -147,7 +147,7 @@ prompt(
   if (pathExists.sync(paths.yarnLockFile)) {
     console.log(cyan('Running yarn...'));
     fs.removeSync(ownPath);
-    spawnSync('yarn', [], {stdio: 'inherit'});
+    spawnSync('yarnpkg', [], {stdio: 'inherit'});
   } else {
     console.log(cyan('Running npm install...'));
     fs.removeSync(ownPath);

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -65,7 +65,7 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
   var args;
 
   if (useYarn) {
-    command = 'yarn';
+    command = 'yarnpkg';
     args = ['add'];
   } else {
     command = 'npm';


### PR DESCRIPTION
There’s a common tool included in Hadoop that also has a `yarn` command, which created issues for users who had Hadoop installed:
* #1257
* #1363

Yarn also installs the command under `yarnpkg` alias (added in https://github.com/yarnpkg/yarn/commit/cefa9a368dd3df1a1f1ecd9e50de9c5fabefbc92) so we can use `yarnpkg` instead of `yarn` to make it more reliable.

This has no effect on users who don't have Hadoop installed, but those who have won't see errors from falsely detecting Hadoop Yarn as Yarn the package manager, and they can now also install Yarn to make use of our Yarn support without the Hadoop Yarn interfering.