### PR TITLE
Added option to disable yarn on initial build to fix jest failure

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -111,7 +111,7 @@ function createApp(name, verbose, version) {
   }
 
   if (program.disableYarn) {
-    console.log(chalk.orange('Yarn has been disabled via the "--disable-yarn" command line option.\n Using npm package manager to build'));
+    console.log(chalk.yellow('Yarn has been disabled via the "--disable-yarn" command line option.\n Using npm package manager to build'));
   }
   console.log(
     'Creating a new React app in ' + chalk.green(root) + '.'

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -69,6 +69,7 @@ var program = require('commander')
   })
   .option('--verbose', 'print additional logs')
   .option('--scripts-version <alternative-package>', 'use a non-standard version of react-scripts')
+  .option('--disable-yarn', 'disallow using yarn over npm, (useful for certain global binary packages failing with yarn)')
   .on('--help', function () {
     console.log('    Only ' + chalk.green('<project-directory>') + ' is required.');
     console.log();
@@ -109,6 +110,9 @@ function createApp(name, verbose, version) {
     process.exit(1);
   }
 
+  if (program.disableYarn) {
+    console.log(chalk.orange('Yarn has been disabled via the "--disable-yarn" command line option.\n Using npm package manager to build'));
+  }
   console.log(
     'Creating a new React app in ' + chalk.green(root) + '.'
   );
@@ -136,6 +140,9 @@ function createApp(name, verbose, version) {
 function shouldUseYarn() {
   try {
     execSync('yarnpkg --version', {stdio: 'ignore'});
+    if (program.disableYarn) {
+      return false;
+    }
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
When creating an app using yarn / yarnpkg, some binaries do not get properly linked, causing the Jest test scripts to fail.
If yarn is used after using npm for the initial build, everything seems to work fine.
The issue to track regarding yarn binaries should be https://github.com/yarnpkg/yarn/issues/648

This PR adds a --disable-yarn option, which will force the initial build to use npm.