### PR TITLE
Change console.log for errors and warnings

### DIFF
--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -133,12 +133,12 @@ compiler.plugin('done', function(stats) {
   }
   if (messages.errors.length) {
     console.log('Failed to compile.');
-    messages.errors.forEach(console.log);
+    messages.errors.forEach(e => console.log(e));
     return;
   }
   if (messages.warnings.length) {
     console.log('Compiled with warnings.');
-    messages.warnings.forEach(console.log);
+    messages.warnings.forEach(w => console.log(w));
   }
 });
 ```


### PR DESCRIPTION
Array.forEach is passed the following parameters:

currentValue
    The current element being processed in the array.
index
    The index of the current element being processed in the array.
array
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach

console.log takes multiple arguments. We only want to print the first one, the actual message.