### PR TITLE
webpack-dev-server patch for 'still-ok' success status

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -248,6 +248,7 @@ connection.onmessage = function(e) {
   case 'hash':
     handleAvailableHash(message.data);
     break;
+  case 'still-ok':
   case 'ok':
     handleSuccess();
     break;


### PR DESCRIPTION
handleSuccess function in react-dev-utils/webpackHotDevClient.js does not run for message.type of 'still-ok'. added 'still-ok' to the switch statement so in can reload the window and appropriately clear error messages.