### PR TITLE
Add optimize-js-plugin to webpack.config.prod.js

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -15,6 +15,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var ManifestPlugin = require('webpack-manifest-plugin');
 var InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
+var OptimizeJsPlugin = require('optimize-js-plugin');
 var url = require('url');
 var paths = require('./paths');
 var getClientEnvironment = require('./env');
@@ -261,6 +262,7 @@ module.exports = {
         screw_ie8: true
       }
     }),
+    new OptimizeJsPlugin(),
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
     new ExtractTextPlugin('static/css/[name].[contenthash:8].css'),
     // Generate a manifest file which contains a mapping of all asset filenames

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -53,6 +53,7 @@
     "jest": "18.0.0",
     "json-loader": "0.5.4",
     "object-assign": "4.1.0",
+    "optimize-js-plugin": "0.0.4",
     "postcss-loader": "1.0.0",
     "promise": "7.1.1",
     "react-dev-utils": "^0.4.2",


### PR DESCRIPTION
This PR adds the **optimize-js** lib to the build process:

* https://github.com/nolanlawson/optimize-js
* https://github.com/vigneshshanmugam/optimize-js-plugin

Benchmarks from @nolanlawson:

| Browser | Typical speed boost/regression using optimize-js |
| ---- | ----- |
| Chrome 55 | 20.63% |
| Edge 14 | 13.52% |
| Firefox 50 | 8.26% |
| Safari 10 | -1.04% |