### PR TITLE
Create empty package.json in e2e test (#1401)

### DIFF
--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -152,7 +152,12 @@ mv package.json.orig package.json
 
 # Install the CLI in a temporary location
 cd $temp_cli_path
-echo "{}" > package.json
+
+# Initialize package.json before installing the CLI becuase npm will not install
+# the CLI properly in the temporary location if it is missing.
+npm init --yes
+
+# Now we can install the CLI from the local package.
 npm install $cli_path
 
 # Install the app in a temporary location

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -153,7 +153,7 @@ mv package.json.orig package.json
 # Install the CLI in a temporary location
 cd $temp_cli_path
 
-# Initialize package.json before installing the CLI becuase npm will not install
+# Initialize package.json before installing the CLI because npm will not install
 # the CLI properly in the temporary location if it is missing.
 npm init --yes
 

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -152,6 +152,7 @@ mv package.json.orig package.json
 
 # Install the CLI in a temporary location
 cd $temp_cli_path
+echo "{}" > package.json
 npm install $cli_path
 
 # Install the app in a temporary location


### PR DESCRIPTION
Create empty package.json in e2e test while installing packaged CLI to prevent installation issues. Related to #1401.