### PR TITLE
Add causes of dev server not detecting changes

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1254,7 +1254,7 @@ Note that in order to support routers that use HTML5 `pushState` API, you may wa
 
 ## Troubleshooting
 
-### `npm start` doesn't detect changes
+### `npm start` doesn’t detect changes
 
 When you save a file while `npm start` is running, the browser should refresh with the updated code.<br>
 If this doesn’t happen, try one of the following workarounds:

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -62,10 +62,10 @@ You can find the most recent version of this guide [here](https://github.com/fac
   - [S3 and CloudFront](#s3-and-cloudfront)
   - [Surge](#surge)
 - [Troubleshooting](#troubleshooting)
+  - [`npm start` doesn’t detect changes](#npm-start-doesnt-detect-changes)
   - [`npm test` hangs on macOS Sierra](#npm-test-hangs-on-macos-sierra)
   - [`npm run build` silently fails](#npm-run-build-silently-fails)
   - [`npm run build` fails on Heroku](#npm-run-build-fails-on-heroku)
-  - [`npm start` doesn't detect changes](#npm-start-doesnt-detect-changes)
 - [Something Missing?](#something-missing)
 
 ## Updating to New Releases
@@ -1254,6 +1254,19 @@ Note that in order to support routers that use HTML5 `pushState` API, you may wa
 
 ## Troubleshooting
 
+### `npm start` doesn't detect changes
+
+When you save a file while `npm start` is running, the browser should refresh with the updated code.<br>
+If this doesn’t happen, try one of the following workarounds:
+
+* If your project is in a Dropbox folder, try moving it out.
+* If the watcher doesn’t see a file called `index.js` and you’re referencing it by the folder name, you [need to restart the watcher](https://github.com/facebookincubator/create-react-app/issues/1164) due to a Webpack bug.
+* Some editors like Vim and IntelliJ have a “safe write” feature that currently breaks the watcher. You will need to disable it. Follow the instructions in [“Working with editors supporting safe write”](https://webpack.github.io/docs/webpack-dev-server.html#working-with-editors-ides-supporting-safe-write).
+* If your project path contains parentheses, try moving the project to a path without them. This is caused by a [Webpack watcher bug](https://github.com/webpack/watchpack/issues/42).
+* On Linux and OS X, you might need to [tweak system settings](https://webpack.github.io/docs/troubleshooting.html#not-enough-watchers) to allow more watchers.
+
+If none of these solutions help please leave a comment [in this thread](https://github.com/facebookincubator/create-react-app/issues/659).
+
 ### `npm test` hangs on macOS Sierra
 
 If you run `npm test` and the console gets stuck after printing `react-scripts test --env=jsdom` to the console there might be a problem with your [Watchman](https://facebook.github.io/watchman/) installation as described in [facebookincubator/create-react-app#713](https://github.com/facebookincubator/create-react-app/issues/713).
@@ -1286,15 +1299,6 @@ It is reported that `npm run build` can fail on machines with no swap space, whi
 
 This may be a problem with case sensitive filenames.
 Please refer to [this section](#resolving-module-not-found-error-cannot-resolve-file-or-directory).
-
-### `npm start` doesn't detect changes
-
-Some common causes:
-
-* Starting project in a Dropbox folder, you need to move it out
-* Some editors like Vim and IntelliJ have a "safe write" feature that breaks the watcher, you need to disable it. See ["Working with editors/IDEs supporting safe write"](https://webpack.github.io/docs/webpack-dev-server.html#working-with-editors-ides-supporting-safe-write) from the webpack-dev-server docs
-* Parenthesis in project folder name, you need to remove them until it is fixed. See [webpack/webpack#2753](https://github.com/webpack/webpack/issues/2753)
-* You might need to tweak system settings (https://webpack.github.io/docs/troubleshooting.html#not-enough-watchers)
 
 ## Something Missing?
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -65,6 +65,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
   - [`npm test` hangs on macOS Sierra](#npm-test-hangs-on-macos-sierra)
   - [`npm run build` silently fails](#npm-run-build-silently-fails)
   - [`npm run build` fails on Heroku](#npm-run-build-fails-on-heroku)
+  - [`npm start` doesn't detect changes](#npm-start-doesnt-detect-changes)
 - [Something Missing?](#something-missing)
 
 ## Updating to New Releases
@@ -1285,6 +1286,15 @@ It is reported that `npm run build` can fail on machines with no swap space, whi
 
 This may be a problem with case sensitive filenames.
 Please refer to [this section](#resolving-module-not-found-error-cannot-resolve-file-or-directory).
+
+### `npm start` doesn't detect changes
+
+Some common causes:
+
+* Starting project in a Dropbox folder, you need to move it out
+* Some editors like Vim and IntelliJ have a "safe write" feature that breaks the watcher, you need to disable it. See ["Working with editors/IDEs supporting safe write"](https://webpack.github.io/docs/webpack-dev-server.html#working-with-editors-ides-supporting-safe-write) from the webpack-dev-server docs
+* Parenthesis in project folder name, you need to remove them until it is fixed. See [webpack/webpack#2753](https://github.com/webpack/webpack/issues/2753)
+* You might need to tweak system settings (https://webpack.github.io/docs/troubleshooting.html#not-enough-watchers)
 
 ## Something Missing?
 


### PR DESCRIPTION
Added a summary of causes of `npm start` not detecting changes to Troubleshooting chapter of User Guide. Collected from #659 and #1374 