### PR TITLE
Use offline cached version with yarn when it's possible

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -166,6 +166,13 @@ function install(useYarn, dependencies, verbose, isOnline) {
         '--exact',
         isOnline === false && '--offline'
       ].concat(dependencies);
+
+      if (!isOnline) {
+        console.log(chalk.yellow('You appear to be offline.'));
+        console.log(chalk.yellow('Falling back to the local Yarn cache.'));
+        console.log();
+      }
+
     } else {
       checkNpmVersion();
       command = 'npm';

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -179,7 +179,9 @@ function install(useYarn, dependencies, verbose, isOnline) {
     var child = spawn(command, args, {stdio: 'inherit'});
     child.on('close', function(code) {
       if (code !== 0) {
-        reject();
+        reject({
+          command: command + ' ' + args.join(' ')
+        });
         return;
       }
       resolve();
@@ -223,9 +225,13 @@ function run(root, appName, version, verbose, originalDirectory, template) {
       var init = require(scriptsPath);
       init(root, appName, verbose, originalDirectory, template);
     })
-    .catch(function() {
+    .catch(function(reason) {
       console.log();
-      console.error('Aborting installation.', chalk.cyan(command + ' ' + args.join(' ')), 'has failed.');
+      console.log('Aborting installation.');
+      if (reason.command) {
+        console.log('  ' + chalk.cyan(reason.command), 'has failed.')
+      }
+      console.log();
 
       // On 'exit' we will delete these files from target directory.
       var knownGeneratedFiles = [

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -179,8 +179,6 @@ function install(useYarn, dependencies, verbose, isOnline) {
     var child = spawn(command, args, {stdio: 'inherit'});
     child.on('close', function(code) {
       if (code !== 0) {
-        console.log();
-        console.error('Aborting installation.', chalk.cyan(command + ' ' + args.join(' ')), 'has failed.');
         reject();
         return;
       }
@@ -226,6 +224,9 @@ function run(root, appName, version, verbose, originalDirectory, template) {
       init(root, appName, verbose, originalDirectory, template);
     })
     .catch(function() {
+      console.log();
+      console.error('Aborting installation.', chalk.cyan(command + ' ' + args.join(' ')), 'has failed.');
+
       // On 'exit' we will delete these files from target directory.
       var knownGeneratedFiles = [
         'package.json', 'npm-debug.log', 'yarn-error.log', 'yarn-debug.log', 'node_modules'

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -225,7 +225,7 @@ function run(root, appName, version, verbose, originalDirectory, template) {
       var init = require(scriptsPath);
       init(root, appName, verbose, originalDirectory, template);
     })
-    .catch(function(command, args) {
+    .catch(function() {
       // On 'exit' we will delete these files from target directory.
       var knownGeneratedFiles = [
         'package.json', 'npm-debug.log', 'yarn-error.log', 'yarn-debug.log', 'node_modules'

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -155,11 +155,11 @@ function shouldUseYarn() {
   }
 }
 
-function install(dependencies, verbose, isOnline) {
+function install(useYarn, dependencies, verbose, isOnline) {
   return new Promise(function(resolve, reject) {
     var command;
     var args;
-    if (shouldUseYarn()) {
+    if (useYarn) {
       command = 'yarnpkg';
       args = [
         'add',
@@ -201,10 +201,11 @@ function run(root, appName, version, verbose, originalDirectory, template) {
     ', and ' + chalk.cyan(packageName) + '...'
   );
   console.log();
-
-  checkIfOnline()
+  
+  var useYarn = shouldUseYarn();
+  checkIfOnline(useYarn)
     .then(function(isOnline) {
-      return install(allDependencies, verbose, isOnline);
+      return install(useYarn, allDependencies, verbose, isOnline);
     })
     .then(function() {
       checkNodeVersion(packageName);
@@ -422,7 +423,13 @@ function isSafeToCreateProjectIn(root) {
     });
 }
 
-function checkIfOnline() {
+function checkIfOnline(useYarn) {
+  if (!useYarn) {
+    // Don't ping the Yarn registry.
+    // We'll just assume the best case.
+    return Promise.resolve(true);
+  }
+  
   return new Promise(function(resolve) {
     dns.resolve('registry.yarnpkg.com', function(err) {
       resolve(err === null);

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -12,7 +12,7 @@ var path = require('path');
 var spawn = require('cross-spawn');
 var chalk = require('chalk');
 
-module.exports = function(appPath, appName, verbose, originalDirectory, template) {
+module.exports = function(appPath, appName, verbose, originalDirectory, template, isOnline) {
   var ownPackageName = require(path.join(__dirname, '..', 'package.json')).name;
   var ownPath = path.join(appPath, 'node_modules', ownPackageName);
   var appPackage = require(path.join(appPath, 'package.json'));
@@ -69,7 +69,10 @@ module.exports = function(appPath, appName, verbose, originalDirectory, template
 
   if (useYarn) {
     command = 'yarnpkg';
-    args = ['add'];
+    args = [
+      'add',
+      isOnline === false && '--offline'
+    ];
   } else {
     command = 'npm';
     args = [

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -12,7 +12,7 @@ var path = require('path');
 var spawn = require('cross-spawn');
 var chalk = require('chalk');
 
-module.exports = function(appPath, appName, verbose, originalDirectory, template, isOnline) {
+module.exports = function(appPath, appName, verbose, originalDirectory, template) {
   var ownPackageName = require(path.join(__dirname, '..', 'package.json')).name;
   var ownPath = path.join(appPath, 'node_modules', ownPackageName);
   var appPackage = require(path.join(appPath, 'package.json'));
@@ -69,10 +69,7 @@ module.exports = function(appPath, appName, verbose, originalDirectory, template
 
   if (useYarn) {
     command = 'yarnpkg';
-    args = [
-      'add',
-      isOnline === false && '--offline'
-    ];
+    args = ['add'];
   } else {
     command = 'npm';
     args = [


### PR DESCRIPTION
This pull request enables offline support from the next version of yarn. With the 0.19 version there are some issues. The related issue is #1235!

Right now we prefer offline over online with --prefer-offline flag. Maybe in the future yarn wil have a --prefer-online flag and we can change it with that ;)

Let me know if it's ok!
cheers,
Simon
