### PR TITLE
Added babel-runtime dependency to deduplicate dependencies when using yarn

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -28,6 +28,7 @@
     "babel-eslint": "7.1.1",
     "babel-jest": "18.0.0",
     "babel-loader": "6.2.10",
+    "babel-runtime": "^6.20.0",
     "babel-preset-react-app": "^2.0.1",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",


### PR DESCRIPTION
By adding `babel-runtime` as a top level dependency (even though it is not directly depended on) forces yarn to hoist the version to the top which reduces the resultant `node_modules` directory size significantly. The npm install is unaffected.

**npm baseline:**

```
  114.7 MiB [##########] /node_modules
   64.0 KiB [          ]  README.md
   32.0 KiB [          ] /public
   24.0 KiB [          ] /src
    4.0 KiB [          ]  package.json
    4.0 KiB [          ]  .gitignore
```

**npm with patch:**

```
  114.7 MiB [##########] /node_modules
   64.0 KiB [          ]  README.md
   32.0 KiB [          ] /public
   24.0 KiB [          ] /src
    4.0 KiB [          ]  package.json
    4.0 KiB [          ]  .gitignore
```

**yarn baseline:**

```
  560.0 MiB [##########] /node_modules
  216.0 KiB [          ]  yarn.lock
   64.0 KiB [          ]  README.md
   32.0 KiB [          ] /public
   24.0 KiB [          ] /src
    4.0 KiB [          ]  package.json
    4.0 KiB [          ]  .gitignore
```

**yarn with patch:**

```
  150.0 MiB [##########] /node_modules
  216.0 KiB [          ]  yarn.lock
   64.0 KiB [          ]  README.md
   32.0 KiB [          ] /public
   24.0 KiB [          ] /src
    4.0 KiB [          ]  package.json
    4.0 KiB [          ]  .gitignore
```

More info: https://github.com/facebookincubator/create-react-app/issues/1397