### PR TITLE
Added --auto-eject switch to create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,24 @@ my-app/
     logo.svg
 ```
 
+
+
 No configuration or complicated folder structures, just the files you need to build your app.<br>
+
+#### `--auto-eject` switch
+
+**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+
+If you like create-react-app for everyday work and usually modifying the webpack configuration,
+you can use `--auto-eject` switch to automatically eject the react-scripts after everything finished.
+
+For more information about ejecting please refer to [npm run eject](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-eject)
+
+```sh
+create-react-app my-app --auto-eject
+cd my-app
+```
+
 Once the installation is done, you can run some commands inside the project folder:
 
 ### `npm start`

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -70,6 +70,7 @@ var program = commander
   })
   .option('--verbose', 'print additional logs')
   .option('--scripts-version <alternative-package>', 'use a non-standard version of react-scripts')
+  .option('--auto-eject', 'automatically runs eject operation after installation')
   .allowUnknownOption()
   .on('--help', function () {
     console.log('    Only ' + chalk.green('<project-directory>') + ' is required.');
@@ -102,9 +103,9 @@ var hiddenProgram = new commander.Command()
     'use a non-standard application template')
   .parse(process.argv)
 
-createApp(projectName, program.verbose, program.scriptsVersion, hiddenProgram.internalTestingTemplate);
+createApp(projectName, program.verbose, program.scriptsVersion, program.autoEject, hiddenProgram.internalTestingTemplate);
 
-function createApp(name, verbose, version, template) {
+function createApp(name, verbose, version, autoEject, template) {
   var root = path.resolve(name);
   var appName = path.basename(root);
 
@@ -137,7 +138,7 @@ function createApp(name, verbose, version, template) {
   console.log('Installing ' + chalk.cyan('react-scripts') + '...');
   console.log();
 
-  run(root, appName, version, verbose, originalDirectory, template);
+  run(root, appName, version, verbose, originalDirectory, autoEject, template);
 }
 
 function shouldUseYarn() {
@@ -170,7 +171,7 @@ function install(packageToInstall, verbose, callback) {
   });
 }
 
-function run(root, appName, version, verbose, originalDirectory, template) {
+function run(root, appName, version, verbose, originalDirectory, autoEject, template) {
   var packageToInstall = getInstallPackage(version);
   var packageName = getPackageName(packageToInstall);
 
@@ -190,7 +191,7 @@ function run(root, appName, version, verbose, originalDirectory, template) {
       'init.js'
     );
     var init = require(scriptsPath);
-    init(root, appName, verbose, originalDirectory, template);
+    init(root, appName, verbose, originalDirectory, autoEject, template);
   });
 }
 

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -17,10 +17,21 @@ var chalk = require('chalk');
 var green = chalk.green;
 var cyan = chalk.cyan;
 
-prompt(
+new Promise(resolve => {
+  const force = process.argv[2];
+
+  if (force !== undefined && (force === '--force' || force === '-f')) {
+    return resolve(true);
+  }
+
+  prompt(
   'Are you sure you want to eject? This action is permanent.',
   false
-).then(shouldEject => {
+  ).then(shouldEject => {
+    resolve(shouldEject);
+  });
+
+}).then(shouldEject => {
   if (!shouldEject) {
     console.log(cyan('Close one! Eject aborted.'));
     process.exit(1);

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -12,7 +12,7 @@ var path = require('path');
 var spawn = require('cross-spawn');
 var chalk = require('chalk');
 
-module.exports = function(appPath, appName, verbose, originalDirectory, template) {
+module.exports = function(appPath, appName, verbose, originalDirectory, autoEject, template) {
   var ownPackageName = require(path.join(__dirname, '..', 'package.json')).name;
   var ownPath = path.join(appPath, 'node_modules', ownPackageName);
   var appPackage = require(path.join(appPath, 'package.json'));
@@ -113,32 +113,59 @@ module.exports = function(appPath, appName, verbose, originalDirectory, template
       cdpath = appPath;
     }
 
-    console.log();
-    console.log('Success! Created ' + appName + ' at ' + appPath);
-    console.log('Inside that directory, you can run several commands:');
-    console.log();
-    console.log(chalk.cyan('  ' + command + ' start'));
-    console.log('    Starts the development server.');
-    console.log();
-    console.log(chalk.cyan('  ' + command + ' run build'));
-    console.log('    Bundles the app into static files for production.');
-    console.log();
-    console.log(chalk.cyan('  ' + command + ' test'));
-    console.log('    Starts the test runner.');
-    console.log();
-    console.log(chalk.cyan('  ' + command + ' run eject'));
-    console.log('    Removes this tool and copies build dependencies, configuration files');
-    console.log('    and scripts into the app directory. If you do this, you can’t go back!');
-    console.log();
-    console.log('We suggest that you begin by typing:');
-    console.log();
-    console.log(chalk.cyan('  cd'), cdpath);
-    console.log('  ' + chalk.cyan(command + ' start'));
-    if (readmeExists) {
-      console.log();
-      console.log(chalk.yellow('You had a `README.md` file, we renamed it to `README.old.md`'));
+    // If --eject option given, we will run 'npm run eject'
+    if (autoEject) {
+      var ejectSpawn = spawn("npm", ['run', 'eject', '--force']);
+
+      // Check if eject option has returned any error?
+      ejectSpawn.stderr.on('data', function (error) {
+        console.error(error.toString());
+        process.exit(1);
+      });
+
+      ejectSpawn.on('close', function (code) {
+        // So there has been an error. Process no further!
+        if (code !== 0) {
+          process.exit(code);
+        }
+        successMessage();
+      });
+    } else {
+      // There is no eject command. Just display the success message.
+      successMessage();
     }
-    console.log();
-    console.log('Happy hacking!');
+
+    function successMessage() {
+      console.log();
+      console.log('Success! Created ' + appName + ' at ' + appPath);
+      console.log('Inside that directory, you can run several commands:');
+      console.log();
+      console.log(chalk.cyan('  ' + command + ' start'));
+      console.log('    Starts the development server.');
+      console.log();
+      console.log(chalk.cyan('  ' + command + ' run build'));
+      console.log('    Bundles the app into static files for production.');
+      console.log();
+      console.log(chalk.cyan('  ' + command + ' test'));
+      console.log('    Starts the test runner.');
+      console.log();
+      if (!autoEject) {
+        console.log(chalk.cyan('  ' + command + ' run eject'));
+        console.log('    Removes this tool and copies build dependencies, configuration files');
+        console.log('    and scripts into the app directory. If you do this, you can’t go back!');
+        console.log();
+      }
+      console.log('We suggest that you begin by typing:');
+      console.log();
+      console.log(chalk.cyan('  cd'), cdpath);
+      console.log('  ' + chalk.cyan(command + ' start'));
+      if (readmeExists) {
+        console.log();
+        console.log(chalk.yellow('You had a `README.md` file, we renamed it to `README.old.md`'));
+      }
+      console.log();
+      console.log('Happy hacking!');
+    }
+
   });
 };

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -165,6 +165,8 @@ Instead, it will copy all the configuration files and the transitive dependencie
 
 You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
 
+If you want to skip the yes or no questioning when `eject`ing, you can use `--force` (or `-f`) switch.
+
 ## Syntax Highlighting in the Editor
 
 To configure the syntax highlighting in your favorite text editor, head to the [relevant Babel documentation page](https://babeljs.io/docs/editors) and follow the instructions. Some of the most popular editors are covered.


### PR DESCRIPTION
added --auto-eject switch to automatically ejecting after installation.
also added --force switch to eject.js
Readme files updated accordingly

I am using create-react-app for everyday work, and usually ejecting and modifying webpack for react-hot-loader and also for other things. This is shortens the waiting a little. Also it gives opportunity to automate the operations. (like automatically updating webpack, adding few extra dependencies, so that I don't have to do it all the time.)