### PR TITLE
Add option for setting webpack watch option polling

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -264,6 +264,7 @@ function runDevServer(host, port, protocol) {
     // Reportedly, this avoids CPU overload on some systems.
     // https://github.com/facebookincubator/create-react-app/issues/293
     watchOptions: {
+      poll: parseInt(process.env.WEBPACK_WATCH_POLL, 10) || undefined,
       ignored: /node_modules/
     },
     // Enable HTTPS if the HTTPS environment variable is set to 'true'


### PR DESCRIPTION
The motivation was for enabling using a virtualbox virtual machine with hot code reloading.
The rsync and normal file synchronisation provided by vagrant 1.9.1 and 5.1.14 does not
trigger webpack to hot reload the code.  By being able to provide an optional environment
variable hot reloading works with vagrant/virtualbox.  For example:

    $ WEBPACK_WATCH_POLL=1000 npm start

Problem and solution discussed by others here:
http://stackoverflow.com/questions/34937294/how-to-enable-hot-reloading-via-shared-folders-with-vagrant-vm#comment64629465_34937378