### PR TITLE
Don't call openBrowser for smoke test

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -286,7 +286,9 @@ function runDevServer(host, port, protocol) {
     console.log(chalk.cyan('Starting the development server...'));
     console.log();
 
-    openBrowser(protocol + '://' + host + ':' + port + '/');
+    if (!isSmokeTest) {
+      openBrowser(protocol + '://' + host + ':' + port + '/');
+    }
   });
 }
 


### PR DESCRIPTION
Nut sure but seems openBrowser should not be called for smoke test