### PR TITLE
Use real build path name in build output

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -212,7 +212,8 @@ function build(previousSizeMap) {
         console.log('  ' + chalk.green('"homepage"') + chalk.cyan(': ') + chalk.green('"http://myname.github.io/myapp"') + chalk.cyan(','));
         console.log();
       }
-      console.log('The ' + chalk.cyan('build') + ' folder is ready to be deployed.');
+      var build = path.relative(process.cwd(), paths.appBuild);
+      console.log('The ' + chalk.cyan(build) + ' folder is ready to be deployed.');
       console.log('You may also serve it locally with a static server:')
       console.log();
       if (useYarn) {
@@ -220,7 +221,7 @@ function build(previousSizeMap) {
       } else {
         console.log('  ' + chalk.cyan('npm') +  ' install -g pushstate-server');
       }
-      console.log('  ' + chalk.cyan('pushstate-server') + ' build');
+      console.log('  ' + chalk.cyan('pushstate-server') + ' ' + build);
       console.log('  ' + chalk.cyan(openCommand) + ' http://localhost:9000');
       console.log();
     }


### PR DESCRIPTION
Use the configured appBuild value in paths.js instead of hard-coding it to 'build'.  This is helpful for the ejected case where the appBuild path is changed to another folder name.