### PR TITLE
Adds instructions to run `flow init`

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -501,7 +501,8 @@ To add Flow to a Create React App project, follow these steps:
 
 1. Run `npm install --save-dev flow-bin`.
 2. Add `"flow": "flow"` to the `scripts` section of your `package.json`.
-3. Add `// @flow` to any files you want to type check (for example, to `src/App.js`).
+3. Run `npm run flow init`.
+4. Add `// @flow` to any files you want to type check (for example, to `src/App.js`).
 
 Now you can run `npm run flow` to check the files for type errors.
 You can optionally use an IDE like [Nuclide](https://nuclide.io/docs/languages/flow/) for a better integrated experience.


### PR DESCRIPTION
Without this step, flow (0.38.0) complains it couldn't find a `.flowconfig` file in the directory.

```bash
yarn run v0.19.1
$ flow 
Could not find a .flowconfig in . or any of its parent directories.
See "flow init --help" for more info

error Command failed with exit code 12.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This isn't ideal (Flow should work without the presence of a `.flowconfig` file) but this change updates the documentation to reflect the current state of the world.