### PR TITLE
Support setting "homepage" to "." to generate relative asset paths

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -27,11 +27,9 @@ var path = require('path');
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
 var publicPath = paths.servedPath;
-// Not everybody wants a single-page app with client side routing without hash.
-// Sometimes, people would rather be able to deploy their app anywhere,
-// without having to specify a "homepage".
-// We can detect this when the publicPath is set to "./".
-var isPublicPathRelative = publicPath === './';
+// Some apps do not use client-side routing with pushState.
+// For these, "homepage" can be set to "." to enable relative asset paths.
+var shouldUseRelativeAssetPaths = publicPath === './';
 // `publicUrl` is just like `publicPath`, but we will provide it to our app
 // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
 // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
@@ -52,7 +50,7 @@ const cssFilename = 'static/css/[name].[contenthash:8].css';
 // (See https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/27)
 // However, our output is structured with css, js and media folders.
 // To have this structure working with relative paths, we have to use custom options.
-const extractTextPluginOptions = isPublicPathRelative
+const extractTextPluginOptions = shouldUseRelativeAssetPaths
   // Making sure that the publicPath goes back to to build folder.
   ? { publicPath: Array(cssFilename.split('/').length).join('../') }
   : undefined;

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -27,6 +27,11 @@ var path = require('path');
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
 var publicPath = paths.servedPath;
+// Not everybody wants a single-page app with client side routing without hash.
+// Sometimes, people would rather be able to deploy their app anywhere,
+// without having to specify a "homepage".
+// We can detect this when the publicPath is set to "./".
+var isPublicPathRelative = publicPath === './';
 // `publicUrl` is just like `publicPath`, but we will provide it to our app
 // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
 // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
@@ -39,6 +44,18 @@ var env = getClientEnvironment(publicUrl);
 if (env.stringified['process.env'].NODE_ENV !== '"production"') {
   throw new Error('Production builds must have NODE_ENV=production.');
 }
+
+// Note: defined here because it will be used more than once.
+const cssFilename = 'static/css/[name].[contenthash:8].css';
+
+// ExtractTextPlugin expects the build output to be flat.
+// (See https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/27)
+// However, our output is structured with css, js and media folders.
+// To have this structure working with relative paths, we have to use custom options.
+const extractTextPluginOptions = isPublicPathRelative
+  // Making sure that the publicPath goes back to to build folder.
+  ? { publicPath: Array(cssFilename.split('/').length).join('../') }
+  : undefined;
 
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
@@ -150,7 +167,11 @@ module.exports = {
       // in the main CSS file.
       {
         test: /\.css$/,
-        loader: ExtractTextPlugin.extract('style', 'css?importLoaders=1!postcss')
+        loader: ExtractTextPlugin.extract(
+          'style',
+          'css?importLoaders=1!postcss',
+          extractTextPluginOptions
+        )
         // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
       },
       // JSON is not enabled by default in Webpack but both Node and Browserify
@@ -241,7 +262,7 @@ module.exports = {
       }
     }),
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
-    new ExtractTextPlugin('static/css/[name].[contenthash:8].css'),
+    new ExtractTextPlugin(cssFilename),
     // Generate a manifest file which contains a mapping of all asset filenames
     // to their corresponding output file so that tools can pick it up without
     // having to parse `index.html`.

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1070,7 +1070,7 @@ To override this, specify the `homepage` in your `package.json`, for example:
 
 This will let Create React App correctly infer the root path to use in the generated HTML file.
 
-#### Setting Homepage to "."
+#### Serving the Same Build from Different Paths
 
 >Note: this feature is available with `react-scripts@0.9.0` and higher.
 
@@ -1080,7 +1080,7 @@ If you are not using the HTML5 `pushState` history API or not using client-side 
   "homepage": ".",
 ```
 
-This will make sure that all the asset paths are relative to `index.html`. You will then be able to move your app from "http://mywebsite.com" to "http://mywebsite.com/relativepath" or even "http://mywebsite.com/relative/path" without having to rebuild it.
+This will make sure that all the asset paths are relative to `index.html`. You will then be able to move your app from `http://mywebsite.com` to `http://mywebsite.com/relativepath` or even `http://mywebsite.com/relative/path` without having to rebuild it.
 
 ### Firebase
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1070,18 +1070,17 @@ To override this, specify the `homepage` in your `package.json`, for example:
 
 This will let Create React App correctly infer the root path to use in the generated HTML file.
 
-#### Making builds deployable anywhere
+#### Setting Homepage to "."
 
 >Note: this feature is available with `react-scripts@0.9.0` and higher.
 
-If your are not using the HTML5 `pushState` history API or not using client-side routing at all, you do not have to specify the definitive URL of your application. Instead, you can put this in your `package.json`:
+If you are not using the HTML5 `pushState` history API or not using client-side routing at all, it is unnecessary to specify the URL from which your app will be served. Instead, you can put this in your `package.json`:
 
 ```js
-  "homepage": "./",
+  "homepage": ".",
 ```
 
-This will make sure that all the assets are loaded relatively to the generated `index.html`, effectively allowing you to build your application once and deploy it anywhere.
-
+This will make sure that all the asset paths are relative to `index.html`. You will then be able to move your app from "http://mywebsite.com" to "http://mywebsite.com/relativepath" or even "http://mywebsite.com/relative/path" without having to rebuild it.
 
 ### Firebase
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1070,6 +1070,18 @@ To override this, specify the `homepage` in your `package.json`, for example:
 
 This will let Create React App correctly infer the root path to use in the generated HTML file.
 
+#### Making builds deployable anywhere
+
+>Note: this feature is available with `react-scripts@0.9.0` and higher.
+
+If your are not using the HTML5 `pushState` history API or not using client-side routing at all, you do not have to specify the definitive URL of your application. Instead, you can put this in your `package.json`:
+
+```js
+  "homepage": "./",
+```
+
+This will make sure that all the assets are loaded relatively to the generated `index.html`, effectively allowing you to build your application once and deploy it anywhere.
+
 
 ### Firebase
 


### PR DESCRIPTION
The goal is to be able to set `homepage` in the `package.json` to `./` (or just `.`) to be able to deploy the app anywhere. This topic has already been mentioned in #1094, #931 and #165.

This PR will obviously not make this `homepage` "trick" works with client-side routing without hash but not everybody needs this feature anyway.

The only problem I saw when setting the `homepage` to `./` is #1480. This issue is caused by ExtractTextPlugin not supporting non-flat build output by default. To fix it, we can use the `publicPath` option of this plugin and go back to the build folder when needed.