### PR TITLE
Make build exit with error code when interrupted

### DIFF
--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -16,11 +16,13 @@ case 'test':
   if (result.signal) {
     if (result.signal == 'SIGKILL') {
       console.log(
+        'The build failed because the process exited too early. ' +
         'This probably means the system ran out of memory or someone called ' +
         '`kill -9` on the process.'
       );
     } else if (result.signal == 'SIGTERM') {
       console.log(
+        'The build failed because the process exited too early. ' +
         'Someone might have called `kill` or `killall`, or the system could ' +
         'be shutting down.'
       );

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -13,6 +13,20 @@ case 'test':
     [require.resolve('../scripts/' + script)].concat(args),
     {stdio: 'inherit'}
   );
+  if (result.signal) {
+    if (result.signal == 'SIGKILL') {
+      console.log(
+        'This probably means the system ran out of memory or someone called ' +
+        '`kill -9` on the process.'
+      );
+    } else if (result.signal == 'SIGTERM') {
+      console.log(
+        'Someone might have called `kill` or `killall`, or the system could ' +
+        'be shutting down.'
+      );
+    }
+    process.exit(1);
+  }
   process.exit(result.status);
   break;
 default:

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -235,8 +235,10 @@ function copyPublicFolder() {
 }
 
 process.on('SIGTERM', function () {
-  console.log('Build stopped by SIGTERM. This could mean someone that ' +
-      'killed the process (e.g. with `kill -15` or `killall`), that the ' +
-      'system is shutting down, or that it ran out of memory.');
+  console.log(
+    'Build stopped by SIGTERM. This could mean that someone killed the ' +
+    'process (e.g. with `kill -15` or `killall`), that the system is ' +
+    'shutting down, or that it ran out of memory.'
+  );
   process.exit(15);
 });

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -233,3 +233,15 @@ function copyPublicFolder() {
     filter: file => file !== paths.appHtml
   });
 }
+
+var signals = {
+  'SIGINT': 2,
+  'SIGTERM': 15
+};
+
+Object.keys(signals).forEach(function (signalName) {
+  process.on(signalName, function () {
+    console.log('Build stopped by ' + signalName);
+    process.exit(signals[signalName]);
+  });
+});

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -234,24 +234,9 @@ function copyPublicFolder() {
   });
 }
 
-var signals = [
-  {
-    name: 'SIGINT',
-    code: 2,
-    message: 'This usually means someone pressed Ctrl+C.'
-  },
-  {
-    name: 'SIGTERM',
-    code: 15,
-    message: 'This could mean someone that killed the process (e.g. with ' +
-      '`kill -15` or `killall`), that the system is shutting down, or that ' +
-      'it ran out of memory.'
-  }
-];
-
-signals.forEach(function (signal) {
-  process.on(signal.name, function () {
-    console.log('ERROR: Build stopped by ' + signal.name + '. ' + signal.message);
-    process.exit(signal.code);
-  });
+process.on('SIGTERM', function () {
+  console.log('Build stopped by SIGTERM. This could mean someone that ' +
+      'killed the process (e.g. with `kill -15` or `killall`), that the ' +
+      'system is shutting down, or that it ran out of memory.');
+  process.exit(15);
 });

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -234,14 +234,24 @@ function copyPublicFolder() {
   });
 }
 
-var signals = {
-  'SIGINT': 2,
-  'SIGTERM': 15
-};
+var signals = [
+  {
+    name: 'SIGINT',
+    code: 2,
+    message: 'This usually means someone pressed Ctrl+C.'
+  },
+  {
+    name: 'SIGTERM',
+    code: 15,
+    message: 'This could mean someone that killed the process (e.g. with ' +
+      '`kill -15` or `killall`), that the system is shutting down, or that ' +
+      'it ran out of memory.'
+  }
+];
 
-Object.keys(signals).forEach(function (signalName) {
-  process.on(signalName, function () {
-    console.log('Build stopped by ' + signalName);
-    process.exit(signals[signalName]);
+signals.forEach(function (signal) {
+  process.on(signal.name, function () {
+    console.log('ERROR: Build stopped by ' + signal.name + '. ' + signal.message);
+    process.exit(signal.code);
   });
 });

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -233,12 +233,3 @@ function copyPublicFolder() {
     filter: file => file !== paths.appHtml
   });
 }
-
-process.on('SIGTERM', function () {
-  console.log(
-    'Build stopped by SIGTERM. This could mean that someone killed the ' +
-    'process (e.g. with `kill -15` or `killall`), that the system is ' +
-    'shutting down, or that it ran out of memory.'
-  );
-  process.exit(15);
-});


### PR DESCRIPTION
This addresses issue #1493 

Current behavior is that `npm run build` exits code 0 without creating a bundle when interrupted. This change makes the build script catch catchable interruptions and exit with the appropriate error code.