### PR TITLE
Fix `test -e` with wildcard arguments.

### DIFF
--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -39,6 +39,13 @@ function handle_exit {
   exit
 }
 
+# Check for the existence of one or more files.
+function exists {
+  for f in $*; do
+    test -e "$f"
+  done
+}
+
 function create_react_app {
   node "$temp_cli_path"/node_modules/create-react-app/index.js $*
 }
@@ -86,7 +93,7 @@ create_react_app --scripts-version=0.4.0 test-app-version-number
 cd test-app-version-number
 
 # Check corresponding scripts version is installed.
-test -e node_modules/react-scripts
+exists node_modules/react-scripts
 grep '"version": "0.4.0"' node_modules/react-scripts/package.json
 
 # ******************************************************************************
@@ -98,7 +105,7 @@ create_react_app --scripts-version=https://registry.npmjs.org/react-scripts/-/re
 cd test-app-tarball-url
 
 # Check corresponding scripts version is installed.
-test -e node_modules/react-scripts
+exists node_modules/react-scripts
 grep '"version": "0.4.0"' node_modules/react-scripts/package.json
 
 # ******************************************************************************
@@ -110,7 +117,7 @@ create_react_app --scripts-version=react-scripts-fork test-app-fork
 cd test-app-fork
 
 # Check corresponding scripts version is installed.
-test -e node_modules/react-scripts-fork
+exists node_modules/react-scripts-fork
 
 # ******************************************************************************
 # Test nested folder path as the project name

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -43,6 +43,13 @@ function create_react_app {
   node "$temp_cli_path"/node_modules/create-react-app/index.js $*
 }
 
+# Check for the existence of one or more files.
+function exists {
+  for f in $*; do
+    test -e "$f"
+  done
+}
+
 # Exit the script with a helpful error message when any error is encountered
 trap 'set +x; handle_error $LINENO $BASH_COMMAND' ERR
 
@@ -116,8 +123,8 @@ npm link $root_path/packages/babel-preset-react-app
 # Test the build
 NODE_PATH=src REACT_APP_SHELL_ENV_MESSAGE=fromtheshell npm run build
 # Check for expected output
-test -e build/*.html
-test -e build/static/js/main.*.js
+exists build/*.html
+exists build/static/js/main.*.js
 
 # Unit tests
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
@@ -168,8 +175,8 @@ rm .babelrc
 # Test the build
 NODE_PATH=src REACT_APP_SHELL_ENV_MESSAGE=fromtheshell npm run build
 # Check for expected output
-test -e build/*.html
-test -e build/static/js/main.*.js
+exists build/*.html
+exists build/static/js/main.*.js
 
 # Unit tests
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -45,6 +45,13 @@ function create_react_app {
   node "$temp_cli_path"/node_modules/create-react-app/index.js $*
 }
 
+# Check for the existence of one or more files.
+function exists {
+  for f in $*; do
+    test -e "$f"
+  done
+}
+
 # Exit the script with a helpful error message when any error is encountered
 trap 'set +x; handle_error $LINENO $BASH_COMMAND' ERR
 
@@ -86,16 +93,16 @@ fi
 # Test local build command
 npm run build
 # Check for expected output
-test -e build/*.html
-test -e build/static/js/*.js
-test -e build/static/css/*.css
-test -e build/static/media/*.svg
-test -e build/favicon.ico
+exists build/*.html
+exists build/static/js/*.js
+exists build/static/css/*.css
+exists build/static/media/*.svg
+exists build/favicon.ico
 
 # Run tests with CI flag
 CI=true npm test
 # Uncomment when snapshot testing is enabled by default:
-# test -e template/src/__snapshots__/App.test.js.snap
+# exists template/src/__snapshots__/App.test.js.snap
 
 # Test local start command
 npm start -- --smoke-test
@@ -148,16 +155,16 @@ cd test-app
 # Test the build
 npm run build
 # Check for expected output
-test -e build/*.html
-test -e build/static/js/*.js
-test -e build/static/css/*.css
-test -e build/static/media/*.svg
-test -e build/favicon.ico
+exists build/*.html
+exists build/static/js/*.js
+exists build/static/css/*.css
+exists build/static/media/*.svg
+exists build/favicon.ico
 
 # Run tests with CI flag
 CI=true npm test
 # Uncomment when snapshot testing is enabled by default:
-# test -e src/__snapshots__/App.test.js.snap
+# exists src/__snapshots__/App.test.js.snap
 
 # Test the server
 npm start -- --smoke-test
@@ -178,11 +185,11 @@ npm link $root_path/packages/react-scripts
 # Test the build
 npm run build
 # Check for expected output
-test -e build/*.html
-test -e build/static/js/*.js
-test -e build/static/css/*.css
-test -e build/static/media/*.svg
-test -e build/favicon.ico
+exists build/*.html
+exists build/static/js/*.js
+exists build/static/css/*.css
+exists build/static/media/*.svg
+exists build/favicon.ico
 
 # Run tests, overring the watch option to disable it.
 # `CI=true npm test` won't work here because `npm test` becomes just `jest`.
@@ -190,7 +197,7 @@ test -e build/favicon.ico
 # `scripts/test.js` survive ejection (right now it doesn't).
 npm test -- --watch=no
 # Uncomment when snapshot testing is enabled by default:
-# test -e src/__snapshots__/App.test.js.snap
+# exists src/__snapshots__/App.test.js.snap
 
 # Test the server
 npm start -- --smoke-test


### PR DESCRIPTION
The `test` command fails with multiple arguments when given a unary operator such as '-e'. Add a function that can test one or more files by looping over all files.

Specifically, if I add another template asset (i.e. 404.html) the e2e scripts fail with "binary operator expected" because the glob expands to `test -e build/404.html build/index.html`.