### PR TITLE
Bump node 0.10 references to node 4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - TEST_SUITE=kitchensink
 matrix:
   include:
-    - node_js: 0.10
+    - node_js: 4
       env: TEST_SUITE=simple
     - node_js: 6
       env: USE_YARN=yes TEST_SUITE=simple

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -30,7 +30,7 @@
 // tell people to update their global version of create-react-app.
 //
 // Also be careful with new language features.
-// This file must work on Node 0.10+.
+// This file must work on Node 4+.
 //
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //   /!\ DO NOT MODIFY THIS FILE /!\


### PR DESCRIPTION
> Create React App requires Node 4 or higher.

Simply changing all reference of Node 0.10 -> Node 4.