### PR TITLE
Gracefully handle initial installation error (#1505)

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -202,7 +202,7 @@ function run(root, appName, version, verbose, originalDirectory, template) {
       var remainingFiles = fs.readdirSync(path.join(root));
       if (!remainingFiles.length) {
         // Delete target folder if empty
-        console.log('Deleting', chalk.cyan(appName), 'from', chalk.cyan(originalDirectory));
+        console.log('Deleting', chalk.cyan(appName + '/'), 'from', chalk.cyan(path.resolve(root, '..')));
         fs.removeSync(path.join(root));
       }
       console.log('Done.');

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -182,7 +182,30 @@ function run(root, appName, version, verbose, originalDirectory, template) {
 
   install(allDependencies, verbose, function(code, command, args) {
     if (code !== 0) {
-      console.error(chalk.cyan(command + ' ' + args.join(' ')) + ' failed');
+      console.log();
+      console.error('Aborting installation.', chalk.cyan(command + ' ' + args.join(' ')), 'has failed.');
+      // On 'exit' we will delete these files from target directory.
+      var knownGeneratedFiles = [
+        'package.json', 'npm-debug.log', 'yarn-error.log', 'yarn-debug.log', 'node_modules'
+      ];
+      var currentFiles = fs.readdirSync(path.join(root));
+      currentFiles.forEach(function (file) {
+        knownGeneratedFiles.forEach(function (fileToMatch) {
+          // This will catch `(npm-debug|yarn-error|yarn-debug).log*` files
+          // and the rest of knownGeneratedFiles.
+          if ((fileToMatch.match(/.log/g) && file.indexOf(fileToMatch) === 0) || file === fileToMatch) {
+            console.log('Deleting generated file...', chalk.cyan(file));
+            fs.removeSync(path.join(root, file));
+          }
+        });
+      });
+      var remainingFiles = fs.readdirSync(path.join(root));
+      if (!remainingFiles.length) {
+        // Delete target folder if empty
+        console.log('Deleting', chalk.cyan(appName), 'from', chalk.cyan(originalDirectory));
+        fs.removeSync(path.join(root));
+      }
+      console.log('Done.');
       process.exit(1);
     }
 

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -120,6 +120,32 @@ cd test-app-fork
 exists node_modules/react-scripts-fork
 
 # ******************************************************************************
+# Test project folder is deleted on failing package installation
+# ******************************************************************************
+
+cd $temp_app_path
+# we will install a non-existing package to simulate a failed installataion.
+create_react_app --scripts-version=`date +%s` test-app-should-not-exist || true
+# confirm that the project folder was deleted
+test ! -d test-app-should-not-exist
+
+# ******************************************************************************
+# Test project folder is not deleted when creating app over existing folder
+# ******************************************************************************
+
+cd $temp_app_path
+mkdir test-app-should-remain
+echo '## Hello' > ./test-app-should-remain/README.md
+# we will install a non-existing package to simulate a failed installataion.
+create_react_app --scripts-version=`date +%s` test-app-should-remain || true
+# confirm the file exist
+test -e test-app-should-remain/README.md
+# confirm only README.md is the only file in the directory
+if [ "$(ls -1 ./test-app-should-remain | wc -l | tr -d '[:space:]')" != "1" ]; then
+  false
+fi
+
+# ******************************************************************************
 # Test nested folder path as the project name
 # ******************************************************************************
 


### PR DESCRIPTION
As per #1505 
> Currently, when npm fails for the first time, you end up with an empty project that doesn't work.

> We should delete the broken files we added (or the whole folder if we created it), and print a message explaining the problem is with npm, as well as the underlying message.

* Print out message when problem occurs
* Delete project folder on errors