### PR TITLE
Don't run CI on Node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,5 @@ env:
     - TEST_SUITE=kitchensink
 matrix:
   include:
-    - node_js: 0.10
-      env: TEST_SUITE=simple
     - node_js: 6
       env: USE_YARN=yes TEST_SUITE=simple


### PR DESCRIPTION
It's out of maintenance and we already broke it by updating Lerna version which is incompatible.
So might as well stop testing that we gracefully crash in it.