### PR TITLE
Tweak syntax doc

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -176,7 +176,7 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 ## Supported Language Features and Polyfills
 
 This project supports a superset of the latest JavaScript standard.  
-In addition to [ES6](https://leanpub.com/understandinges6/read) syntax features, it also supports:
+In addition to [ES6](https://github.com/lukehoban/es6features) syntax features, it also supports:
 
 * [Exponentiation Operator](https://github.com/rwaldron/exponentiation-operator) (ES2016).
 * [Async/await](https://github.com/tc39/ecmascript-asyncawait) (ES2017).

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -175,12 +175,14 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 
 ## Supported Language Features and Polyfills
 
-This project supports a superset of the latest JavaScript standard, which includes async and await.  
-In addition to ES2017, it also supports:
+This project supports a superset of the latest JavaScript standard.  
+In addition to [ES6](https://leanpub.com/understandinges6/read) syntax features, it also supports:
 
-* [JSX](https://facebook.github.io/react/docs/introducing-jsx.html) and [Flow](https://flowtype.org/) syntax.
-* [Class Fields and Static Properties](https://github.com/tc39/proposal-class-public-fields) (stage 2 proposal).
+* [Exponentiation Operator](https://github.com/rwaldron/exponentiation-operator) (ES2016).
+* [Async/await](https://github.com/tc39/ecmascript-asyncawait) (ES2017).
 * [Object Rest/Spread Properties](https://github.com/sebmarkbage/ecmascript-rest-spread) (stage 3 proposal).
+* [Class Fields and Static Properties](https://github.com/tc39/proposal-class-public-fields) (stage 2 proposal).
+* [JSX](https://facebook.github.io/react/docs/introducing-jsx.html) and [Flow](https://flowtype.org/) syntax.
 
 Learn more about [different proposal stages](https://babeljs.io/docs/plugins/#presets-stage-x-experimental-presets-).
 


### PR DESCRIPTION
I'd like to avoid using "ES2017" as the baseline because nobody knows what it means.
Seriously, there's so much confusion that it's just not a good way of framing the doc IMO.

Instead, I propose using ES6 as the baseline (since that's the big update that's well-known), and add individual syntax features in a list (both stable and proposed). At some point we can reset the baseline but I think for now it's nice to be explicit.