### PR TITLE
Enable page reloading for files in `public/`

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -252,6 +252,10 @@ connection.onmessage = function(e) {
   case 'ok':
     handleSuccess();
     break;
+  case 'content-changed':
+    // Triggered when a file from `contentBase` changed.
+    window.location.reload();
+    break;
   case 'warnings':
     handleWarnings(message.data);
     break;

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -249,6 +249,8 @@ function runDevServer(host, port, protocol) {
     // for some reason broken when imported through Webpack. If you just want to
     // use an image, put it in `src` and `import` it from JavaScript instead.
     contentBase: paths.appPublic,
+    // By default files from `contentBase` will not trigger a page reload.
+    watchContentBase: true,
     // Enable hot reloading server. It will provide /sockjs-node/ endpoint
     // for the WebpackDevServer client so it can learn when the files were
     // updated. The WebpackDevServer client is included as an entry point


### PR DESCRIPTION
This makes files in the `public/` folder reload the page when they change.

Test plan:
- create a project;
- start the project with `npm start`;
- modify something in `public/index.html`, for example the `<title>`;
- hit save;
- verify that the page has reloaded and the title has changed.

Fixes #656, fixes #1508