### PR TITLE
Bump `recursive-readdir`.

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -56,7 +56,7 @@
     "postcss-loader": "1.2.2",
     "promise": "7.1.1",
     "react-dev-utils": "^0.5.0",
-    "recursive-readdir": "2.1.0",
+    "recursive-readdir": "2.1.1",
     "strip-ansi": "3.0.1",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",


### PR DESCRIPTION
`recurisve-readir` released a patch bump to bump `minimatch` to a version that dedupes with the common `minimatch@3.0.3`.  Checks off an item on #1183.
It'll be like 80% less significant after #1490, but this way I can at least pretend to be useful.