### PR TITLE
Allow --scripts-version git urls

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -212,6 +212,11 @@ function getPackageName(installPackage) {
     // The package name could be with or without semver version, e.g. react-scripts-0.2.0-alpha.1.tgz
     // However, this function returns package name only without semver version.
     return installPackage.match(/^.+\/(.+?)(?:-\d+.+)?\.tgz$/)[1];
+  } else if (installPackage.indexOf('git+') === 0) {
+    // Pull package name out of git urls e.g:
+    // git+https://github.com/mycompany/react-scripts.git
+    // git+ssh://github.com/mycompany/react-scripts.git#v1.2.3
+    return installPackage.match(/([^\/]+)\.git(#.*)?$/)[1];
   } else if (installPackage.indexOf('@') > 0) {
     // Do not match @scope/ when stripping off @version or @tag
     return installPackage.charAt(0) + installPackage.substr(1).split('@')[0];


### PR DESCRIPTION
We maintain a psuedo-fork of react-scripts at https://github.com/firstlookmedia/react-scripts (it only matches the general structure). It seems desirable from #682 to be able to use git repos as the argument to `--scripts-version` -- if some company wants to keep its fork private, this avoids requiring a private npm account. This PR makes that possible:

(https)

```shell
create-react-app --scripts-version=git+https://github.com/firstlookmedia/react-scripts.git#init myapp
```

or (ssh)

```shell
create-react-app --scripts-version=git+ssh://git@github.com/firstlookmedia/react-scripts.git myapp
```

---

Note that this requires the `react-scripts` package being hoisted to its own git repo.

---

Note also we haven't yet implemented the `init.js` script (the `init` branch above will work with this method but won't setup the boilerplate).