### PR TITLE
Switch from Neo to Neutrino

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If you don’t agree with the choices made in this project, you might want to ex
 Some of the more popular and actively maintained ones are:
 
 * [insin/nwb](https://github.com/insin/nwb)
-* [mozilla/neo](https://github.com/mozilla/neo)
+* [Mozilla's Neutrino + neutrino-preset-react](https://neutrino.js.org)
 * [NYTimes/kyt](https://github.com/NYTimes/kyt)
 * [zeit/next.js](https://github.com/zeit/next.js)
 * [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby)

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If you don’t agree with the choices made in this project, you might want to ex
 Some of the more popular and actively maintained ones are:
 
 * [insin/nwb](https://github.com/insin/nwb)
-* [Mozilla's Neutrino + neutrino-preset-react](https://neutrino.js.org)
+* [mozilla-neutrino/neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev)
 * [NYTimes/kyt](https://github.com/NYTimes/kyt)
 * [zeit/next.js](https://github.com/zeit/next.js)
 * [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby)


### PR DESCRIPTION
We've moved away from active Neo development, instead transitioning to a more generic approach by coupling our Webpack wrapper Neutrino with a preset for building React apps: [neutrino-preset-react](https://www.npmjs.com/package/neutrino-preset-react).