### PR TITLE
replace mozilla/neo with neutrino

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If you don’t agree with the choices made in this project, you might want to ex
 Some of the more popular and actively maintained ones are:
 
 * [insin/nwb](https://github.com/insin/nwb)
-* [mozilla/neo](https://github.com/mozilla/neo)
+* [neutrino](https://neutrino.js.org)
 * [NYTimes/kyt](https://github.com/NYTimes/kyt)
 * [zeit/next.js](https://github.com/zeit/next.js)
 * [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby)


### PR DESCRIPTION
The mozilla/neo project states that it was deprecated and replaced with neutrino.