### PR TITLE
(feat): add webpack validation error logging

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -135,7 +135,6 @@ function build(previousSizeMap) {
   console.log('Creating an optimized production build...');
 
   var compiler;
-
   try {
     compiler = webpack(config);
   } catch (err) {

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -138,9 +138,8 @@ function build(previousSizeMap) {
 
   try {
     compiler = webpack(config);
-  }
-  catch(err) {
-    printErrors('Failed to configure webpack.', [err]);
+  } catch (err) {
+    printErrors('Failed to compile.', [err]);
     process.exit(1);
   }
 

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -133,7 +133,18 @@ function printErrors(summary, errors) {
 // Create the production build and print the deployment instructions.
 function build(previousSizeMap) {
   console.log('Creating an optimized production build...');
-  webpack(config).run((err, stats) => {
+
+  var compiler;
+
+  try {
+    compiler = webpack(config);
+  }
+  catch(err) {
+    printErrors('Failed to configure webpack.', [err]);
+    process.exit(1);
+  }
+
+  compiler.run((err, stats) => {
     if (err) {
       printErrors('Failed to compile.', [err]);
       process.exit(1);

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -65,9 +65,8 @@ function setupCompiler(host, port, protocol) {
   // It lets us listen to some events and provide our own custom messages.
   try {
     compiler = webpack(config, handleCompile);
-  }
-  catch(err) {
-    console.log(chalk.red('Failed to setup webpack'));
+  } catch (err) {
+    console.log(chalk.red('Failed to compile.'));
     console.log();
     console.log(err.message || err);
     console.log();

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -63,7 +63,16 @@ if (isSmokeTest) {
 function setupCompiler(host, port, protocol) {
   // "Compiler" is a low-level interface to Webpack.
   // It lets us listen to some events and provide our own custom messages.
-  compiler = webpack(config, handleCompile);
+  try {
+    compiler = webpack(config, handleCompile);
+  }
+  catch(err) {
+    console.log(chalk.red('Failed to setup webpack'));
+    console.log();
+    console.log(err.message || err);
+    console.log();
+    process.exit(1);
+  }
 
   // "invalid" event fires when you have changed a file, and Webpack is
   // recompiling a bundle. WebpackDevServer takes care to pause serving the


### PR DESCRIPTION
Webpack validates the configuration during setup. If there are problems detected, it will throw a validation error. The problem is, that the build and start scripts don't print the messages.

Main cause for this particular problem is when users eject and modify the webpack config.

Only valid for webpack2 builds.

fixes https://github.com/facebookincubator/create-react-app/issues/1595

Error logging before this change: 
```
$ npm run build

> combined@1.0.0 build C:\Projects\combined
> node scripts/build.js

Creating an optimized production build...
C:\Projects\combined\node_modules\webpack\lib\webpack.js:19
                throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
                ^

Error
    at webpack (C:\Projects\combined\node_modules\webpack\lib\webpack.js:19:9)
    at build (C:\Projects\combined\scripts\build.js:125:3)
    at recursive (C:\Projects\combined\scripts\build.js:72:3)
    at C:\Projects\combined\node_modules\recursive-readdir\index.js:37:14
    at FSReqWrap.oncomplete (fs.js:111:15)
```

Error logging after this change:
```
$ npm run build

> combined@1.0.0 build C:\Projects\combined
> node scripts/build.js

Creating an optimized production build...
Failed to configure webpack.

Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration has an unknown property 'devtoo'. These properties are valid:
   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry, externals?, loader?, module?, name?, node?, output?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, stats?, target?, watch?, watchOptions? }
   For typos: please correct them.
   For loader options: webpack 2 no longer allows custom properties in configuration.
     Loaders should be updated to allow passing options via loader options in module.rules.
     Until loaders are updated one can use the LoaderOptionsPlugin to pass these options to the loader:
     plugins: [
       new webpack.LoaderOptionsPlugin({
         // test: /\.xxx$/, // may apply this only for some modules
         options: {
           devtoo: ...
         }
       })
     ]
 - configuration.resolve has an unknown property 'fallback'. These properties are valid:
   object { alias?, aliasFields?, cachePredicate?, descriptionFiles?, enforceExtension?, enforceModuleExtension?, extensions?, fileSystem?, mainFields?, mainFiles?, moduleExtensions?, modules?, plugins?, resolver?, symlinks?, unsafeCache?, useSyncFileSystemCalls? }
```

