### PR TITLE
Fix conflict file issue in IJ static web projects by adding web.iml to the exclusion list

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -273,7 +273,7 @@ function checkAppName(appName) {
 // https://github.com/facebookincubator/create-react-app/pull/368#issuecomment-243446094
 function isSafeToCreateProjectIn(root) {
   var validFiles = [
-    '.DS_Store', 'Thumbs.db', '.git', '.gitignore', '.idea', 'README.md', 'LICENSE'
+    '.DS_Store', 'Thumbs.db', '.git', '.gitignore', '.idea', 'README.md', 'LICENSE', 'web.iml'
   ];
   return fs.readdirSync(root)
     .every(function(file) {


### PR DESCRIPTION
To avoid file conflict issue with IJ static web projects.

This is related to issue #368. 
IJ static web project creates the file web.iml which also triggers the conflict file issue, as the .idea dir did.