### PR TITLE
Compile `react-native-` node modules

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -150,7 +150,10 @@ module.exports = {
       // Process JS with Babel.
       {
         test: /\.(js|jsx)$/,
-        include: paths.appSrc,
+        include: [
+          paths.appSrc,
+          /node_modules[\\\/]react-native-.*/
+        ],
         loader: 'babel-loader',
         options: {
           // @remove-on-eject-begin

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -157,7 +157,10 @@ module.exports = {
       // Process JS with Babel.
       {
         test: /\.(js|jsx)$/,
-        include: paths.appSrc,
+				include: [
+          paths.appSrc,
+          /node_modules[\\\/]react-native-.*/
+        ],
         loader: 'babel-loader',
         // @remove-on-eject-begin
         options: {


### PR DESCRIPTION
Right now people using this with [react-native-web](https://github.com/necolas/react-native-web) are unable to use any pure JS react-native modules becuase they usually use ES6 and JSX.

React-native's build tool passes all their modules through babel to let module authors use "the latest and greatest" in JS syntax. This tool. however, doesn't compile modules due to performance costs that that would incur.

Many react-native components seem to have names that start with `react-native-`. I think that a good compromise would be to compile these modules, this enabling react-native-web projects to use this tool to get up and running instantly without needing to eject in order to use dependencies, while at the same time having no real effect on existing projects that don't make use of `react-native-web`

Currently react-native-web is missing the easy to use tooling that's provided with react-native. This change could bring react-native-web development to about the same level and enable people to build hybrid projects faster.

I've currently got this running with [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) and am planning on using many more as time progresses.