### PR TITLE
Fix npm test on Windows

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -32,7 +32,7 @@ const createJestConfig = require('../utils/createJestConfig');
 const path = require('path');
 const paths = require('../config/paths');
 argv.push('--config', JSON.stringify(createJestConfig(
-  relativePath => path.posix.resolve(__dirname.replace(/[\\]+/g, path.posix.sep), '..', relativePath),
+  relativePath => path.resolve(__dirname, '..', relativePath),
   path.resolve(paths.appSrc, '..'),
   false
 )));


### PR DESCRIPTION
Should fix https://github.com/facebookincubator/create-react-app/issues/1645.

I haven't tested it but I won't have access to Windows until Monday so going to ninja-land it.

The reason I believe this is a fix is because #1635 should only have fixed a problem for ejecting. So I'm just rolling back the part that isn't relevant for ejecting (and that worked well before).