### PR TITLE
Set Chrome userDataDir to be under .vscode folder

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -269,7 +269,7 @@ Then add the block below to your `launch.json` file and put it inside the `.vsco
     "request": "launch",
     "url": "http://localhost:3000",
     "webRoot": "${workspaceRoot}/src",
-    "userDataDir": "${workspaceRoot}/.chrome",
+    "userDataDir": "${workspaceRoot}/.vscode/chrome",
     "sourceMapPathOverrides": {
       "webpack:///src/*": "${webRoot}/*"
     }


### PR DESCRIPTION
Addendum to #1540. Keeping `userDataDir` under `.vscode` folder honors common gitignore rules for VSCode.