### PR TITLE
Add overrideConfig option for the react-scripts test script

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -33,11 +33,9 @@ const createJestConfig = require('../utils/createJestConfig');
 const path = require('path');
 const paths = require('../config/paths');
 
-let overrideConfig;
+var overrideConfig;
 if ( overrideArg ) {
-  const parts = overrideArg.split('=');
-  overrideConfig = require(path.resolve(paths.appSrc, '..', parts[1]));
-  console.log('config is', overrideConfig.transformIgnorePatterns);
+  overrideConfig = require(path.resolve(paths.appSrc, '..', overrideArg.split('=')[1] ));
 }
 
 argv.push('--config', JSON.stringify(createJestConfig(

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -20,6 +20,7 @@ require('dotenv').config({silent: true});
 
 const jest = require('jest');
 const argv = process.argv.slice(2);
+const overrideArg = (process.argv.filter((i) => i.match('--overrideConfig')) || [])[0];
 
 // Watch unless on CI or in coverage mode
 if (!process.env.CI && argv.indexOf('--coverage') < 0) {
@@ -31,10 +32,19 @@ if (!process.env.CI && argv.indexOf('--coverage') < 0) {
 const createJestConfig = require('../utils/createJestConfig');
 const path = require('path');
 const paths = require('../config/paths');
+
+let overrideConfig;
+if ( overrideArg ) {
+  const parts = overrideArg.split('=');
+  overrideConfig = require(path.resolve(paths.appSrc, '..', parts[1]));
+  console.log('config is', overrideConfig.transformIgnorePatterns);
+}
+
 argv.push('--config', JSON.stringify(createJestConfig(
   relativePath => path.resolve(__dirname, '..', relativePath),
   path.resolve(paths.appSrc, '..'),
-  false
+  false,
+  overrideConfig
 )));
 // @remove-on-eject-end
 jest.run(argv);

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -156,6 +156,9 @@ You will also see any lint errors in the console.
 Launches the test runner in the interactive watch mode.<br>
 See the section about [running tests](#running-tests) for more information.
 
+You can add your own test configuration by specifying a json file using '--overrideConfig'.
+This will also override existing react-scripts configuration.
+
 ### `npm run build`
 
 Builds the app for production to the `build` folder.<br>

--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -12,7 +12,7 @@
 const fs = require('fs');
 const paths = require('../config/paths');
 
-module.exports = (resolve, rootDir, isEjecting) => {
+module.exports = (resolve, rootDir, isEjecting, overrides) => {
   // Use this instead of `paths.testsSetup` to avoid putting
   // an absolute filename into configuration after ejecting.
   const setupTestsFile = fs.existsSync(paths.testsSetup) ? '<rootDir>/src/setupTests.js' : undefined;
@@ -45,5 +45,12 @@ module.exports = (resolve, rootDir, isEjecting) => {
   if (rootDir) {
     config.rootDir = rootDir;
   }
+
+  if( overrides ) {
+    Object.keys(overrides).forEach((k) => {
+      config[k] = overrides[k];
+    });
+  }
+
   return config;
 };


### PR DESCRIPTION
Hey all, new contributor here. While I'm really enjoying all of the greatness that this project has to offer, I've run up against a few issues when it comes to testing that would be easily solved by adding my own jest configuration.

Unfortunately the jest configuration appears to be inaccessible to the user, so this branch attempts to allow the user the ability to configure this as needed. From what I understand, I could add my own config by `ejecting` the react-scripts, but that seems a little too heavy handed.

I also understand that this might go against the core value of 'convention over configuration', so if you'd prefer to avoid this approach, that's fine too.

In particular, I've been following along with jest not running tests inside of `/src/node_modules`. In my case, I'm also getting import errors `SyntaxError: Unexpected token import` during testing that is resolved by adding 

```
  "transformIgnorePatterns": [
    "<rootDir>/(node_modules)/"
  ]
```

to the jest config. But I don't see any way of adding my own config options to the jest config at the present time. (If there is, I'd definitely appreciate that feedback).

Thanks!

**Usage**

you can define your own config options in a json file
`config.json`

```
{
    "transformIgnorePatterns": [
    "<rootDir>/(node_modules)/"
  ]
}
```

You can then specify that json file in `package.json`

```
"test": "react-scripts test --env=jsdom  --overrideConfig=config.json",
```

the options will be merged with (and can override) the existing configuration options