### PR TITLE
removing un-necessary link within Readme

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1,7 +1,6 @@
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
 
-Below you will find some information on how to perform common tasks.<br>
-You can find the most recent version of this guide [here](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md).
+Below you will find some information on how to perform common tasks.
 
 ## Table of Contents
 


### PR DESCRIPTION
The link to the most recent version of the guide is redundant, as it links back to the same file.