### PR TITLE
add project name validation

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -39,6 +39,7 @@
 'use strict';
 
 var chalk = require('chalk');
+var validateProjectName = require("validate-npm-package-name");
 
 var currentNodeVersion = process.versions.node;
 if (currentNodeVersion.split('.')[0] < 4) {
@@ -95,6 +96,14 @@ if (typeof projectName === 'undefined') {
   console.log();
   console.log('Run ' + chalk.cyan(program.name() + ' --help') + ' to see all options.');
   process.exit(1);
+}
+
+function printValidationResults(results) {
+  if (typeof results !== 'undefined') {
+    results.forEach(function (error) {
+      console.error('  ' + error);
+    });
+  }
 }
 
 var hiddenProgram = new commander.Command()
@@ -307,6 +316,14 @@ function checkAppName(appName) {
   var dependencies = ['react', 'react-dom'];
   var devDependencies = ['react-scripts'];
   var allDependencies = dependencies.concat(devDependencies).sort();
+
+  var validationResult = validateProjectName(appName);
+  if (!validationResult.validForNewPackages) {
+    console.error('We cannot create a project called ' + chalk.green(appName) + ' because the name does not match npm naming restrictions:');
+    printValidationResults(validationResult.errors);
+    printValidationResults(validationResult.warnings);
+    process.exit(1);
+  }
 
   if (allDependencies.indexOf(appName) >= 0) {
     console.error(

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -101,7 +101,7 @@ if (typeof projectName === 'undefined') {
 function printValidationResults(results) {
   if (typeof results !== 'undefined') {
     results.forEach(function (error) {
-      console.error('  ' + error);
+      console.error(chalk.red('  * ' + error));
     });
   }
 }
@@ -312,19 +312,18 @@ function checkNodeVersion(packageName) {
 }
 
 function checkAppName(appName) {
-  // TODO: there should be a single place that holds the dependencies
-  var dependencies = ['react', 'react-dom'];
-  var devDependencies = ['react-scripts'];
-  var allDependencies = dependencies.concat(devDependencies).sort();
-
   var validationResult = validateProjectName(appName);
   if (!validationResult.validForNewPackages) {
-    console.error('We cannot create a project called ' + chalk.green(appName) + ' because the name does not match npm naming restrictions:');
+    console.error('Could not create a project called ' + chalk.red('"' + appName + '"') + ' because of npm naming restrictions:');
     printValidationResults(validationResult.errors);
     printValidationResults(validationResult.warnings);
     process.exit(1);
   }
-
+  
+  // TODO: there should be a single place that holds the dependencies
+  var dependencies = ['react', 'react-dom'];
+  var devDependencies = ['react-scripts'];
+  var allDependencies = dependencies.concat(devDependencies).sort();
   if (allDependencies.indexOf(appName) >= 0) {
     console.error(
       chalk.red(

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -24,6 +24,7 @@
     "commander": "^2.9.0",
     "cross-spawn": "^4.0.0",
     "fs-extra": "^1.0.0",
-    "semver": "^5.0.3"
+    "semver": "^5.0.3",
+    "validate-npm-package-name": "^3.0.0"
   }
 }


### PR DESCRIPTION
Could be a potential fix for #1649

The main idea is to validate the project name to meet the npm specification. If the validation fails detailed error information is provided to resolve the issue.

``` 
$ node ./create-react-app/packages/create-react-app/index.js "   asdf:asdf asdfasdf asdföjk asdlöfj alösdfjk aölsdfkjalö sdfjkalösdkfj öalsdkfjalös dfdklö jasdlöfj asödlfjasl
ö dfkjaslödfkj asdlöfjkaslöd fkjasdlöfjaslö dfjasöldfjasöldfjk aösdlfj aölsdfjasdf asdf SAD asdfasdfasdf asdfasdfa sdfasdäfk äasdfjklö asdfjlö aksdjfölasjd fölaksdfjölasj dfö
laksdfj  DSD~"
The project name    asdf:asdf asdfasdf asdföjk asdlöfj alösdfjk aölsdfkjalö sdfjkalösdkfj öalsdkfjalös dfdklö jasdlöfj asödlfjaslö dfkjaslödfkj asdlöfjkaslöd fkjasdlöfjaslö dfjasöldfjasöldfjk aösdlfj aölsdfjasdf asdf SAD asdfasdfasdf asdfasdfa sdfasdäfk äasdfjklö asdfjlö aksdjfölasjd fölaksdfjölasj dfölaksdfj  DSD~ is not valid:
  name cannot contain leading or trailing spaces
  name can only contain URL-friendly characters
  name can no longer contain more than 214 characters
  name can no longer contain capital letters
  name can no longer contain special characters ("~'!()*")
```