### PR TITLE
Revert "Enable eslint caching in development"

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -114,14 +114,13 @@ module.exports = {
         test: /\.(js|jsx)$/,
         enforce: 'pre',
         use: [{
+          // @remove-on-eject-begin
+          // Point ESLint to our predefined config.
           options: {
-            // @remove-on-eject-begin
-            // Point ESLint to our predefined config.
             configFile: path.join(__dirname, '../.eslintrc'),
-            useEslintrc: false,
-            // @remove-on-eject-end
-            cache: true
+            useEslintrc: false
           },
+          // @remove-on-eject-end
           loader: 'eslint-loader'
         }],
         include: paths.appSrc


### PR DESCRIPTION
Reverts facebookincubator/create-react-app#1578.

As I mentioned in https://github.com/facebookincubator/create-react-app/issues/1656#issuecomment-282608398, `eslint-loader` caching code does not have proper error handling, causing failures when used together with Yarn.