### PR TITLE
fix react dependency versions during initial install

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -212,8 +212,9 @@ function run(root, appName, version, verbose, originalDirectory, template) {
     checkNodeVersion(packageName);
 
     // Since react-scripts has been installed with --save
-    // We need to move it into devDependencies and rewrite package.json
-    moveReactScriptsToDev(packageName);
+    // we need to move it into devDependencies and rewrite package.json
+    // also ensure react dependencies have caret version range
+    fixDependencies(packageName);
 
     var scriptsPath = path.resolve(
       process.cwd(),
@@ -325,7 +326,24 @@ function checkAppName(appName) {
   }
 }
 
-function moveReactScriptsToDev(packageName) {
+function patchReactDependencyVersion(name, version) {
+  if (typeof version === 'undefined') {
+    console.error(
+      chalk.red('Missing ' + name + ' dependency in package.json')
+    );
+    process.exit(1);
+  }
+  var patchedVersion = '^' + version;
+  if (!semver.validRange(patchedVersion)) {
+    console.error(
+      'Unable to patch ' + name + ' dependency version because version ' + chalk.red(version) + ' will become invalid ' + chalk.red(patchedVersion)
+    );
+    patchedVersion = version;
+  }
+  return patchedVersion;
+}
+
+function fixDependencies(packageName) {
   var packagePath = path.join(process.cwd(), 'package.json');
   var packageJson = require(packagePath);
 
@@ -348,6 +366,9 @@ function moveReactScriptsToDev(packageName) {
   packageJson.devDependencies = packageJson.devDependencies || {};
   packageJson.devDependencies[packageName] = packageVersion;
   delete packageJson.dependencies[packageName];
+
+  packageJson.dependencies['react'] = patchReactDependencyVersion('react', packageJson.dependencies['react']);
+  packageJson.dependencies['react-dom'] = patchReactDependencyVersion('react-dom', packageJson.dependencies['react-dom']);
 
   fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2));
 }

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -326,21 +326,26 @@ function checkAppName(appName) {
   }
 }
 
-function patchReactDependencyVersion(name, version) {
+function makeCaretRange(dependencies, name) {
+  var version = dependencies[name];
+
   if (typeof version === 'undefined') {
     console.error(
       chalk.red('Missing ' + name + ' dependency in package.json')
     );
     process.exit(1);
   }
+
   var patchedVersion = '^' + version;
+
   if (!semver.validRange(patchedVersion)) {
     console.error(
       'Unable to patch ' + name + ' dependency version because version ' + chalk.red(version) + ' will become invalid ' + chalk.red(patchedVersion)
     );
     patchedVersion = version;
   }
-  return patchedVersion;
+
+  dependencies[name] = patchedVersion;
 }
 
 function fixDependencies(packageName) {
@@ -367,8 +372,8 @@ function fixDependencies(packageName) {
   packageJson.devDependencies[packageName] = packageVersion;
   delete packageJson.dependencies[packageName];
 
-  packageJson.dependencies['react'] = patchReactDependencyVersion('react', packageJson.dependencies['react']);
-  packageJson.dependencies['react-dom'] = patchReactDependencyVersion('react-dom', packageJson.dependencies['react-dom']);
+  makeCaretRange(packageJson.dependencies, 'react');
+  makeCaretRange(packageJson.dependencies, 'react-dom');
 
   fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2));
 }


### PR DESCRIPTION
Possible fix for #1663

This change will patch the package.json dependencies for `react` and `react-dom` after the successfull installation. A caret will be prepanded and afterwards validated if a valid semver version range is the result.