### PR TITLE
add X-FORWARDED headers for proxy requests

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -220,7 +220,8 @@ function addMiddleware(devServer) {
       onError: onProxyError(proxy),
       secure: false,
       changeOrigin: true,
-      ws: true
+      ws: true,
+      xfwd: true
     });
     devServer.use(mayProxy, hpm);
 


### PR DESCRIPTION
fix for #1676

The change will configure the proxy middleware to send X-FORWARDED-* headers.