### PR TITLE
Fixes #1684 when installing with yarn online

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -163,9 +163,13 @@ function install(useYarn, dependencies, verbose, isOnline) {
       command = 'yarnpkg';
       args = [
         'add',
-        '--exact',
-        isOnline === false && '--offline'
-      ].concat(dependencies);
+        '--exact'
+      ];
+
+      if (isOnline === false)
+        args.append('--offline');
+
+      args = args.concat(dependencies);
 
       if (!isOnline) {
         console.log(chalk.yellow('You appear to be offline.'));


### PR DESCRIPTION
This was a quick fix of #1684 which i used to create a new project and the `"false" : "0.0.4"` dependency was gone.