### PR TITLE
Fixed missing --recursive flag in first `npm run watch-css` command

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -428,7 +428,7 @@ Then in `package.json`, add the following lines to `scripts`:
 ```diff
    "scripts": {
 +    "build-css": "node-sass src/ -o src/",
-+    "watch-css": "npm run build-css && node-sass src/ -o src/ --watch",
++    "watch-css": "npm run build-css && node-sass src/ -o src/ --watch --recursive",
      "start": "react-scripts start",
      "build": "react-scripts build",
      "test": "react-scripts test --env=jsdom",


### PR DESCRIPTION
The first `package.json` change doesn't have the `--recursive` flag that is included in the later example where it updates the `start, `build`, and `start-js` commands. This pr would update it so it matches this [line](https://github.com/facebookincubator/create-react-app/compare/master...mklemme:patch-1#diff-4e6ec56f74ee42069aac401a4fe448adR456).

