### PR TITLE
pin and upgrade lerna version

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.37",
+  "lerna": "2.0.0-beta.38",
   "version": "independent",
   "changelog": {
     "repo": "facebookincubator/create-react-app",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-import": "2.0.1",
     "eslint-plugin-jsx-a11y": "2.2.3",
     "eslint-plugin-react": "6.4.1",
-    "lerna": "^2.0.0-beta.37",
+    "lerna": "2.0.0-beta.38",
     "lerna-changelog": "^0.2.3"
   }
 }


### PR DESCRIPTION
Lerna just released a new version here https://github.com/lerna/lerna/releases/tag/v2.0.0-beta.38
But I encountered this error after deleting yarn.lock and node_modules and tried to install again.
```
yarn
yarn install v0.21.3
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
$ lerna bootstrap
Lerna v2.0.0-beta.38
Independent Versioning Mode
Lerna version mismatch: The current version of lerna is 2.0.0-beta.38, but the Lerna version in `lerna.json` is 2.0.0-beta.37. You can either run `lerna init` again or install `lerna@2.0.0-beta.37`.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
I don't know if we should upgrade to 2.0.0-beta.38 or just stay with 2.0.0-beta.37 in lerna.json?