### PR TITLE
Fix openBrowser() when BROWSER=open on macOS

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -50,10 +50,16 @@ function openBrowser(url) {
     }
   }
 
+  // On OS X, check if BROWSER has been set to "open",
+  // and if so, do not pass it to the opn() options.
+  const isBrowserValid = !(
+    process.platform === 'darwin' && browser === 'open'
+  );
+
   // Fallback to opn
   // (It will always open new tab)
   try {
-    var options = {app: browser};
+    var options = {app: isBrowserValid? browser : ''};
     opn(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {

--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -17,7 +17,7 @@ function openBrowser(url) {
   // Attempt to honor this environment variable.
   // It is specific to the operating system.
   // See https://github.com/sindresorhus/opn#app for documentation.
-  const browser = process.env.BROWSER;
+  let browser = process.env.BROWSER;
 
   // Special case: BROWSER="none" will prevent opening completely.
   if (browser === 'none') {
@@ -50,16 +50,18 @@ function openBrowser(url) {
     }
   }
 
-  // On OS X, check if BROWSER has been set to "open",
-  // and if so, do not pass it to the opn() options.
-  const isBrowserValid = !(
-    process.platform === 'darwin' && browser === 'open'
-  );
-
+  // Another special case: on OS X, check if BROWSER has been set to "open".
+  // In this case, instead of passing `open` to `opn` (which won't work),
+  // just ignore it (thus ensuring the intended behavior, i.e. opening the system browser):
+  // https://github.com/facebookincubator/create-react-app/pull/1690#issuecomment-283518768
+  if (process.platform === 'darwin' && browser === 'open') {
+    browser = undefined;
+  }
+  
   // Fallback to opn
   // (It will always open new tab)
   try {
-    var options = {app: isBrowserValid? browser : ''};
+    var options = {app: browser};
     opn(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {


### PR DESCRIPTION
On OS X, the `BROWSER` environment variable can be set to `open` to open the default browser.

In this case, the value should not be passed to `opn()` as a `browser` option. Doing so would pass it to the `open` command using the `-a` parameter and not do anything:

<img width="314" alt="image" src="https://cloud.githubusercontent.com/assets/36158/23480278/465e6b08-febf-11e6-8fdb-54d00a9b1422.png">

This change passes an empty string in this situation. I added `isBrowserValid` to make it clearer and to make it easy to add other cases in the future.