### PR TITLE
add double quotes to escape spaces in paths in e2e

### DIFF
--- a/tasks/cra.sh
+++ b/tasks/cra.sh
@@ -52,7 +52,7 @@ root_path=$PWD
 # ******************************************************************************
 
 # Install all our packages
-$root_path/node_modules/.bin/lerna bootstrap
+"$root_path"/node_modules/.bin/lerna bootstrap
 
 cd packages/react-scripts
 
@@ -61,10 +61,10 @@ cp package.json package.json.orig
 
 # Replace own dependencies (those in the `packages` dir) with the local paths
 # of those packages.
-node $root_path/tasks/replace-own-deps.js
+node "$root_path"/tasks/replace-own-deps.js
 
 # Finally, pack react-scripts
-scripts_path=$root_path/packages/react-scripts/`npm pack`
+scripts_path="$root_path"/packages/react-scripts/`npm pack`
 
 # Restore package.json
 rm package.json
@@ -79,8 +79,8 @@ mv package.json.orig package.json
 yarn cache clean || true
 
 # Go back to the root directory and run the command from here
-cd $root_path
-node packages/create-react-app/index.js --scripts-version=$scripts_path "$@"
+cd "$root_path"
+node packages/create-react-app/index.js --scripts-version="$scripts_path" "$@"
 
 # Cleanup
 cleanup

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -21,8 +21,8 @@ temp_app_path=`mktemp -d 2>/dev/null || mktemp -d -t 'temp_app_path'`
 
 function cleanup {
   echo 'Cleaning up.'
-  cd $root_path
-  rm -rf $temp_cli_path $temp_app_path
+  cd "$root_path"
+  rm -rf "$temp_cli_path" "$temp_app_path"
 }
 
 # Error messages are redirected to stderr
@@ -77,18 +77,18 @@ fi
 # ******************************************************************************
 
 # Pack CLI
-cd $root_path/packages/create-react-app
+cd "$root_path"/packages/create-react-app
 cli_path=$PWD/`npm pack`
 
 # Install the CLI in a temporary location
-cd $temp_cli_path
-npm install $cli_path
+cd "$temp_cli_path"
+npm install "$cli_path"
 
 # ******************************************************************************
 # Test --scripts-version with a version number
 # ******************************************************************************
 
-cd $temp_app_path
+cd "$temp_app_path"
 create_react_app --scripts-version=0.4.0 test-app-version-number
 cd test-app-version-number
 
@@ -100,7 +100,7 @@ grep '"version": "0.4.0"' node_modules/react-scripts/package.json
 # Test --scripts-version with a tarball url
 # ******************************************************************************
 
-cd $temp_app_path
+cd "$temp_app_path"
 create_react_app --scripts-version=https://registry.npmjs.org/react-scripts/-/react-scripts-0.4.0.tgz test-app-tarball-url
 cd test-app-tarball-url
 
@@ -112,7 +112,7 @@ grep '"version": "0.4.0"' node_modules/react-scripts/package.json
 # Test --scripts-version with a custom fork of react-scripts
 # ******************************************************************************
 
-cd $temp_app_path
+cd "$temp_app_path"
 create_react_app --scripts-version=react-scripts-fork test-app-fork
 cd test-app-fork
 
@@ -123,7 +123,7 @@ exists node_modules/react-scripts-fork
 # Test project folder is deleted on failing package installation
 # ******************************************************************************
 
-cd $temp_app_path
+cd "$temp_app_path"
 # we will install a non-existing package to simulate a failed installataion.
 create_react_app --scripts-version=`date +%s` test-app-should-not-exist || true
 # confirm that the project folder was deleted
@@ -133,7 +133,7 @@ test ! -d test-app-should-not-exist
 # Test project folder is not deleted when creating app over existing folder
 # ******************************************************************************
 
-cd $temp_app_path
+cd "$temp_app_path"
 mkdir test-app-should-remain
 echo '## Hello' > ./test-app-should-remain/README.md
 # we will install a non-existing package to simulate a failed installataion.
@@ -150,7 +150,7 @@ fi
 # ******************************************************************************
 
 #Testing a path that exists
-cd $temp_app_path
+cd "$temp_app_path"
 mkdir test-app-nested-paths-t1
 cd test-app-nested-paths-t1
 mkdir -p test-app-nested-paths-t1/aa/bb/cc/dd
@@ -159,13 +159,13 @@ cd test-app-nested-paths-t1/aa/bb/cc/dd
 npm start -- --smoke-test
 
 #Testing a path that does not exist
-cd $temp_app_path
+cd "$temp_app_path"
 create_react_app test-app-nested-paths-t2/aa/bb/cc/dd
 cd test-app-nested-paths-t2/aa/bb/cc/dd
 npm start -- --smoke-test
 
 #Testing a path that is half exists
-cd $temp_app_path
+cd "$temp_app_path"
 mkdir -p test-app-nested-paths-t3/aa
 create_react_app test-app-nested-paths-t3/aa/bb/cc/dd
 cd test-app-nested-paths-t3/aa/bb/cc/dd

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -22,9 +22,9 @@ temp_app_path=`mktemp -d 2>/dev/null || mktemp -d -t 'temp_app_path'`
 function cleanup {
   echo 'Cleaning up.'
   ps -ef | grep 'react-scripts' | grep -v grep | awk '{print $2}' | xargs kill -s 9
-  cd $root_path
+  cd "$root_path"
   # TODO: fix "Device or resource busy" and remove ``|| $CI`
-  rm -rf $temp_cli_path $temp_app_path || $CI
+  rm -rf "$temp_cli_path" $temp_app_path || $CI
 }
 
 # Error messages are redirected to stderr
@@ -42,7 +42,7 @@ function handle_exit {
 }
 
 function create_react_app {
-  node "$temp_cli_path"/node_modules/create-react-app/index.js $*
+  node "$temp_cli_path"/node_modules/create-react-app/index.js "$@"
 }
 
 # Check for the existence of one or more files.
@@ -79,21 +79,21 @@ fi
 # ******************************************************************************
 
 # Pack CLI
-cd $root_path/packages/create-react-app
+cd "$root_path"/packages/create-react-app
 cli_path=$PWD/`npm pack`
 
 # Go to react-scripts
-cd $root_path/packages/react-scripts
+cd "$root_path"/packages/react-scripts
 
 # Save package.json because we're going to touch it
 cp package.json package.json.orig
 
 # Replace own dependencies (those in the `packages` dir) with the local paths
 # of those packages.
-node $root_path/tasks/replace-own-deps.js
+node "$root_path"/tasks/replace-own-deps.js
 
 # Finally, pack react-scripts
-scripts_path=$root_path/packages/react-scripts/`npm pack`
+scripts_path="$root_path"/packages/react-scripts/`npm pack`
 
 # Restore package.json
 rm package.json
@@ -104,12 +104,12 @@ mv package.json.orig package.json
 # ******************************************************************************
 
 # Install the CLI in a temporary location
-cd $temp_cli_path
-npm install $cli_path
+cd "$temp_cli_path"
+npm install "$cli_path"
 
 # Install the app in a temporary location
 cd $temp_app_path
-create_react_app --scripts-version=$scripts_path --internal-testing-template=$root_path/packages/react-scripts/fixtures/kitchensink test-kitchensink
+create_react_app --scripts-version="$scripts_path" --internal-testing-template="$root_path"/packages/react-scripts/fixtures/kitchensink test-kitchensink
 
 # ******************************************************************************
 # Now that we used create-react-app to create an app depending on react-scripts,
@@ -120,7 +120,7 @@ create_react_app --scripts-version=$scripts_path --internal-testing-template=$ro
 cd test-kitchensink
 
 # Link to our preset
-npm link $root_path/packages/babel-preset-react-app
+npm link "$root_path"/packages/babel-preset-react-app
 
 # Test the build
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
@@ -172,16 +172,16 @@ E2E_FILE=./build/index.html \
 # ******************************************************************************
 
 # Unlink our preset
-npm unlink $root_path/packages/babel-preset-react-app
+npm unlink "$root_path"/packages/babel-preset-react-app
 
 # Eject...
 echo yes | npm run eject
 
 # ...but still link to the local packages
-npm link $root_path/packages/babel-preset-react-app
-npm link $root_path/packages/eslint-config-react-app
-npm link $root_path/packages/react-dev-utils
-npm link $root_path/packages/react-scripts
+npm link "$root_path"/packages/babel-preset-react-app
+npm link "$root_path"/packages/eslint-config-react-app
+npm link "$root_path"/packages/react-dev-utils
+npm link "$root_path"/packages/react-scripts
 
 # Test the build
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -42,7 +42,7 @@ function handle_exit {
 }
 
 function create_react_app {
-  node "$temp_cli_path"/node_modules/create-react-app/index.js $*
+  node "$temp_cli_path"/node_modules/create-react-app/index.js "$@"
 }
 
 # Check for the existence of one or more files.

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -21,10 +21,10 @@ temp_app_path=`mktemp -d 2>/dev/null || mktemp -d -t 'temp_app_path'`
 
 function cleanup {
   echo 'Cleaning up.'
-  cd $root_path
+  cd "$root_path"
   # Uncomment when snapshot testing is enabled by default:
   # rm ./packages/react-scripts/template/src/__snapshots__/App.test.js.snap
-  rm -rf $temp_cli_path $temp_app_path
+  rm -rf "$temp_cli_path" $temp_app_path
 }
 
 # Error messages are redirected to stderr
@@ -126,21 +126,21 @@ npm start -- --smoke-test
 # ******************************************************************************
 
 # Pack CLI
-cd $root_path/packages/create-react-app
+cd "$root_path"/packages/create-react-app
 cli_path=$PWD/`npm pack`
 
 # Go to react-scripts
-cd $root_path/packages/react-scripts
+cd "$root_path"/packages/react-scripts
 
 # Save package.json because we're going to touch it
 cp package.json package.json.orig
 
 # Replace own dependencies (those in the `packages` dir) with the local paths
 # of those packages.
-node $root_path/tasks/replace-own-deps.js
+node "$root_path"/tasks/replace-own-deps.js
 
 # Finally, pack react-scripts
-scripts_path=$root_path/packages/react-scripts/`npm pack`
+scripts_path="$root_path"/packages/react-scripts/`npm pack`
 
 # Restore package.json
 rm package.json
@@ -151,12 +151,12 @@ mv package.json.orig package.json
 # ******************************************************************************
 
 # Install the CLI in a temporary location
-cd $temp_cli_path
-npm install $cli_path
+cd "$temp_cli_path"
+npm install "$cli_path"
 
 # Install the app in a temporary location
 cd $temp_app_path
-create_react_app --scripts-version=$scripts_path test-app
+create_react_app --scripts-version="$scripts_path" test-app
 
 # ******************************************************************************
 # Now that we used create-react-app to create an app depending on react-scripts,
@@ -243,10 +243,10 @@ verify_env_url
 echo yes | npm run eject
 
 # ...but still link to the local packages
-npm link $root_path/packages/babel-preset-react-app
-npm link $root_path/packages/eslint-config-react-app
-npm link $root_path/packages/react-dev-utils
-npm link $root_path/packages/react-scripts
+npm link "$root_path"/packages/babel-preset-react-app
+npm link "$root_path"/packages/eslint-config-react-app
+npm link "$root_path"/packages/react-dev-utils
+npm link "$root_path"/packages/react-scripts
 
 # Test the build
 npm run build

--- a/tasks/release.sh
+++ b/tasks/release.sh
@@ -39,6 +39,6 @@ if [ -n "$(git status --porcelain)" ]; then
   exit 1;
 fi
 
-cd $root_path
+cd "$root_path"
 # Go!
 ./node_modules/.bin/lerna publish --independent "$@"


### PR DESCRIPTION
Plans to fix https://github.com/facebookincubator/create-react-app/issues/1652
This happens when you clone create-react-app to a path where it has spaces in any of the parent foldes.

To test it, just rename your parent folder to something with spaces and run `npm run e2e`