### PR TITLE
Update now.sh deployment instructions.

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1493,7 +1493,7 @@ When you build the project, Create React App will place the `public` folder cont
 4. Run `now` from your project directory. You will see a **now.sh** URL in your output like this:
     
     ```
-    > Ready! https://aosa-features-tpspyhtdtk.now.sh (copied to clipboard)
+    > Ready! https://your-project-dirname-tpspyhtdtk.now.sh (copied to clipboard)
     ```
     
     Paste that URL into your browser when the build is complete, and you will see your deployed app.

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1478,7 +1478,27 @@ When you build the project, Create React App will place the `public` folder cont
 
 ### Now
 
-See [this example](https://github.com/xkawi/create-react-app-now) for a zero-configuration single-command deployment with [now](https://zeit.co/now).
+[now](https://zeit.co/now) offers a zero-configuration single-command deployment.
+
+1. Install the `now` command-line tool either via the recommended [desktop tool](https://zeit.co/download) or via node with `npm install -g now`.
+
+2. Install `serve` by running `npm install --save serve`.
+
+3. Add this line to `scripts` in `package.json`:
+    
+    ```
+    "now-start": "serve build/",
+    ```
+    
+4. Run `now` from your project directory. You will see a **now.sh** URL in your output like this:
+    
+    ```
+    > Ready! https://aosa-features-tpspyhtdtk.now.sh (copied to clipboard)
+    ```
+    
+    Paste that URL into your browser when the build is complete, and you will see your deployed app.
+
+Details are available in [this article.](https://zeit.co/blog/now-static)
 
 ### S3 and CloudFront
 


### PR DESCRIPTION
Incorporates changes announced at https://zeit.co/blog/now-static that streamline Now deployments from CRA projects.