### PR TITLE
Don't use ES6 in a file that should run on Node 4

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -17,7 +17,7 @@ function openBrowser(url) {
   // Attempt to honor this environment variable.
   // It is specific to the operating system.
   // See https://github.com/sindresorhus/opn#app for documentation.
-  let browser = process.env.BROWSER;
+  var browser = process.env.BROWSER;
 
   // Special case: BROWSER="none" will prevent opening completely.
   if (browser === 'none') {


### PR DESCRIPTION
Fixes a failure I introduced merging https://github.com/facebookincubator/create-react-app/pull/1690.