### PR TITLE
Lint internal scripts with eslint:recommended

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,16 @@
 {
-  "extends": "react-app"
+  "extends": "eslint:recommended",
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "node": true,
+    "es6": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
+  "rules": {
+    "no-console": "off",
+    "strict": ["error", "global"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,13 +11,7 @@
     "test": "node packages/react-scripts/scripts/test.js --env=jsdom"
   },
   "devDependencies": {
-    "babel-eslint": "7.1.0",
     "eslint": "3.16.1",
-    "eslint-config-react-app": "0.6.0",
-    "eslint-plugin-flowtype": "2.21.0",
-    "eslint-plugin-import": "2.0.1",
-    "eslint-plugin-jsx-a11y": "4.0.0",
-    "eslint-plugin-react": "6.4.1",
     "lerna": "2.0.0-beta.38",
     "lerna-changelog": "^0.2.3"
   }

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+'use strict';
+
 // Inspired by https://github.com/airbnb/javascript but less opinionated.
 
 // We use eslint-loader so even warnings are very visible.

--- a/packages/react-dev-utils/checkRequiredFiles.js
+++ b/packages/react-dev-utils/checkRequiredFiles.js
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+'use strict';
+
 var fs = require('fs');
 var path = require('path');
 var chalk = require('chalk');

--- a/packages/react-dev-utils/clearConsole.js
+++ b/packages/react-dev-utils/clearConsole.js
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+'use strict';
+
 function clearConsole() {
   process.stdout.write(process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H');
 }

--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+'use strict';
+
 // WARNING: this code is untranspiled and is used in browser too.
 // Please make sure any changes are in ES5 or contribute a Babel compile step.
 

--- a/packages/react-dev-utils/getProcessForPort.js
+++ b/packages/react-dev-utils/getProcessForPort.js
@@ -1,3 +1,14 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
 var chalk = require('chalk');
 var execSync = require('child_process').execSync;
 var path = require('path');

--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+'use strict';
+
 var execSync = require('child_process').execSync;
 var opn = require('opn');
 

--- a/packages/react-dev-utils/prompt.js
+++ b/packages/react-dev-utils/prompt.js
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+'use strict';
+
 var rl = require('readline');
 
 // Convention: "no" should be the conservative choice.
@@ -37,6 +39,6 @@ function prompt(question, isYesDefault) {
       return resolve(isYes);
     });
   });
-};
+}
 
 module.exports = prompt;

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+'use strict';
+
 // This alternative WebpackDevServer combines the functionality of:
 // https://github.com/webpack/webpack-dev-server/blob/webpack-1/client/index.js
 // https://github.com/webpack/webpack/blob/webpack-1/hot/dev-server.js
@@ -323,4 +325,4 @@ function tryApplyUpdates(onHotUpdateSuccess) {
       }
     );
   }
-};
+}

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -14,13 +14,13 @@ case 'test':
     {stdio: 'inherit'}
   );
   if (result.signal) {
-    if (result.signal == 'SIGKILL') {
+    if (result.signal === 'SIGKILL') {
       console.log(
         'The build failed because the process exited too early. ' +
         'This probably means the system ran out of memory or someone called ' +
         '`kill -9` on the process.'
       );
-    } else if (result.signal == 'SIGTERM') {
+    } else if (result.signal === 'SIGTERM') {
       console.log(
         'The build failed because the process exited too early. ' +
         'Someone might have called `kill` or `killall`, or the system could ' +

--- a/packages/react-scripts/fixtures/kitchensink/integration/initDOM.js
+++ b/packages/react-scripts/fixtures/kitchensink/integration/initDOM.js
@@ -15,7 +15,7 @@ if (process.env.E2E_FILE) {
   const markup = fs.readFileSync(file, 'utf8')
   getMarkup = () => markup
 
-  const pathPrefix = process.env.PUBLIC_URL.replace(/^https?:\/\/[^\/]+\/?/, '')
+  const pathPrefix = process.env.PUBLIC_URL.replace(/^https?:\/\/[^/]+\/?/, '')
 
   resourceLoader = (resource, callback) => callback(
     null,

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -97,7 +97,7 @@ then
 fi
 
 # Lint own code
-./node_modules/.bin/eslint --ignore-path .gitignore ./
+./node_modules/.bin/eslint --max-warnings 0 --ignore-path .gitignore ./
 
 # ******************************************************************************
 # First, test the create-react-app development environment.


### PR DESCRIPTION
It didn't make a lot of sense to use CRA's own linting setup because we're in a different environment (Node). It was also a pain to do this with our monorepo setup because we'd always trail a version behind. This seems much simpler and will hopefully unbreak master.