### PR TITLE
Relax ESLint config peerDependency

### DIFF
--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -15,7 +15,7 @@
     "eslint": "^3.16.1",
     "eslint-plugin-flowtype": "^2.21.0",
     "eslint-plugin-import": "^2.0.1",
-    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-jsx-a11y": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "eslint-plugin-react": "^6.4.1"
   }
 }


### PR DESCRIPTION
I'm not sure what's going on but it seems like Lerna breaks somewhere on Windows because `peerDependencies` are being checked too early or something.

Maybe this will help.