### PR TITLE
Stop watch process when process.stdin ends closes #1753

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -42,6 +42,11 @@ if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
   process.exit(1);
 }
 
+// Issue: https://github.com/facebookincubator/create-react-app/issues/1753
+// The below lines are added to make sure that this process is
+// exited when stdin is ended. The consequence of not doing this means
+// that all watch processes will stay running despite the process that spawned
+// them being closed.
 process.stdin.on('end', function() {
   process.exit(0);
 });

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -42,6 +42,11 @@ if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
   process.exit(1);
 }
 
+process.stdin.on('end', function() {
+  process.exit(0);
+});
+process.stdin.resume();
+
 // Tools like Cloud9 rely on this.
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
 

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -23,8 +23,20 @@ const jest = require('jest');
 const argv = process.argv.slice(2);
 
 // Watch unless on CI or in coverage mode
+// Exit process when stdin ends only when watch mode enabled
 if (!process.env.CI && argv.indexOf('--coverage') < 0) {
   argv.push('--watch');
+
+  // Issue: https://github.com/facebookincubator/create-react-app/issues/1753
+  // The below lines are added to make sure that this process is
+  // exited when stdin is ended. The consequence of not doing this means
+  // that all watch processes will stay running despite the process that spawned
+  // them being closed.
+
+  process.stdin.on('end', function() {
+    process.exit(0);
+  });
+  process.stdin.resume();
 }
 
 // @remove-on-eject-begin
@@ -44,8 +56,3 @@ argv.push(
 );
 // @remove-on-eject-end
 jest.run(argv);
-
-process.stdin.on('end', function() {
-  process.exit(0);
-});
-process.stdin.resume();

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -44,3 +44,8 @@ argv.push(
 );
 // @remove-on-eject-end
 jest.run(argv);
+
+process.stdin.on('end', function() {
+  process.exit(0);
+});
+process.stdin.resume();


### PR DESCRIPTION
### What has been done
* When `process.stdin` fires an `end` event, the process exits with a `0` exit code

### How has this been tested
* Started the app normally ✅ 
* Started the app when another app was already running (chose a new port) ✅ 
* Started the app via phoenix ✅ 
