### PR TITLE
Suggest `serve` for running in production

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -184,14 +184,14 @@ function build(previousFileSizes) {
       }
       const build = path.relative(process.cwd(), paths.appBuild);
       console.log(`The ${chalk.cyan(build)} folder is ready to be deployed.`);
-      console.log('You may also serve it locally with a static server:');
+      console.log('You may serve it with a static server:');
       console.log();
       if (useYarn) {
-        console.log(`  ${chalk.cyan('yarn')} global add pushstate-server`);
+        console.log(`  ${chalk.cyan('yarn')} global add serve`);
       } else {
-        console.log(`  ${chalk.cyan('npm')} install -g pushstate-server`);
+        console.log(`  ${chalk.cyan('npm')} install -g serve`);
       }
-      console.log(`  ${chalk.cyan('pushstate-server')} build`);
+      console.log(`  ${chalk.cyan('serve')} -s build`);
       console.log(
         `  ${chalk.cyan(openCommand)} http://localhost:${process.env.PORT || 9000}`
       );

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -193,7 +193,7 @@ function build(previousFileSizes) {
       }
       console.log(`  ${chalk.cyan('serve')} -s build`);
       console.log(
-        `  ${chalk.cyan(openCommand)} http://localhost:${process.env.PORT || 9000}`
+        `  ${chalk.cyan(openCommand)} http://localhost:${process.env.PORT || 3000}`
       );
       console.log();
     }

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -192,9 +192,6 @@ function build(previousFileSizes) {
         console.log(`  ${chalk.cyan('npm')} install -g serve`);
       }
       console.log(`  ${chalk.cyan('serve')} -s build`);
-      console.log(
-        `  ${chalk.cyan(openCommand)} http://localhost:${process.env.PORT || 3000}`
-      );
       console.log();
     }
   });

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -101,7 +101,6 @@ function build(previousFileSizes) {
     printFileSizesAfterBuild(stats, previousFileSizes);
     console.log();
 
-    const openCommand = process.platform === 'win32' ? 'start' : 'open';
     const appPackage = require(paths.appPackageJson);
     const publicUrl = paths.publicUrl;
     const publicPath = config.output.publicPath;

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1251,7 +1251,9 @@ app.get('/', function (req, res) {
 app.listen(9000);
 ```
 
-The choice of your server software isn't important either. Since `create-react-app` is completely platform-agnostic, there's no need to explicitly use Node. The `build` folder with static assets is the only output produced by Create React App.
+The choice of your server software isn't important either. Since `create-react-app` is completely platform-agnostic, there's no need to explicitly use Node.
+
+The `build` folder with static assets is the only output produced by Create React App.
 
 However this is not quite enough if you use client-side routing. Read the next section if you want to support URLs like `/todos/42` in your single-page app.
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1223,7 +1223,9 @@ npm install -g serve
 serve -s build
 ```
 
-The last command shown above will serve your static site on the port **3000**. Like many of [serve](https://github.com/zeit/serve)'s internal settings, the port can be adjusted using the `-p` or `--port` flags. Run this command to get a full list of the options available:
+The last command shown above will serve your static site on the port **3000**. Like many of [serve](https://github.com/zeit/serve)'s internal settings, the port can be adjusted using the `-p` or `--port` flags.
+
+Run this command to get a full list of the options available:
 
 ```sh
 serve -h

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -62,6 +62,8 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Developing Components in Isolation](#developing-components-in-isolation)
 - [Making a Progressive Web App](#making-a-progressive-web-app)
 - [Deployment](#deployment)
+  - [Node.js (Static)](#nodejs-static)
+  - [Other Platforms (+ Non-Static)](#other-platforms--non-static)
   - [Serving Apps with Client-Side Routing](#serving-apps-with-client-side-routing)
   - [Building for Relative Paths](#building-for-relative-paths)
   - [Azure](#azure)
@@ -1210,7 +1212,26 @@ You can turn your React app into a [Progressive Web App](https://developers.goog
 
 ## Deployment
 
-`npm run build` creates a `build` directory with a production build of your app. Set up your favourite HTTP server so that a visitor to your site is served `index.html`, and requests to static paths like `/static/js/main.<hash>.js` are served with the contents of the `/static/js/main.<hash>.js` file. For example, Python contains a built-in HTTP server that can serve static files:
+`npm run build` creates a `build` directory with a production build of your app. Set up your favourite HTTP server so that a visitor to your site is served `index.html`, and requests to static paths like `/static/js/main.<hash>.js` are served with the contents of the `/static/js/main.<hash>.js` file.
+
+### Node.js (Static)
+
+For environments using Node.js, the easiest way to handle this would be to install [serve](https://github.com/zeit/serve) and let it handle the rest:
+
+```sh
+npm install -g serve
+serve -s build
+```
+
+The last command shown above will serve your static site on the port **3000**. Like many of [serve](https://github.com/zeit/serve)'s internal settings, the port can be adjusted using the `-p` or `--port` flags. Run this command to get a full list of the options available:
+
+```sh
+serve -h
+```
+
+### Other Platforms (+ Non-Static)
+
+You don't necessarily need Node.js or a static webserver in order to run a `create-react-app` project in production. For example, Python contains a built-in HTTP server that can serve static files:
 
 ```sh
 cd build

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1216,14 +1216,14 @@ You can turn your React app into a [Progressive Web App](https://developers.goog
 
 ### Static Server
 
-For environments using Node.js, the easiest way to handle this would be to install [serve](https://github.com/zeit/serve) and let it handle the rest:
+For environments using [Node](https://nodejs.org/), the easiest way to handle this would be to install [serve](https://github.com/zeit/serve) and let it handle the rest:
 
 ```sh
 npm install -g serve
 serve -s build
 ```
 
-The last command shown above will serve your static site on the port **3000**. Like many of [serve](https://github.com/zeit/serve)'s internal settings, the port can be adjusted using the `-p` or `--port` flags.
+The last command shown above will serve your static site on the port **5000**. Like many of [serve](https://github.com/zeit/serve)’s internal settings, the port can be adjusted using the `-p` or `--port` flags.
 
 Run this command to get a full list of the options available:
 
@@ -1233,9 +1233,9 @@ serve -h
 
 ### Other Solutions
 
-You don't necessarily need a static server in order to run a `create-react-app` project in production. It works just as fine integrated into an existing dynamic one.
+You don’t necessarily need a static server in order to run a Create React App project in production. It works just as fine integrated into an existing dynamic one.
 
-Here's a programmatic example using [Node](https://nodejs.org/) and [Express](http://expressjs.com/):
+Here’s a programmatic example using [Node](https://nodejs.org/) and [Express](http://expressjs.com/):
 
 ```javascript
 const express = require('express');
@@ -1251,7 +1251,7 @@ app.get('/', function (req, res) {
 app.listen(9000);
 ```
 
-The choice of your server software isn't important either. Since `create-react-app` is completely platform-agnostic, there's no need to explicitly use Node.
+The choice of your server software isn’t important either. Since Create React App is completely platform-agnostic, there’s no need to explicitly use Node.
 
 The `build` folder with static assets is the only output produced by Create React App.
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -62,8 +62,8 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Developing Components in Isolation](#developing-components-in-isolation)
 - [Making a Progressive Web App](#making-a-progressive-web-app)
 - [Deployment](#deployment)
-  - [Node.js (Static)](#nodejs-static)
-  - [Other Platforms (+ Non-Static)](#other-platforms--non-static)
+  - [Static Server](#static-server)
+  - [Other Solutions](#other-solutions)
   - [Serving Apps with Client-Side Routing](#serving-apps-with-client-side-routing)
   - [Building for Relative Paths](#building-for-relative-paths)
   - [Azure](#azure)
@@ -1214,7 +1214,7 @@ You can turn your React app into a [Progressive Web App](https://developers.goog
 
 `npm run build` creates a `build` directory with a production build of your app. Set up your favourite HTTP server so that a visitor to your site is served `index.html`, and requests to static paths like `/static/js/main.<hash>.js` are served with the contents of the `/static/js/main.<hash>.js` file.
 
-### Node.js (Static)
+### Static Server
 
 For environments using Node.js, the easiest way to handle this would be to install [serve](https://github.com/zeit/serve) and let it handle the rest:
 
@@ -1231,16 +1231,11 @@ Run this command to get a full list of the options available:
 serve -h
 ```
 
-### Other Platforms (+ Non-Static)
+### Other Solutions
 
-You don't necessarily need Node.js or a static webserver in order to run a `create-react-app` project in production. For example, Python contains a built-in HTTP server that can serve static files:
+You don't necessarily need a static server in order to run a `create-react-app` project in production. It works just as fine integrated into an existing dynamic one.
 
-```sh
-cd build
-python -m SimpleHTTPServer 9000
-```
-
-If you’re using [Node](https://nodejs.org/) and [Express](http://expressjs.com/) as a server, it might look like this:
+Here's a programmatic example using [Node](https://nodejs.org/) and [Express](http://expressjs.com/):
 
 ```javascript
 const express = require('express');
@@ -1256,7 +1251,7 @@ app.get('/', function (req, res) {
 app.listen(9000);
 ```
 
-Create React App is not opinionated about your choice of web server. Any static file server will do. The `build` folder with static assets is the only output produced by Create React App.
+The choice of your server software isn't important either. Since `create-react-app` is completely platform-agnostic, there's no need to explicitly use Node. The `build` folder with static assets is the only output produced by Create React App.
 
 However this is not quite enough if you use client-side routing. Read the next section if you want to support URLs like `/todos/42` in your single-page app.
 


### PR DESCRIPTION
This PR introduces [serve](https://github.com/zeit/serve) as the new suggested way of handling `create-react-app` projects in production.

However, it also ensures that the docs clearly state that this is only a good idea inside Node.js environments. For all other platforms (or servers that aren't static-only), we still provide the user with a clear explanation of what to do in theses cases.

This closes https://github.com/facebookincubator/create-react-app/issues/1757.

How it looks:

![screen shot 2017-03-08 at 08 48 40](https://cloud.githubusercontent.com/assets/6170607/23694796/144a5466-03dc-11e7-9e38-c8c88bd0a035.png)
