### PR TITLE
disable ignoring unused vars prefixed with _

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -136,8 +136,6 @@ module.exports = {
     'no-unused-vars': [
       'warn',
       {
-        vars: 'local',
-        varsIgnorePattern: '^_',
         args: 'none',
         ignoreRestSiblings: true,
       },


### PR DESCRIPTION

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

In App.js file created an unused variable _x, eslint shows no-unused-vars error as expected
