### PR TITLE
Run CI on Node 7; Bump detect-port: 1.0.1 -> 1.1.0 (#1776)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - 4
   - 6
+  - 7
 cache:
   directories:
   - node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,11 @@
 environment:
   matrix:
+    - nodejs_version: 7
+      test_suite: "simple"
+    - nodejs_version: 7
+      test_suite: "installs"
+    - nodejs_version: 7
+      test_suite: "kitchensink"
     - nodejs_version: 6
       test_suite: "simple"
     - nodejs_version: 6

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -35,7 +35,7 @@
     "connect-history-api-fallback": "1.3.0",
     "cross-spawn": "4.0.2",
     "css-loader": "0.26.2",
-    "detect-port": "1.0.1",
+    "detect-port": "1.1.0",
     "dotenv": "2.0.0",
     "eslint": "3.16.1",
     "eslint-config-react-app": "^0.6.1",


### PR DESCRIPTION
Should fix UnhandledPromiseRejectionWarning on Node 7.7.2 (#1776)