### PR TITLE
Feature/1798 suggest yarn build

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -149,7 +149,7 @@ module.exports = function(
   console.log(chalk.cyan(`  ${displayedCommand} start`));
   console.log('    Starts the development server.');
   console.log();
-  console.log(chalk.cyan(`  ${displayedCommand} run build`));
+  console.log(chalk.cyan(`  ${displayedCommand} build`));
   console.log('    Bundles the app into static files for production.');
   console.log();
   console.log(chalk.cyan(`  ${displayedCommand} test`));

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -155,7 +155,7 @@ module.exports = function(
   console.log(chalk.cyan(`  ${displayedCommand} test`));
   console.log('    Starts the test runner.');
   console.log();
-  console.log(chalk.cyan(`  ${displayedCommand} run eject`));
+  console.log(chalk.cyan(`  ${displayedCommand} eject`));
   console.log(
     '    Removes this tool and copies build dependencies, configuration files'
   );

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -149,13 +149,17 @@ module.exports = function(
   console.log(chalk.cyan(`  ${displayedCommand} start`));
   console.log('    Starts the development server.');
   console.log();
-  console.log(chalk.cyan(`  ${displayedCommand} build`));
+  console.log(
+    chalk.cyan(`  ${displayedCommand} ${useYarn ? '' : 'run '}build`)
+  );
   console.log('    Bundles the app into static files for production.');
   console.log();
   console.log(chalk.cyan(`  ${displayedCommand} test`));
   console.log('    Starts the test runner.');
   console.log();
-  console.log(chalk.cyan(`  ${displayedCommand} eject`));
+  console.log(
+    chalk.cyan(`  ${displayedCommand} ${useYarn ? '' : 'run '}eject`)
+  );
   console.log(
     '    Removes this tool and copies build dependencies, configuration files'
   );


### PR DESCRIPTION
Fixes #1798 

---
Changed `packages/react-scripts/scripts/init.js` to suggest `yarn build` instead of `yarn run build`. 

As a bonus, I also changed `yarn run eject` to be `yarn eject`, in order to be consistent. I can change back if this is not desired.

Trial run of the `npm run create-react-app` script screenshot: ![Screenshot showing yarn build and yarn test](http://image.prntscr.com/image/e705dd0bb4b8443997c07c53cd677dbc.png)

Test results from `npm test`: ![Screenshot showing npm test results](http://image.prntscr.com/image/24d8b38a93ae459eb10e05add13f1c72.png)

I'll also note that the commit message for 9d080d3 is incorrect; it should read "remove 'run' from 'yarn eject' command as well".