### PR TITLE
Update now instructions to support html5 history

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1520,7 +1520,7 @@ When you build the project, Create React App will place the `public` folder cont
 3. Add this line to `scripts` in `package.json`:
     
     ```
-    "now-start": "serve build/",
+    "now-start": "serve --single build/",
     ```
     
 4. Run `now` from your project directory. You will see a **now.sh** URL in your output like this:

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1520,7 +1520,7 @@ When you build the project, Create React App will place the `public` folder cont
 3. Add this line to `scripts` in `package.json`:
     
     ```
-    "now-start": "serve --single build/",
+    "now-start": "serve -s build/",
     ```
     
 4. Run `now` from your project directory. You will see a **now.sh** URL in your output like this:


### PR DESCRIPTION
Passing the `--single` flag to ensure HTML5 history api support (for things like react router). 

<img width="743" alt="screenshot 2017-03-12 11 38 45" src="https://cloud.githubusercontent.com/assets/4060187/23833183/7b89b268-0718-11e7-92ae-a5fa7988da5b.png">