### PR TITLE
Allow creation of apps in empty mercurial repos

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -501,6 +501,7 @@ function isSafeToCreateProjectIn(root) {
     'README.md',
     'LICENSE',
     'web.iml',
+    '.hg',
   ];
   return fs.readdirSync(root).every(file => validFiles.indexOf(file) >= 0);
 }

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -503,6 +503,7 @@ function isSafeToCreateProjectIn(root) {
     'web.iml',
     '.hg',
     '.hgignore',
+    '.hgcheck',
   ];
   return fs.readdirSync(root).every(file => validFiles.indexOf(file) >= 0);
 }

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -502,6 +502,7 @@ function isSafeToCreateProjectIn(root) {
     'LICENSE',
     'web.iml',
     '.hg',
+    '.hgignore',
   ];
   return fs.readdirSync(root).every(file => validFiles.indexOf(file) >= 0);
 }


### PR DESCRIPTION
Currently create-react-app fails on newly created mercurial repos. This change fixes that.
