### PR TITLE
Updating the scripts to only execute when they are called directly.

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -33,24 +33,26 @@ const measureFileSizesBeforeBuild = FileSizeReporter.measureFileSizesBeforeBuild
 const printFileSizesAfterBuild = FileSizeReporter.printFileSizesAfterBuild;
 const useYarn = fs.existsSync(paths.yarnLockFile);
 
-// Warn and crash if required files are missing
-if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
-  process.exit(1);
+function main() {
+  // Warn and crash if required files are missing
+  if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
+    process.exit(1);
+  }
+
+  // First, read the current file sizes in build directory.
+  // This lets us display how much they changed later.
+  measureFileSizesBeforeBuild(paths.appBuild).then(previousFileSizes => {
+    // Remove all content but keep the directory so that
+    // if you're in it, you don't end up in Trash
+    fs.emptyDirSync(paths.appBuild);
+
+    // Start the webpack build
+    build(previousFileSizes);
+
+    // Merge with the public folder
+    copyPublicFolder();
+  });
 }
-
-// First, read the current file sizes in build directory.
-// This lets us display how much they changed later.
-measureFileSizesBeforeBuild(paths.appBuild).then(previousFileSizes => {
-  // Remove all content but keep the directory so that
-  // if you're in it, you don't end up in Trash
-  fs.emptyDirSync(paths.appBuild);
-
-  // Start the webpack build
-  build(previousFileSizes);
-
-  // Merge with the public folder
-  copyPublicFolder();
-});
 
 // Print out errors
 function printErrors(summary, errors) {
@@ -201,4 +203,10 @@ function copyPublicFolder() {
     dereference: true,
     filter: file => file !== paths.appHtml,
   });
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  main();
 }

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -20,176 +20,184 @@ const createJestConfig = require('./utils/createJestConfig');
 const green = chalk.green;
 const cyan = chalk.cyan;
 
-prompt(
-  'Are you sure you want to eject? This action is permanent.',
-  false
-).then(shouldEject => {
-  if (!shouldEject) {
-    console.log(cyan('Close one! Eject aborted.'));
-    process.exit(1);
-  }
-
-  console.log('Ejecting...');
-
-  const ownPath = paths.ownPath;
-  const appPath = paths.appPath;
-
-  function verifyAbsent(file) {
-    if (fs.existsSync(path.join(appPath, file))) {
-      console.error(
-        `\`${file}\` already exists in your app folder. We cannot ` +
-          'continue as you would lose all the changes in that file or directory. ' +
-          'Please move or delete it (maybe make a copy for backup) and run this ' +
-          'command again.'
-      );
+function main() {
+  prompt(
+    'Are you sure you want to eject? This action is permanent.',
+    false
+  ).then(shouldEject => {
+    if (!shouldEject) {
+      console.log(cyan('Close one! Eject aborted.'));
       process.exit(1);
     }
-  }
 
-  const folders = ['config', 'config/jest', 'scripts', 'scripts/utils'];
+    console.log('Ejecting...');
 
-  // Make shallow array of files paths
-  const files = folders.reduce(
-    (files, folder) => {
-      return files.concat(
-        fs
-          .readdirSync(path.join(ownPath, folder))
-          // set full path
-          .map(file => path.join(ownPath, folder, file))
-          // omit dirs from file list
-          .filter(file => fs.lstatSync(file).isFile())
-      );
-    },
-    []
-  );
+    const ownPath = paths.ownPath;
+    const appPath = paths.appPath;
 
-  // Ensure that the app folder is clean and we won't override any files
-  folders.forEach(verifyAbsent);
-  files.forEach(verifyAbsent);
-
-  console.log();
-  console.log(cyan(`Copying files into ${appPath}`));
-
-  folders.forEach(folder => {
-    fs.mkdirSync(path.join(appPath, folder));
-  });
-
-  files.forEach(file => {
-    let content = fs.readFileSync(file, 'utf8');
-
-    // Skip flagged files
-    if (content.match(/\/\/ @remove-file-on-eject/)) {
-      return;
+    function verifyAbsent(file) {
+      if (fs.existsSync(path.join(appPath, file))) {
+        console.error(
+          `\`${file}\` already exists in your app folder. We cannot ` +
+            'continue as you would lose all the changes in that file or directory. ' +
+            'Please move or delete it (maybe make a copy for backup) and run this ' +
+            'command again.'
+        );
+        process.exit(1);
+      }
     }
-    content = content
-      // Remove dead code from .js files on eject
-      .replace(
-        /\/\/ @remove-on-eject-begin([\s\S]*?)\/\/ @remove-on-eject-end/mg,
-        ''
-      )
-      // Remove dead code from .applescript files on eject
-      .replace(
-        /-- @remove-on-eject-begin([\s\S]*?)-- @remove-on-eject-end/mg,
-        ''
-      )
-      .trim() + '\n';
-    console.log(`  Adding ${cyan(file.replace(ownPath, ''))} to the project`);
-    fs.writeFileSync(file.replace(ownPath, appPath), content);
-  });
-  console.log();
 
-  const ownPackage = require(path.join(ownPath, 'package.json'));
-  const appPackage = require(path.join(appPath, 'package.json'));
-  const babelConfig = JSON.parse(
-    fs.readFileSync(path.join(ownPath, '.babelrc'), 'utf8')
-  );
-  const eslintConfig = JSON.parse(
-    fs.readFileSync(path.join(ownPath, '.eslintrc'), 'utf8')
-  );
+    const folders = ['config', 'config/jest', 'scripts', 'scripts/utils'];
 
-  console.log(cyan('Updating the dependencies'));
-  const ownPackageName = ownPackage.name;
-  if (appPackage.devDependencies[ownPackageName]) {
-    console.log(`  Removing ${cyan(ownPackageName)} from devDependencies`);
-    delete appPackage.devDependencies[ownPackageName];
-  }
-  if (appPackage.dependencies[ownPackageName]) {
-    console.log(`  Removing ${cyan(ownPackageName)} from dependencies`);
-    delete appPackage.dependencies[ownPackageName];
-  }
+    // Make shallow array of files paths
+    const files = folders.reduce(
+      (files, folder) => {
+        return files.concat(
+          fs
+            .readdirSync(path.join(ownPath, folder))
+            // set full path
+            .map(file => path.join(ownPath, folder, file))
+            // omit dirs from file list
+            .filter(file => fs.lstatSync(file).isFile())
+        );
+      },
+      []
+    );
 
-  Object.keys(ownPackage.dependencies).forEach(key => {
-    // For some reason optionalDependencies end up in dependencies after install
-    if (ownPackage.optionalDependencies[key]) {
-      return;
-    }
-    console.log(`  Adding ${cyan(key)} to devDependencies`);
-    appPackage.devDependencies[key] = ownPackage.dependencies[key];
-  });
-  console.log();
-  console.log(cyan('Updating the scripts'));
-  delete appPackage.scripts['eject'];
-  Object.keys(appPackage.scripts).forEach(key => {
-    Object.keys(ownPackage.bin).forEach(binKey => {
-      const regex = new RegExp(binKey + ' (\\w+)', 'g');
-      appPackage.scripts[key] = appPackage.scripts[key].replace(
-        regex,
-        'node scripts/$1.js'
-      );
-      console.log(
-        `  Replacing ${cyan(`"${binKey} ${key}"`)} with ${cyan(`"node scripts/${key}.js"`)}`
-      );
+    // Ensure that the app folder is clean and we won't override any files
+    folders.forEach(verifyAbsent);
+    files.forEach(verifyAbsent);
+
+    console.log();
+    console.log(cyan(`Copying files into ${appPath}`));
+
+    folders.forEach(folder => {
+      fs.mkdirSync(path.join(appPath, folder));
     });
-  });
 
-  console.log();
-  console.log(cyan('Configuring package.json'));
-  // Add Jest config
-  console.log(`  Adding ${cyan('Jest')} configuration`);
-  appPackage.jest = createJestConfig(
-    filePath => path.posix.join('<rootDir>', filePath),
-    null,
-    true
-  );
+    files.forEach(file => {
+      let content = fs.readFileSync(file, 'utf8');
 
-  // Add Babel config
-  console.log(`  Adding ${cyan('Babel')} preset`);
-  appPackage.babel = babelConfig;
+      // Skip flagged files
+      if (content.match(/\/\/ @remove-file-on-eject/)) {
+        return;
+      }
+      content = content
+        // Remove dead code from .js files on eject
+        .replace(
+          /\/\/ @remove-on-eject-begin([\s\S]*?)\/\/ @remove-on-eject-end/mg,
+          ''
+        )
+        // Remove dead code from .applescript files on eject
+        .replace(
+          /-- @remove-on-eject-begin([\s\S]*?)-- @remove-on-eject-end/mg,
+          ''
+        )
+        .trim() + '\n';
+      console.log(`  Adding ${cyan(file.replace(ownPath, ''))} to the project`);
+      fs.writeFileSync(file.replace(ownPath, appPath), content);
+    });
+    console.log();
 
-  // Add ESlint config
-  console.log(`  Adding ${cyan('ESLint')} configuration`);
-  appPackage.eslintConfig = eslintConfig;
+    const ownPackage = require(path.join(ownPath, 'package.json'));
+    const appPackage = require(path.join(appPath, 'package.json'));
+    const babelConfig = JSON.parse(
+      fs.readFileSync(path.join(ownPath, '.babelrc'), 'utf8')
+    );
+    const eslintConfig = JSON.parse(
+      fs.readFileSync(path.join(ownPath, '.eslintrc'), 'utf8')
+    );
 
-  fs.writeFileSync(
-    path.join(appPath, 'package.json'),
-    JSON.stringify(appPackage, null, 2) + '\n'
-  );
-  console.log();
-
-  // "Don't destroy what isn't ours"
-  if (ownPath.indexOf(appPath) === 0) {
-    try {
-      // remove react-scripts and react-scripts binaries from app node_modules
-      Object.keys(ownPackage.bin).forEach(binKey => {
-        fs.removeSync(path.join(appPath, 'node_modules', '.bin', binKey));
-      });
-      fs.removeSync(ownPath);
-    } catch (e) {
-      // It's not essential that this succeeds
+    console.log(cyan('Updating the dependencies'));
+    const ownPackageName = ownPackage.name;
+    if (appPackage.devDependencies[ownPackageName]) {
+      console.log(`  Removing ${cyan(ownPackageName)} from devDependencies`);
+      delete appPackage.devDependencies[ownPackageName];
     }
-  }
+    if (appPackage.dependencies[ownPackageName]) {
+      console.log(`  Removing ${cyan(ownPackageName)} from dependencies`);
+      delete appPackage.dependencies[ownPackageName];
+    }
 
-  if (fs.existsSync(paths.yarnLockFile)) {
-    console.log(cyan('Running yarn...'));
-    spawnSync('yarnpkg', [], { stdio: 'inherit' });
-  } else {
-    console.log(cyan('Running npm install...'));
-    spawnSync('npm', ['install'], { stdio: 'inherit' });
-  }
-  console.log(green('Ejected successfully!'));
-  console.log();
+    Object.keys(ownPackage.dependencies).forEach(key => {
+      // For some reason optionalDependencies end up in dependencies after install
+      if (ownPackage.optionalDependencies[key]) {
+        return;
+      }
+      console.log(`  Adding ${cyan(key)} to devDependencies`);
+      appPackage.devDependencies[key] = ownPackage.dependencies[key];
+    });
+    console.log();
+    console.log(cyan('Updating the scripts'));
+    delete appPackage.scripts['eject'];
+    Object.keys(appPackage.scripts).forEach(key => {
+      Object.keys(ownPackage.bin).forEach(binKey => {
+        const regex = new RegExp(binKey + ' (\\w+)', 'g');
+        appPackage.scripts[key] = appPackage.scripts[key].replace(
+          regex,
+          'node scripts/$1.js'
+        );
+        console.log(
+          `  Replacing ${cyan(`"${binKey} ${key}"`)} with ${cyan(`"node scripts/${key}.js"`)}`
+        );
+      });
+    });
 
-  console.log(green('Please consider sharing why you ejected in this survey:'));
-  console.log(green('  http://goo.gl/forms/Bi6CZjk1EqsdelXk1'));
-  console.log();
-});
+    console.log();
+    console.log(cyan('Configuring package.json'));
+    // Add Jest config
+    console.log(`  Adding ${cyan('Jest')} configuration`);
+    appPackage.jest = createJestConfig(
+      filePath => path.posix.join('<rootDir>', filePath),
+      null,
+      true
+    );
+
+    // Add Babel config
+    console.log(`  Adding ${cyan('Babel')} preset`);
+    appPackage.babel = babelConfig;
+
+    // Add ESlint config
+    console.log(`  Adding ${cyan('ESLint')} configuration`);
+    appPackage.eslintConfig = eslintConfig;
+
+    fs.writeFileSync(
+      path.join(appPath, 'package.json'),
+      JSON.stringify(appPackage, null, 2) + '\n'
+    );
+    console.log();
+
+    // "Don't destroy what isn't ours"
+    if (ownPath.indexOf(appPath) === 0) {
+      try {
+        // remove react-scripts and react-scripts binaries from app node_modules
+        Object.keys(ownPackage.bin).forEach(binKey => {
+          fs.removeSync(path.join(appPath, 'node_modules', '.bin', binKey));
+        });
+        fs.removeSync(ownPath);
+      } catch (e) {
+        // It's not essential that this succeeds
+      }
+    }
+
+    if (fs.existsSync(paths.yarnLockFile)) {
+      console.log(cyan('Running yarn...'));
+      spawnSync('yarnpkg', [], { stdio: 'inherit' });
+    } else {
+      console.log(cyan('Running npm install...'));
+      spawnSync('npm', ['install'], { stdio: 'inherit' });
+    }
+    console.log(green('Ejected successfully!'));
+    console.log();
+
+    console.log(green('Please consider sharing why you ejected in this survey:'));
+    console.log(green('  http://goo.gl/forms/Bi6CZjk1EqsdelXk1'));
+    console.log();
+  });
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  main();
+}

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -91,30 +91,38 @@ function run(port) {
   });
 }
 
-// We attempt to use the default port but if it is busy, we offer the user to
-// run on a different port. `detect()` Promise resolves to the next free port.
-detect(DEFAULT_PORT).then(port => {
-  if (port === DEFAULT_PORT) {
-    run(port);
-    return;
-  }
+function main() {
+  // We attempt to use the default port but if it is busy, we offer the user to
+  // run on a different port. `detect()` Promise resolves to the next free port.
+  detect(DEFAULT_PORT).then(port => {
+    if (port === DEFAULT_PORT) {
+      run(port);
+      return;
+    }
 
-  if (isInteractive) {
-    clearConsole();
-    const existingProcess = getProcessForPort(DEFAULT_PORT);
-    const question = chalk.yellow(
-      `Something is already running on port ${DEFAULT_PORT}.` +
-        `${existingProcess ? ` Probably:\n  ${existingProcess}` : ''}`
-    ) + '\n\nWould you like to run the app on another port instead?';
+    if (isInteractive) {
+      clearConsole();
+      const existingProcess = getProcessForPort(DEFAULT_PORT);
+      const question = chalk.yellow(
+        `Something is already running on port ${DEFAULT_PORT}.` +
+          `${existingProcess ? ` Probably:\n  ${existingProcess}` : ''}`
+      ) + '\n\nWould you like to run the app on another port instead?';
 
-    prompt(question, true).then(shouldChangePort => {
-      if (shouldChangePort) {
-        run(port);
-      }
-    });
-  } else {
-    console.log(
-      chalk.red(`Something is already running on port ${DEFAULT_PORT}.`)
-    );
-  }
-});
+      prompt(question, true).then(shouldChangePort => {
+        if (shouldChangePort) {
+          run(port);
+        }
+      });
+    } else {
+      console.log(
+        chalk.red(`Something is already running on port ${DEFAULT_PORT}.`)
+      );
+    }
+  });
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  main();
+}

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -20,27 +20,34 @@ process.env.PUBLIC_URL = '';
 require('dotenv').config({ silent: true });
 
 const jest = require('jest');
-const argv = process.argv.slice(2);
 
-// Watch unless on CI or in coverage mode
-if (!process.env.CI && argv.indexOf('--coverage') < 0) {
-  argv.push('--watch');
+function main(argv) {
+  // Watch unless on CI or in coverage mode
+  if (!process.env.CI && argv.indexOf('--coverage') < 0) {
+    argv.push('--watch');
+  }
+
+  // @remove-on-eject-begin
+  // This is not necessary after eject because we embed config into package.json.
+  const createJestConfig = require('./utils/createJestConfig');
+  const path = require('path');
+  const paths = require('../config/paths');
+  argv.push(
+    '--config',
+    JSON.stringify(
+      createJestConfig(
+        relativePath => path.resolve(__dirname, '..', relativePath),
+        path.resolve(paths.appSrc, '..'),
+        false
+      )
+    )
+  );
+  // @remove-on-eject-end
+  jest.run(argv);
 }
 
-// @remove-on-eject-begin
-// This is not necessary after eject because we embed config into package.json.
-const createJestConfig = require('./utils/createJestConfig');
-const path = require('path');
-const paths = require('../config/paths');
-argv.push(
-  '--config',
-  JSON.stringify(
-    createJestConfig(
-      relativePath => path.resolve(__dirname, '..', relativePath),
-      path.resolve(paths.appSrc, '..'),
-      false
-    )
-  )
-);
-// @remove-on-eject-end
-jest.run(argv);
+module.exports = main;
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}


### PR DESCRIPTION
In their current state, the scripts are cannot be imported without being immediately run. This change allows scripts to be imported and run directly. This change not only useful for creating custom script packages that wrap react-scripts, but is also a start toward making the scripts themselves testable.

``` javascript
const buildReact = require('react-scripts/scripts/build');

buildReact();
```

It would be nice to add the ability to pass options or custom config to the scripts, but I wanted to open this PR first and see where the discussion leads.