### PR TITLE
Customize the port for openBrowser

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -48,6 +48,8 @@ const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
 function run(port) {
   const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
   const host = process.env.HOST || 'localhost';
+  // The port on which the app will be browsed (in case the app is behind a proxy)
+  const publicPort = parseInt(process.env.PUBLIC_PORT, 10) || port;
 
   // Create a webpack compiler that is configured with custom messages.
   const compiler = createWebpackCompiler(
@@ -59,7 +61,7 @@ function run(port) {
       console.log();
       console.log('The app is running at:');
       console.log();
-      console.log(`  ${chalk.cyan(`${protocol}://${host}:${port}/`)}`);
+      console.log(`  ${chalk.cyan(`${protocol}://${host}:${publicPort}/`)}`);
       console.log();
       console.log('Note that the development build is not optimized.');
       console.log(
@@ -87,7 +89,7 @@ function run(port) {
     console.log(chalk.cyan('Starting the development server...'));
     console.log();
 
-    openBrowser(`${protocol}://${host}:${port}/`);
+    openBrowser(`${protocol}://${host}:${publicPort}/`);
   });
 }
 


### PR DESCRIPTION
Many times in local development, the port the app is listening on is not the same as the "public" port that the app is being locally tested on, particularly when the app consists of multiple, individually deployable modules intended to run under the same domain, some of which are data APIs.  In this case, it's inconvenient to have `start.js` open the browser to the port the app is listening on instead of the public port.

This file change supports the definition of a `PUBLIC_PORT` environment variable that will override the listening port when the `openBrowser` function is called.

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
