### PR TITLE
Makes end-to-end testing crash on unhandled rejections

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -13,7 +13,7 @@
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.NODE_ENV = 'production';
 
-// Makes end-to-end testing crash on unhandled rejections instead of silently
+// Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
 process.on('unhandledRejection', err => {

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -13,6 +13,13 @@
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.NODE_ENV = 'production';
 
+// Makes end-to-end testing crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  throw err;
+});
+
 // Load environment variables from .env file. Suppress warnings using silent
 // if this file is missing. dotenv will never modify any environment variables
 // that have already been set.

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -9,6 +9,13 @@
  */
 'use strict';
 
+// Makes end-to-end testing crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  throw err;
+});
+
 const fs = require('fs-extra');
 const path = require('path');
 const spawnSync = require('cross-spawn').sync;

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-// Makes end-to-end testing crash on unhandled rejections instead of silently
+// Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
 process.on('unhandledRejection', err => {

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -9,6 +9,13 @@
  */
 'use strict';
 
+// Makes end-to-end testing crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  throw err;
+});
+
 const fs = require('fs-extra');
 const path = require('path');
 const spawn = require('cross-spawn');

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-// Makes end-to-end testing crash on unhandled rejections instead of silently
+// Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
 process.on('unhandledRejection', err => {

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -10,6 +10,13 @@
 // @remove-on-eject-end
 'use strict';
 
+// Makes end-to-end testing crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  throw err;
+});
+
 process.env.NODE_ENV = 'development';
 
 // Load environment variables from .env file. Suppress warnings using silent

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -10,7 +10,7 @@
 // @remove-on-eject-end
 'use strict';
 
-// Makes end-to-end testing crash on unhandled rejections instead of silently
+// Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
 process.on('unhandledRejection', err => {

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -13,6 +13,13 @@
 process.env.NODE_ENV = 'test';
 process.env.PUBLIC_URL = '';
 
+// Makes end-to-end testing crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  throw err;
+});
+
 // Load environment variables from .env file. Suppress warnings using silent
 // if this file is missing. dotenv will never modify any environment variables
 // that have already been set.

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -13,7 +13,7 @@
 process.env.NODE_ENV = 'test';
 process.env.PUBLIC_URL = '';
 
-// Makes end-to-end testing crash on unhandled rejections instead of silently
+// Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
 process.on('unhandledRejection', err => {


### PR DESCRIPTION
This makes sure that end-to-end-testing crash when `scripts/*.js` run into an unhandled promise rejection as explained here https://github.com/facebookincubator/create-react-app/issues/1806#issuecomment-286146425.

This code has been added at the beginning of each script:

```javascript
process.on('unhandledRejection', err => {
  throw err;
});
```

### Before

Faulty `eject.js` fails silently.

<img width="1041" alt="before" src="https://cloud.githubusercontent.com/assets/5003380/23905113/525e6b46-08ca-11e7-824c-44cd8a91ab8c.png">
<img width="1027" alt="before 2" src="https://cloud.githubusercontent.com/assets/5003380/23905121/578060ca-08ca-11e7-81de-958eed928936.png">

### After

Faulty `eject.js` makes end-to-end testing crash.

<img width="947" alt="after" src="https://cloud.githubusercontent.com/assets/5003380/23904795/75f20ffa-08c9-11e7-820f-4832c52e10b0.png">

Note that the bug outlined above should be fixed by #1810.