### PR TITLE
Fix responsive behavior in iOS 9+

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -501,6 +501,7 @@ function isSafeToCreateProjectIn(root) {
     'README.md',
     'LICENSE',
     'web.iml',
+    '.hg',
   ];
   return fs.readdirSync(root).every(file => validFiles.indexOf(file) >= 0);
 }

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -503,6 +503,7 @@ function isSafeToCreateProjectIn(root) {
     'web.iml',
     '.hg',
     '.hgignore',
+    '.hgcheck',
   ];
   return fs.readdirSync(root).every(file => validFiles.indexOf(file) >= 0);
 }

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -502,6 +502,7 @@ function isSafeToCreateProjectIn(root) {
     'LICENSE',
     'web.iml',
     '.hg',
+    '.hgignore',
   ];
   return fs.readdirSync(root).every(file => validFiles.indexOf(file) >= 0);
 }

--- a/packages/react-scripts/template/public/index.html
+++ b/packages/react-scripts/template/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.


### PR DESCRIPTION
Adding _shirink-to-fit=no_ to ensure proper responsive behavior in iOS 9+

For more about why this is needed read _[The Problem with iOS Safari and shrink-to-fit](https://bitsofco.de/ios-safari-and-shrink-to-fit/)_