### PR TITLE
Added note & link to Client-Side-Routing in UserGuide.

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1437,6 +1437,7 @@ GitHub Pages doesn’t support routers that use the HTML5 `pushState` history AP
 
 * You could switch from using HTML5 history API to routing with hashes. If you use React Router, you can switch to `hashHistory` for this effect, but the URL will be longer and more verbose (for example, `http://user.github.io/todomvc/#/todos/42?_k=yknaj`). [Read more](https://github.com/reactjs/react-router/blob/master/docs/guides/Histories.md#histories) about different history implementations in React Router.
 * Alternatively, you can use a trick to teach GitHub Pages to handle 404 by redirecting to your `index.html` page with a special redirect parameter. You would need to add a `404.html` file with the redirection code to the `build` folder before deploying your project, and you’ll need to add code handling the redirect parameter to `index.html`. You can find a detailed explanation of this technique [in this guide](https://github.com/rafrex/spa-github-pages).
+* Use of `process.env.PUBLIC_URL` with `browserHistory` for matching root path of router to `homepage` can be seen & explained in this [repository](https://github.com/rockchalkwushock/CRA-gh-pages-deployment).
 
 ### Heroku
 
@@ -1518,17 +1519,17 @@ When you build the project, Create React App will place the `public` folder cont
 2. Install `serve` by running `npm install --save serve`.
 
 3. Add this line to `scripts` in `package.json`:
-    
+
     ```
     "now-start": "serve build/",
     ```
-    
+
 4. Run `now` from your project directory. You will see a **now.sh** URL in your output like this:
-    
+
     ```
     > Ready! https://your-project-dirname-tpspyhtdtk.now.sh (copied to clipboard)
     ```
-    
+
     Paste that URL into your browser when the build is complete, and you will see your deployed app.
 
 Details are available in [this article.](https://zeit.co/blog/now-static)


### PR DESCRIPTION
Updated notes on client-side-routing in UserGuide as per request from @gaearon in #1765. 

Link to repository being mentioned in UserGuide: [repo](https://github.com/rockchalkwushock/CRA-gh-pages-deployment)

Please advise if anything more is needed or incorrect for contributing...first time contributing on Github to a major project.