### PR TITLE
Added test to check for accidental extraneous dependencies

### DIFF
--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -140,7 +140,6 @@ cd test-app-fork
 
 # Check corresponding scripts version is installed.
 exists node_modules/react-scripts-fork
-checkDependencies
 
 # ******************************************************************************
 # Test project folder is deleted on failing package installation
@@ -151,7 +150,6 @@ cd "$temp_app_path"
 create_react_app --scripts-version=`date +%s` test-app-should-not-exist || true
 # confirm that the project folder was deleted
 test ! -d test-app-should-not-exist
-checkDependencies
 
 # ******************************************************************************
 # Test project folder is not deleted when creating app over existing folder
@@ -168,7 +166,6 @@ test -e test-app-should-remain/README.md
 if [ "$(ls -1 ./test-app-should-remain | wc -l | tr -d '[:space:]')" != "1" ]; then
   false
 fi
-checkDependencies
 
 # ******************************************************************************
 # Test --scripts-version with a scoped fork tgz of react-scripts
@@ -181,13 +178,12 @@ cd test-app-scoped-fork-tgz
 
 # Check corresponding scripts version is installed.
 exists node_modules/@enoah_netzach/react-scripts
-checkDependencies
 
 # ******************************************************************************
 # Test nested folder path as the project name
 # ******************************************************************************
 
-#Testing a path that exists
+# Testing a path that exists
 cd "$temp_app_path"
 mkdir test-app-nested-paths-t1
 cd test-app-nested-paths-t1
@@ -195,13 +191,14 @@ mkdir -p test-app-nested-paths-t1/aa/bb/cc/dd
 create_react_app test-app-nested-paths-t1/aa/bb/cc/dd
 cd test-app-nested-paths-t1/aa/bb/cc/dd
 npm start -- --smoke-test
-#Testing a path that does not exist
+
+# Testing a path that does not exist
 cd "$temp_app_path"
 create_react_app test-app-nested-paths-t2/aa/bb/cc/dd
 cd test-app-nested-paths-t2/aa/bb/cc/dd
 npm start -- --smoke-test
 
-#Testing a path that is half exists
+# Testing a path that is half exists
 cd "$temp_app_path"
 mkdir -p test-app-nested-paths-t3/aa
 create_react_app test-app-nested-paths-t3/aa/bb/cc/dd

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -85,6 +85,33 @@ cd "$temp_cli_path"
 npm install "$cli_path"
 
 # ******************************************************************************
+# Test for accidental dependencies
+# ******************************************************************************
+
+cd "$temp_app_path"
+create_react_app test-app-accidental-dependencies
+cd test-app-accidental-dependencies
+
+# Check if accidental extraneous dependencies are present
+# Only react, react-dom, react-scripts should be present
+if ! awk '/"dependencies": {/{y=1;next}/},/{y=0; next}y' package.json | \
+grep -v -q -E '^\s*"react(?:-dom|-scripts)?"'; then
+ echo "Dependencies are correct"
+else
+ echo "There are extraneous dependencies in package.json"
+ exit 1
+fi
+
+
+if ! awk '/"devDependencies": {/{y=1;next}/},/{y=0; next}y' package.json | \
+grep -v -q -E '^\s*"react(?:-dom|-scripts)?"'; then
+ echo "Dev Dependencies are correct"
+else
+ echo "There are extraneous devDependencies in package.json"
+ exit 1
+fi
+
+# ******************************************************************************
 # Test --scripts-version with a version number
 # ******************************************************************************
 
@@ -169,7 +196,6 @@ mkdir -p test-app-nested-paths-t1/aa/bb/cc/dd
 create_react_app test-app-nested-paths-t1/aa/bb/cc/dd
 cd test-app-nested-paths-t1/aa/bb/cc/dd
 npm start -- --smoke-test
-
 #Testing a path that does not exist
 cd "$temp_app_path"
 create_react_app test-app-nested-paths-t2/aa/bb/cc/dd

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -49,7 +49,7 @@ function exists {
 # Check for accidental dependencies in package.json
 function checkDependencies {
   if ! awk '/"dependencies": {/{y=1;next}/},/{y=0; next}y' package.json | \
-  grep -v -q -E '^\s*"react(?:-dom|-scripts)?"'; then
+  grep -v -q -E '^\s*"react(-dom|-scripts)?"'; then
    echo "Dependencies are correct"
   else
    echo "There are extraneous dependencies in package.json"
@@ -58,7 +58,7 @@ function checkDependencies {
 
 
   if ! awk '/"devDependencies": {/{y=1;next}/},/{y=0; next}y' package.json | \
-  grep -v -q -E '^\s*"react(?:-dom|-scripts)?"'; then
+  grep -v -q -E '^\s*"react(-dom|-scripts)?"'; then
    echo "Dev Dependencies are correct"
   else
    echo "There are extraneous devDependencies in package.json"


### PR DESCRIPTION
Fixes #1720 
It just checks package.json and check if includes `react, react-dom, react-scripts`, if other is found it will fail the test.
