### PR TITLE
Forbid using window properties as global variables

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -26,11 +26,19 @@ module.exports = {
   plugins: ['import', 'flowtype', 'jsx-a11y', 'react'],
 
   env: {
-    browser: true,
     commonjs: true,
     es6: true,
     jest: true,
     node: true,
+  },
+
+  globals: {
+    document: true,
+    window: true,
+    confirm: true,
+    alert: true,
+    localStorage: true,
+    sessionStorage: true,
   },
 
   parserOptions: {

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -35,10 +35,8 @@ module.exports = {
   globals: {
     document: true,
     window: true,
-    confirm: true,
-    alert: true,
-    localStorage: true,
-    sessionStorage: true,
+    console: true,
+    navigator: true
   },
 
   parserOptions: {

--- a/packages/react-scripts/fixtures/kitchensink/src/App.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/App.js
@@ -25,7 +25,7 @@ class BuiltEmitter extends Component {
   }
 
   handleReady() {
-    document.dispatchEvent(new Event('ReactFeatureDidMount'));
+    document.dispatchEvent(new window.Event('ReactFeatureDidMount'));
   }
 
   render() {
@@ -53,7 +53,7 @@ class App extends Component {
   }
 
   componentDidMount() {
-    const feature = location.hash.slice(1);
+    const feature = window.location.hash.slice(1);
     switch (feature) {
       case 'array-destructuring':
         import(

--- a/packages/react-scripts/fixtures/kitchensink/src/features/webpack/NoExtInclusion.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/features/webpack/NoExtInclusion.js
@@ -11,7 +11,7 @@ import React from 'react';
 import aFileWithoutExt from './assets/aFileWithoutExt';
 
 const text = aFileWithoutExt.includes('base64')
-  ? atob(aFileWithoutExt.split('base64,')[1]).trim()
+  ? window.atob(aFileWithoutExt.split('base64,')[1]).trim()
   : aFileWithoutExt;
 
 export default () => (

--- a/packages/react-scripts/fixtures/kitchensink/src/features/webpack/UnknownExtInclusion.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/features/webpack/UnknownExtInclusion.js
@@ -11,7 +11,7 @@ import React from 'react';
 import aFileWithExtUnknown from './assets/aFileWithExt.unknown';
 
 const text = aFileWithExtUnknown.includes('base64')
-  ? atob(aFileWithExtUnknown.split('base64,')[1]).trim()
+  ? window.atob(aFileWithExtUnknown.split('base64,')[1]).trim()
   : aFileWithExtUnknown;
 
 export default () => (


### PR DESCRIPTION
All the properties of window object such as `name`, `self`, and `status` are considered to be global variables because of having `browser` env in eslint config.
As a result this variables are ignored by eslint for errors such as `no-unused-vars` when someone uses this variables in their code without the intent of using them as a global variable.

To solve this we'd have to remove `browser` env  from eslint config and add a list of global variables that are more commonly used. Other window properties are not considered global and requires `window.` qualifier.

I have added a list of all variables that I think are commonly used as globals in browser env.
Please guide if I have missed something.

***How did I test this?***
I created a new app with 
`npm run create-react-app test-app`
`npm start`
Added `console.log(status)` to index.js file
And it showed error in terminal that `status` is not defined. (As expected)

But text-editors (Atom)  won't show this as it requires `eslint-config-react-app` to be installed globally and hence it becomes necessary to update that package globally for this to work.

closes #1834