### PR TITLE
Changed resolve into lookup

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -516,7 +516,7 @@ function checkIfOnline(useYarn) {
   }
 
   return new Promise(resolve => {
-    dns.resolve('registry.yarnpkg.com', err => {
+    dns.lookup('registry.yarnpkg.com', err => {
       resolve(err === null);
     });
   });


### PR DESCRIPTION
As discussed in issue https://github.com/facebookincubator/create-react-app/issues/1818

When we ran `yarn run create-react-app foo`, it failed because it said it was in offline-mode.
Now, after this change it actually creates a new react-app.