### PR TITLE
Pull command name from package.json instead of letting commander to figure it out on its own

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -21,10 +21,12 @@ const tmp = require('tmp');
 const unpack = require('tar-pack').unpack;
 const hyperquest = require('hyperquest');
 
+const packageJson = require('./package.json');
+
 let projectName;
 
-const program = commander
-  .version(require('./package.json').version)
+const program = new commander.Command(packageJson.name)
+  .version(packageJson.version)
   .arguments('<project-directory>')
   .usage(`${chalk.green('<project-directory>')} [options]`)
   .action(name => {


### PR DESCRIPTION
Solves #1796 by always showing `create-react-app` as a command name in help messaging.

Immediate consequence is that even if I explicitly run the job as `node packages/create-react-app/index.js`, it's going to show me `create-react-app` and not `index`, as before. Which in my opinion makes more sense, but might seem confusing to some experienced contributors.

![screen shot 2017-03-20 at 21 59 48](https://cloud.githubusercontent.com/assets/226223/24123820/01f9a15e-0db9-11e7-9f64-3a838c874c66.png)
