### PR TITLE
Ensure proxy url starts with `http://` or `https://`

### DIFF
--- a/packages/react-scripts/scripts/utils/addWebpackMiddleware.js
+++ b/packages/react-scripts/scripts/utils/addWebpackMiddleware.js
@@ -89,6 +89,14 @@ module.exports = function addWebpackMiddleware(devServer) {
         )
       );
       process.exit(1);
+      // Test that proxy url specified starts with http:// or https://
+    } else if (!/^http(s)?:\/\//.test(proxy)) {
+      console.log(
+        chalk.red(
+          'When "proxy" in package.json is specified it must start with either http:// or https://'
+        )
+      );
+      process.exit(1);
     }
 
     // Otherwise, if proxy is specified, we will let it handle any request.

--- a/packages/react-scripts/scripts/utils/addWebpackMiddleware.js
+++ b/packages/react-scripts/scripts/utils/addWebpackMiddleware.js
@@ -93,7 +93,7 @@ module.exports = function addWebpackMiddleware(devServer) {
     } else if (!/^http(s)?:\/\//.test(proxy)) {
       console.log(
         chalk.red(
-          'When "proxy" in package.json is specified it must start with either http:// or https://'
+          'When "proxy" is specified in package.json it must start with either http:// or https://'
         )
       );
       process.exit(1);


### PR DESCRIPTION

#800 
Added check that if proxy string is provided in package.json then it should start with either http:// or https:// 