### PR TITLE
Re-disable babel modules transform

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -110,6 +110,8 @@ if (env === 'test') {
           },
           // Disable polyfill transforms
           useBuiltIns: false,
+          // Do not transform modules to CJS
+          modules: false,
         },
       ],
       // JSX, Flow

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -21,7 +21,7 @@
     "react-scripts": "./bin/react-scripts.js"
   },
   "dependencies": {
-    "autoprefixer": "6.7.5",
+    "autoprefixer": "6.7.7",
     "babel-core": "6.23.1",
     "babel-eslint": "7.1.1",
     "babel-jest": "18.0.0",
@@ -32,12 +32,12 @@
     "chalk": "1.1.3",
     "connect-history-api-fallback": "1.3.0",
     "cross-spawn": "4.0.2",
-    "css-loader": "0.26.2",
+    "css-loader": "0.27.3",
     "detect-port": "1.1.1",
     "dotenv": "2.0.0",
     "eslint": "3.16.1",
     "eslint-config-react-app": "^0.6.1",
-    "eslint-loader": "1.6.3",
+    "eslint-loader": "1.7.0",
     "eslint-plugin-flowtype": "2.21.0",
     "eslint-plugin-import": "2.0.1",
     "eslint-plugin-jsx-a11y": "4.0.0",
@@ -52,12 +52,12 @@
     "postcss-loader": "1.3.3",
     "promise": "7.1.1",
     "react-dev-utils": "^0.5.2",
-    "style-loader": "0.13.2",
+    "style-loader": "0.16.0",
     "url-loader": "0.5.8",
-    "webpack": "2.2.1",
-    "webpack-dev-server": "2.4.1",
+    "webpack": "2.3.2",
+    "webpack-dev-server": "2.4.2",
     "webpack-manifest-plugin": "1.1.0",
-    "whatwg-fetch": "2.0.2"
+    "whatwg-fetch": "2.0.3"
   },
   "devDependencies": {
     "react": "^15.3.0",


### PR DESCRIPTION
An updated version of webpack was just released which fixes cheap source maps (line numbers) when using harmony module imports.
The babel feature can now be disabled and reliance shifted back onto webpack@2 to handle modules.

Validated by making crash overlay throw an error and having the correct line number appear.

**This PR also upgrades other deps in spirit of trying newer versions in alpha releases.** I did check the upgrades and most seemed to be bug fixes, which is good. Autoprefixer is one we should always try to keep up to date.

![](https://puu.sh/uYmAU/6883f33952.png)