### PR TITLE
Add 'showroom' to 'Alternatives'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Notable alternatives also include:
 * [react-app](https://github.com/kriasoft/react-app)
 * [dev-toolkit](https://github.com/stoikerty/dev-toolkit)
 * [tarec](https://github.com/geowarin/tarec)
+* [showroom](https://github.com/OpusCapitaBES/js-react-showroom-client)
 
 You can also use module bundlers like [webpack](http://webpack.github.io) and [Browserify](http://browserify.org/) directly.<br>
 React documentation includes [a walkthrough](https://facebook.github.io/react/docs/package-management.html) on this topic.


### PR DESCRIPTION
React sandbox with markdown components documentation and quick new preconfigured project generator.