### PR TITLE
Override Jest config by package.json

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -11,6 +11,7 @@
 
 const fs = require('fs');
 const paths = require('../../config/paths');
+const packageConfig = require(paths.appPackageJson).jest;
 
 module.exports = (resolve, rootDir, isEjecting) => {
   // Use this instead of `paths.testsSetup` to avoid putting
@@ -45,5 +46,5 @@ module.exports = (resolve, rootDir, isEjecting) => {
   if (rootDir) {
     config.rootDir = rootDir;
   }
-  return config;
+  return Object.assign({}, config, packageConfig);
 };


### PR DESCRIPTION
<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

The developer can add a Jest config in `package.json` and override what it wants from the config file generated by `react-script`

I've made this to answer #1455 and #1830. I had to ignore `*.stories.js` from my coverage script and the coverage threshold and I didn't want to add them in the script himself but as Jest config.

This is a config that could be used : 

```json
"jest": {
    "collectCoverageFrom": [
      "src/**/*.{js,jsx}",
      "!src/**/*.test.{js,jsx}",
      "!src/**/*.stories.{js,jsx}",
      "!src/stories/**/*.{js,jsx}"
    ],
    "coverageThreshold": {
      "global": {
        "statements": 98,
        "branches": 91,
        "functions": 98,
        "lines": 98
      }
    }
  }
```

I hope it will help