### PR TITLE
Update README.md

### DIFF
--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -225,8 +225,6 @@ prompt(
 
 This is an alternative client for [WebpackDevServer](https://github.com/webpack/webpack-dev-server) that shows a syntax error overlay.
 
-It currently supports only Webpack 1.x.
-
 ```js
 // Webpack development config
 module.exports = {


### PR DESCRIPTION
I guess `It currently supports only Webpack 1.x.` is an old note that wasn't removed when CRA was updated to use webpack 2.x
