### PR TITLE
Add sku to the list of alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Notable alternatives also include:
 * [react-app](https://github.com/kriasoft/react-app)
 * [dev-toolkit](https://github.com/stoikerty/dev-toolkit)
 * [tarec](https://github.com/geowarin/tarec)
+* [sku](https://github.com/seek-oss/sku)
 
 You can also use module bundlers like [webpack](http://webpack.github.io) and [Browserify](http://browserify.org/) directly.<br>
 React documentation includes [a walkthrough](https://facebook.github.io/react/docs/package-management.html) on this topic.


### PR DESCRIPTION
https://github.com/seek-oss/sku

We've built our own open-source tooling similar to create-react-app, designed for our existing front-end tech stack, but with an added focus on static pre-rendering as a first-class citizen. Even though it's designed to make building internal products easier, it's decoupled from our infrastructure and can be used by anyone.