### PR TITLE
Update README.md CSS Preprocessor --> node-sass-chokidar alternative

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -470,7 +470,7 @@ Now running `npm start` and `npm run build` also builds Sass files. Note that `n
 
 **Performance Note**
 
-`node-sass --watch` has been reported to have *performance issues* in certain conditions when used in a virtual machine or with docker. If you are experiencing high CPU usage with node-sass you can alternatively try [node-sass-chokidar](https://www.npmjs.com/package/node-sass-chokidar) which uses a different file-watcher. Usage remains the same, simply replace node-sass with node-sass-chokidar:
+`node-sass --watch` has been reported to have *performance issues* in certain conditions when used in a virtual machine or with docker. If you are experiencing high CPU usage with node-sass you can alternatively try [node-sass-chokidar](https://www.npmjs.com/package/node-sass-chokidar) which uses a different file-watcher. Usage remains the same, simply replace `node-sass` with `node-sass-chokidar`:
 
 ```
 npm uninstall node-sass --save-dev

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -468,6 +468,26 @@ Then we can change `start` and `build` scripts to include the CSS preprocessor c
 
 Now running `npm start` and `npm run build` also builds Sass files. Note that `node-sass` seems to have an [issue recognizing newly created files on some systems](https://github.com/sass/node-sass/issues/1891) so you might need to restart the watcher when you create a file until it’s resolved.
 
+**Performance Note**
+
+`node-sass --watch` has been reported to have *performance issues* in certain conditions when used in a virtual machine or with docker. If you are experiencing high CPU usage with node-sass you can alternatively try [node-sass-chokidar](https://www.npmjs.com/package/node-sass-chokidar) which uses a different file-watcher. Usage remains the same, simply replace node-sass with node-sass-chokidar:
+
+```
+npm uninstall node-sass --save-dev
+npm install node-sass-chokidar --save-dev
+```
+
+And in your scripts:
+
+```diff
+   "scripts": {
+-    "build-css": "node-sass src/ -o src/",
+-    "watch-css": "npm run build-css && node-sass src/ -o src/ --watch --recursive"
++    "build-css": "node-sass-chokidar src/ -o src/",
++    "watch-css": "npm run build-css && node-sass-chokidar src/ -o src/ --watch --recursive"
+   }
+```
+
 ## Adding Images, Fonts, and Files
 
 With Webpack, using static assets like images and fonts works similarly to CSS.


### PR DESCRIPTION
Updates Readme --> CSS Preprocessor to include information on node-sass-chokidar alternative to node-sass.

I originally brought this up in this [#1986](https://github.com/facebookincubator/create-react-app/issues/1986)

### Screenshots of package differences
16GB RAM
2.7 GHz i7

___

`node-sass --watch` in docker for mac
<img width="282" alt="screen shot 2017-04-15 at 12 59 49 pm" src="https://cloud.githubusercontent.com/assets/5776784/25077724/81b55b6c-22fa-11e7-97fa-8151f9e2f6a7.png">

___

`node-sass-chokidar --watch` in docker for mac
![screen shot 2017-04-16 at 12 03 11 am](https://cloud.githubusercontent.com/assets/5776784/25077723/7f9d396c-22fa-11e7-9dca-aa97982f6f97.png)

