### PR TITLE
Added ability to configure Jest via package.json

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -19,6 +19,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
     ? '<rootDir>/src/setupTests.js'
     : undefined;
 
+  const appJestConfig = require(paths.appPackageJson).jest;
+
   // TODO: I don't know if it's safe or not to just use / as path separator
   // in Jest configs. We need help from somebody with Windows to determine this.
   const config = {
@@ -45,5 +47,10 @@ module.exports = (resolve, rootDir, isEjecting) => {
   if (rootDir) {
     config.rootDir = rootDir;
   }
-  return config;
+
+  if (Object.prototype.toString.call(appJestConfig) === '[object Object]') {
+    return Object.assign({}, config, appJestConfig);
+  } else {
+    return config;
+  }
 };

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -46,6 +46,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Pre-Rendering into Static HTML Files](#pre-rendering-into-static-html-files)
 - [Injecting Data from the Server into the Page](#injecting-data-from-the-server-into-the-page)
 - [Running Tests](#running-tests)
+  - [Configuring Jest](#configuring-jest)
   - [Filename Conventions](#filename-conventions)
   - [Command Line Interface](#command-line-interface)
   - [Version Control Integration](#version-control-integration)
@@ -923,6 +924,20 @@ Jest is a Node-based runner. This means that the tests always run in a Node envi
 While Jest provides browser globals such as `window` thanks to [jsdom](https://github.com/tmpvar/jsdom), they are only approximations of the real browser behavior. Jest is intended to be used for unit tests of your logic and your components rather than the DOM quirks.
 
 We recommend that you use a separate tool for browser end-to-end tests if you need them. They are beyond the scope of Create React App.
+
+
+### Configuring Jest
+
+To override default configurations of Jest, simply add a `jest` field to your `package.json`, for example:
+
+```js
+"jest": {
+  "verbose": true,
+  "testResultsProcessor": "./node_modules/jest-junit"
+},
+```
+
+See [Jest Configuration](https://facebook.github.io/jest/docs/configuration.html) for more.
 
 ### Filename Conventions
 


### PR DESCRIPTION
- works when NOT ejected by merging default and app Jest options
- eject simply combines app and default into a single package.json jest field

fixes #1785 

Verified against my own project via `npm link` commands.  I added a `jest` config within my `package.json`, ran `CI=true npm test` and verified that it was using my extra configuration options.  I also ejected locally to make sure that worked properly and it did, resulting in a `package.json` with the merged options in the `jest` field.  I am open to advice on how else to test this feature.
