### PR TITLE
removed options in UglifyJsPlugin which are equal to the defaults

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -258,15 +258,7 @@ module.exports = {
     // Minify the code.
     new webpack.optimize.UglifyJsPlugin({
       compress: {
-        screw_ie8: true, // React doesn't support IE8
         warnings: false,
-      },
-      mangle: {
-        screw_ie8: true,
-      },
-      output: {
-        comments: false,
-        screw_ie8: true,
       },
       sourceMap: true,
     }),

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -260,6 +260,9 @@ module.exports = {
       compress: {
         warnings: false,
       },
+      output: {
+        comments: false,
+      },
       sourceMap: true,
     }),
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.


### PR DESCRIPTION
Snooping around UglifyJS docs I discovered that as of version v2.8.5, the version which webpack uses, the option `screw_ie8` is enabled by default:

>  --screw-ie8                   
Use this flag if you don't wish to support Internet Explorer 6/7/8.
By default UglifyJS will not try to be IE-proof.

That might look a bit vague, but looking in the code I found the default values, `screw_ie8` defaults to `true` and `output.comments` defaults to `false`

https://github.com/mishoo/UglifyJS2/blob/e5cb9275df257751b7322f34bca5e76cc519b974/lib/output.js#L81

https://github.com/mishoo/UglifyJS2/blob/e5cb9275df257751b7322f34bca5e76cc519b974/lib/compress.js#L79

https://github.com/mishoo/UglifyJS2/blob/e5cb9275df257751b7322f34bca5e76cc519b974/lib/output.js#L78

The commit I'm browsing in is the v2.8.5 one 
https://github.com/mishoo/UglifyJS2/commit/e5cb9275df257751b7322f34bca5e76cc519b974