### PR TITLE
add yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ lerna-debug.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn.lock
 /.changelog

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ lerna-debug.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-yarn.lock
+yarn.lock # Don't do this in your projects! We have good reasons to ignore it, but apps usually don't.
 /.changelog


### PR DESCRIPTION
I'm often cleaning my node_modules and reinstall it with yarn, and i notice that it always creates a new yarn.lock file. I think we should decide wether we want yarn.lock on the root of this project or not.

If we want to add it it, i'll close this and do https://github.com/facebookincubator/create-react-app/pull/2012 instead.