### PR TITLE
Change CSS preprocessors doc for composability

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -430,7 +430,7 @@ Then in `package.json`, add the following lines to `scripts`:
 ```diff
    "scripts": {
 +    "build-css": "node-sass src/ -o src/",
-+    "watch-css": "npm run build-css && node-sass src/ -o src/ --watch --recursive",
++    "watch-css": "npm run build-css && npm run build-css -- --watch --recursive",
      "start": "react-scripts start",
      "build": "react-scripts build",
      "test": "react-scripts test --env=jsdom",
@@ -455,7 +455,7 @@ Then we can change `start` and `build` scripts to include the CSS preprocessor c
 ```diff
    "scripts": {
      "build-css": "node-sass src/ -o src/",
-     "watch-css": "npm run build-css && node-sass src/ -o src/ --watch --recursive",
+     "watch-css": "npm run build-css && npm run build-css -- --watch --recursive",
 -    "start": "react-scripts start",
 -    "build": "react-scripts build",
 +    "start-js": "react-scripts start",
@@ -482,9 +482,8 @@ And in your scripts:
 ```diff
    "scripts": {
 -    "build-css": "node-sass src/ -o src/",
--    "watch-css": "npm run build-css && node-sass src/ -o src/ --watch --recursive"
 +    "build-css": "node-sass-chokidar src/ -o src/",
-+    "watch-css": "npm run build-css && node-sass-chokidar src/ -o src/ --watch --recursive"
+     "watch-css": "npm run build-css && npm run build-css -- --watch --recursive"
    }
 ```
 


### PR DESCRIPTION
Since there are dupes in `watch-css` we can just run the same command written in the `build-css` npm script, escape the following params with `--` and specify the params for `build-css`. I always think this is better, but obviously the "escaping" part of escaping params so they don't get passed to `npm` but to the script is confusing, but let me know if this fits the project.

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
