### PR TITLE
Added details how to use setupTests.js after eject

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1068,7 +1068,8 @@ and then use them in your tests like you normally do.
 ### Initializing Test Environment
 
 >Note: this feature is available with `react-scripts@0.4.0` and higher.
->Note: After ejecting you need to manually add [setupTestFrameworkScriptFile](https://facebook.github.io/jest/docs/configuration.html#setuptestframeworkscriptfile-string) in package.json. 
+
+>Note: After [ejecting](#npm-run-eject) you need to manually add [setupTestFrameworkScriptFile](https://facebook.github.io/jest/docs/configuration.html#setuptestframeworkscriptfile-string) in package.json. 
 
 If your app uses a browser API that you need to mock in your tests or if you just need a global setup before running your tests, add a `src/setupTests.js` to your project. It will be automatically executed before running your tests. 
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -176,6 +176,11 @@ If you aren’t satisfied with the build tool and configuration choices, you can
 
 Instead, it will copy all the configuration files and the transitive dependencies (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
 
+Ejecting removes some automatic functionality like:
+
+Automatic registration of src/setupTests.js
+... (what else?)
+
 You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
 
 ## Supported Language Features and Polyfills
@@ -1063,8 +1068,9 @@ and then use them in your tests like you normally do.
 ### Initializing Test Environment
 
 >Note: this feature is available with `react-scripts@0.4.0` and higher.
+>Note: After ejecting you need to manually add [setupTestFrameworkScriptFile](https://facebook.github.io/jest/docs/configuration.html#setuptestframeworkscriptfile-string) in package.json. 
 
-If your app uses a browser API that you need to mock in your tests or if you just need a global setup before running your tests, add a `src/setupTests.js` to your project. It will be automatically executed before running your tests.
+If your app uses a browser API that you need to mock in your tests or if you just need a global setup before running your tests, add a `src/setupTests.js` to your project. It will be automatically executed before running your tests. 
 
 For example:
 


### PR DESCRIPTION
As discussed in #2007, documentation could include information how ejecting affects on otherwise automatic features. This allows to utilize the documentation better after ejecting.

This pull request is sketchy because I don't know how ejecting affects other features than src/setupTests.js. It would be great if you could provide more details.

@anilreddykatta ^