### PR TITLE
when build is failing due to ESLint errors, filter warnings out

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -90,14 +90,14 @@ function build(previousFileSizes) {
     if (stats.compilation.errors.length) {
       printErrors('Failed to compile.', stats.compilation.errors);
       process.exit(1);
-    }
-
-    if (process.env.CI && stats.compilation.warnings.length) {
-      printErrors(
-        'Failed to compile. When process.env.CI = true, warnings are treated as failures. Most CI servers set this automatically.',
-        stats.compilation.warnings
-      );
-      process.exit(1);
+    } else {
+      if (stats.compilation.warnings.length) {
+        printErrors(
+          'Failed to compile. When process.env.CI = true, warnings are treated as failures. Most CI servers set this automatically.',
+          stats.compilation.warnings
+        );
+        if (process.env.CI) process.exit(1);
+      }
     }
 
     console.log(chalk.green('Compiled successfully.'));


### PR DESCRIPTION
@gaearon I wasn't sure if you wanted to place process.exit(1) when there are warning or not, but if process.env.CI hasn't set it should print warnings. I've tested by enabling root/.eslintignore line4 packages/react-scripts/template and produce some warning.