### PR TITLE
Add more info about OOM build failiure [docs]

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -79,7 +79,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - [Troubleshooting](#troubleshooting)
   - [`npm start` doesn’t detect changes](#npm-start-doesnt-detect-changes)
   - [`npm test` hangs on macOS Sierra](#npm-test-hangs-on-macos-sierra)
-  - [`npm run build` silently fails](#npm-run-build-silently-fails)
+  - [`npm run build` exits too early](#npm-run-build-exits-too-early)
   - [`npm run build` fails on Heroku](#npm-run-build-fails-on-heroku)
 - [Something Missing?](#something-missing)
 
@@ -1598,9 +1598,13 @@ If this still doesn’t help, try running `launchctl unload -F ~/Library/LaunchA
 
 There are also reports that *uninstalling* Watchman fixes the issue. So if nothing else helps, remove it from your system and try again.
 
-### `npm run build` silently fails
+### `npm run build` exits too early
 
-It is reported that `npm run build` can fail on machines with no swap space, which is common in cloud environments. If [the symptoms are matching](https://github.com/facebookincubator/create-react-app/issues/1133#issuecomment-264612171), consider adding some swap space to the machine you’re building on, or build the project locally.
+It is reported that `npm run build` can fail on machines with limited memory and no swap space, which is common in cloud environments. Even with small projects this command can increase RAM usage in your system by hundreds of megabytes, so if you have less than 1 GB of available memory your build is likely to fail with the following message: 
+
+>  The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.
+
+If you are completely sure that you didn't terminate the process, consider [adding some swap space](https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-ubuntu-14-04) to the machine you’re building on, or build the project locally.
 
 ### `npm run build` fails on Heroku
 


### PR DESCRIPTION
In the section about npm run build fails in troubleshooting added more
info about memory usage of the build script and a link to a tutorial for
adding more swap space as a viable solution.

Today I tried to create a build in my cheap 512MB Digital Ocean 
Ubuntu server and I ran into issues similar to #1026 and #1493. 
After running the command while having the system monitor open, I
noticed that it uses hundreds of megabytes of memory. The 
docs do mention this issue, but what really helped me was a tutorial
that I found online for adding more swap space to the server. It is for 
Ubuntu 14.04 but it does work on newer versions and it should be still
useful for any other Linux distro that uses systemd. I think that it would
be good to add it to the docs.

Also, since #1496 it no longer fails silently, so I decided to change the title
accordingly along with the console message so that users can easily find it.
