### PR TITLE
Ignore the yarn cache directory

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -26,7 +26,18 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupFiles: [resolve('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,
     testPathIgnorePatterns: [
-      '<rootDir>[/\\\\](build|docs|node_modules|scripts)[/\\\\]',
+      // Ignore the following directories:
+      // build
+      //   - the build output directory
+      // .cache
+      //   - the yarn module cache on Ubuntu if $HOME === rootDir
+      // docs
+      //   - often used to publish to Github Pages
+      // node_modules
+      //   - ignore tests in dependencies
+      // scripts
+      //   - directory generated upon eject
+      '<rootDir>[/\\\\](build|\\.cache|docs|node_modules|scripts)[/\\\\]',
     ],
     testEnvironment: 'node',
     testURL: 'http://localhost',


### PR DESCRIPTION
Fixes #2043 

Test Plan:

```
❯ create-react-app cra-test
❯ cd cra-test
// simulate a failing test in a yarn cache
❯ mkdir -p .cache/yarn/v1
❯ echo "it('fails', () => throw new Error());" > .cache/yarn/v1/Foo.test.js
```

Then test that it fails:
<img width="880" alt="hyper 2017-05-01 16-25-12" src="https://cloud.githubusercontent.com/assets/175496/25598606/d59c3e9e-2e8a-11e7-9b73-32ea6914e74a.png">

Then link the updated version of `react-scripts` and re-run the test:
<img width="425" alt="hyper 2017-05-01 16-25-28" src="https://cloud.githubusercontent.com/assets/175496/25598615/e381a530-2e8a-11e7-8d16-c97e45300bed.png">
