### PR TITLE
Update the string that clears the console.

### DIFF
--- a/packages/react-dev-utils/clearConsole.js
+++ b/packages/react-dev-utils/clearConsole.js
@@ -10,9 +10,7 @@
 'use strict';
 
 function clearConsole() {
-  process.stdout.write(
-    process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H'
-  );
+  process.stdout.write('\x1B[2J\x1B[3J\x1B[H');
 }
 
 module.exports = clearConsole;

--- a/packages/react-dev-utils/clearConsole.js
+++ b/packages/react-dev-utils/clearConsole.js
@@ -10,7 +10,7 @@
 'use strict';
 
 function clearConsole() {
-  process.stdout.write('\x1B[2J\x1B[3J\x1B[H');
+  process.stdout.write(process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H');
 }
 
 module.exports = clearConsole;


### PR DESCRIPTION
#1914
I've tested it with Windows 10 and 7, node versions from ~5.0.0 up to 7.7.0.
Didn't managed to test it on 8 but it should work to.

Before   
![](https://cloud.githubusercontent.com/assets/7072732/24597857/0be2ad9e-1851-11e7-8620-2e4e0238bef9.png)

After   
![2017-05-03_1204](https://cloud.githubusercontent.com/assets/7072732/25654191/d53da554-2ff8-11e7-94aa-791780e90a18.png)


