### PR TITLE
Eslint Config: peerDependencies -> dependencies

### DIFF
--- a/packages/eslint-config-react-app/README.md
+++ b/packages/eslint-config-react-app/README.md
@@ -14,10 +14,10 @@ The easiest way to use this configuration is with [Create React App](https://git
 
 If you want to use this ESLint configuration in a project not built with Create React App, you can install it with following steps.
 
-First, install this package, ESLint and the necessary plugins.
+First, install this package and ESLint.
 
   ```sh
-  npm install --save-dev eslint-config-react-app babel-eslint@7.1.1 eslint@3.16.1 eslint-plugin-flowtype@2.21.0 eslint-plugin-import@2.0.1 eslint-plugin-jsx-a11y@4.0.0 eslint-plugin-react@6.4.1
+  npm install --save-dev eslint-config-react-app eslint@3.16.1
   ```
 
 Then create a file named `.eslintrc` with following contents in the root folder of your project:

--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -10,12 +10,14 @@
   "files": [
     "index.js"
   ],
-  "peerDependencies": {
+  "dependencies": {
     "babel-eslint": "^7.0.0",
-    "eslint": "^3.16.1",
     "eslint-plugin-flowtype": "^2.21.0",
     "eslint-plugin-import": "^2.0.1",
     "eslint-plugin-jsx-a11y": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "eslint-plugin-react": "^6.4.1"
+  },
+  "peerDependencies": {
+    "eslint": "^3.16.1"
   }
 }


### PR DESCRIPTION
[PeerDependencies is not deprecated](https://twitter.com/dan_abramov/status/615284768582799360), but they are a pain in the but.

```sh
$ yarn add eslint-config-react-app
yarn add v0.20.3
warning "eslint-config-react-app@0.6.2" has unmet peer dependency "babel-eslint@^7.0.0".
warning "eslint-config-react-app@0.6.2" has unmet peer dependency "eslint@^3.16.1".
warning "eslint-config-react-app@0.6.2" has unmet peer dependency "eslint-plugin-flowtype@^2.21.0".
warning "eslint-config-react-app@0.6.2" has unmet peer dependency "eslint-plugin-import@^2.0.1".
warning "eslint-config-react-app@0.6.2" has unmet peer dependency "eslint-plugin-jsx-a11y@^2.0.0 || ^3.0.0 || ^4.0.0".
warning "eslint-config-react-app@0.6.2" has unmet peer dependency "eslint-plugin-react@^6.4.1".
success Saved 1 new dependency.
└─ eslint-config-react-app@0.6.2
```

Since eslint-config-react-app depends on all the above packages, it should be installed alongside the package. This will mirror the same behaviour [babel-preset-react-app](https://github.com/facebookincubator/create-react-app/blob/master/packages/babel-preset-react-app/package.json) has which is a breeze. 💨

Should eslint also be installed automatically? I'm not sure. I'm leaving it as a peerDependency for now and would like to hear your thoughts.