### PR TITLE
react-dev-utils/openBrowser now supports urls with 2+ params

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -38,7 +38,7 @@ function openBrowser(url) {
       // Try our best to reuse existing tab
       // on OS X Google Chrome with AppleScript
       execSync('ps cax | grep "Google Chrome"');
-      execSync('osascript openChrome.applescript "' + url + '"', {
+      execSync('osascript openChrome.applescript "' + encodeURI(url) + '"', {
         cwd: __dirname,
         stdio: 'ignore',
       });

--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -38,7 +38,7 @@ function openBrowser(url) {
       // Try our best to reuse existing tab
       // on OS X Google Chrome with AppleScript
       execSync('ps cax | grep "Google Chrome"');
-      execSync('osascript openChrome.applescript ' + url, {
+      execSync('osascript openChrome.applescript "' + url + '"', {
         cwd: __dirname,
         stdio: 'ignore',
       });


### PR DESCRIPTION
Tiny improvement to fix #2047.