### PR TITLE
Add cache-loader to speed up builds

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -171,13 +171,26 @@ module.exports = {
       {
         test: /\.(js|jsx)$/,
         include: paths.appSrc,
-        loader: 'babel-loader',
-        // @remove-on-eject-begin
-        options: {
-          babelrc: false,
-          presets: [require.resolve('babel-preset-react-app')],
-        },
-        // @remove-on-eject-end
+        use: [
+          {
+            loader: 'cache-loader',
+            options: {
+              cacheDirectory: path.resolve(
+                paths.appNodeModules,
+                '.cache-loader'
+              ),
+            },
+          },
+          {
+            loader: 'babel-loader',
+            // @remove-on-eject-begin
+            options: {
+              babelrc: false,
+              presets: [require.resolve('babel-preset-react-app')],
+            },
+            // @remove-on-eject-end
+          },
+        ],
       },
       // The notation here is somewhat confusing.
       // "postcss" loader applies autoprefixer to our CSS.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -28,6 +28,7 @@
     "babel-loader": "7.0.0",
     "babel-preset-react-app": "^2.1.1",
     "babel-runtime": "^6.20.0",
+    "cache-loader": "1.0.3",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",
     "connect-history-api-fallback": "1.3.0",


### PR DESCRIPTION
There's a little speed boost for `yarn build`.
¯\\\_(ツ)\_/¯

```
no `cache-loader`
real	1m4.240s
real	0m58.490s

`cache-loader`:
real	0m57.913s
real	0m48.341s
```

https://github.com/facebookincubator/create-react-app/issues/2037