### PR TITLE
Revert "Forbid using window properties as global variables"

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -26,17 +26,11 @@ module.exports = {
   plugins: ['import', 'flowtype', 'jsx-a11y', 'react'],
 
   env: {
+    browser: true,
     commonjs: true,
     es6: true,
     jest: true,
     node: true,
-  },
-
-  globals: {
-    document: true,
-    window: true,
-    console: true,
-    navigator: true
   },
 
   parserOptions: {

--- a/packages/react-scripts/fixtures/kitchensink/src/App.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/App.js
@@ -26,7 +26,7 @@ class BuiltEmitter extends Component {
   }
 
   handleReady() {
-    document.dispatchEvent(new window.Event('ReactFeatureDidMount'));
+    document.dispatchEvent(new Event('ReactFeatureDidMount'));
   }
 
   render() {
@@ -54,7 +54,7 @@ class App extends Component {
   }
 
   componentDidMount() {
-    const feature = window.location.hash.slice(1);
+    const feature = location.hash.slice(1);
     switch (feature) {
       case 'array-destructuring':
         import(

--- a/packages/react-scripts/fixtures/kitchensink/src/features/webpack/NoExtInclusion.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/features/webpack/NoExtInclusion.js
@@ -11,7 +11,7 @@ import React from 'react';
 import aFileWithoutExt from './assets/aFileWithoutExt';
 
 const text = aFileWithoutExt.includes('base64')
-  ? window.atob(aFileWithoutExt.split('base64,')[1]).trim()
+  ? atob(aFileWithoutExt.split('base64,')[1]).trim()
   : aFileWithoutExt;
 
 export default () => (

--- a/packages/react-scripts/fixtures/kitchensink/src/features/webpack/UnknownExtInclusion.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/features/webpack/UnknownExtInclusion.js
@@ -11,7 +11,7 @@ import React from 'react';
 import aFileWithExtUnknown from './assets/aFileWithExt.unknown';
 
 const text = aFileWithExtUnknown.includes('base64')
-  ? window.atob(aFileWithExtUnknown.split('base64,')[1]).trim()
+  ? atob(aFileWithExtUnknown.split('base64,')[1]).trim()
   : aFileWithExtUnknown;
 
 export default () => (


### PR DESCRIPTION
Reverts facebookincubator/create-react-app#1840.
See the discussion https://github.com/facebookincubator/create-react-app/pull/1840#issuecomment-299933160 for reasons why:

* We probably aren’t going to implement server side rendering any time soon.
* Beginners are genuinely confused why copy-pasting valid examples produces errors.
