### PR TITLE
Do not respect eslintignore

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -126,6 +126,7 @@ module.exports = {
               baseConfig: {
                 extends: ['react-app'],
               },
+              ignore: false,
               useEslintrc: false,
             },
             // @remove-on-eject-end


### PR DESCRIPTION
While playing with #2113 I noticed ESLint only works for a scaffolded application, and not in our monorepo.

It's because our [`.eslintignore`](https://github.com/facebookincubator/create-react-app/blob/master/.eslintignore) says to ignore these files.

Just like `.eslintrc`, we should not respect `.eslintignore` files since webpack is managing the globbing (and only linting `src/**/*.js` files).