### PR TITLE
Bind to all IPv4 addresses

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -54,7 +54,7 @@ const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
 
 function run(port) {
   const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
-  const host = process.env.HOST || 'localhost';
+  const host = process.env.HOST || '0.0.0.0';
 
   // Create a webpack compiler that is configured with custom messages.
   const compiler = createWebpackCompiler(


### PR DESCRIPTION
Let's default to `0.0.0.0` which binds to all available IPv4 addresses.

We might want to bind to `0:0:0:0:0:0:0:0` if we can.

We also might want to open the browser to `localhost` instead of `0.0.0.0` when we detect that you're binding to all interfaces.