### PR TITLE
Omit ESLint warnings when there are ESLint errors

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -84,7 +84,7 @@ function formatMessage(message, isError) {
       "$1 '$4' does not contain an export named '$3'."
     );
   }
-  
+
   // TODO: Ideally we should write a custom ESLint formatter instead.
 
   // If the second line already includes a filename, and it's a warning,
@@ -121,6 +121,18 @@ function formatMessage(message, isError) {
     }
     return true;
   });
+
+  var ESLINT_WARNING_LABEL = String.fromCharCode(27) +
+    '[33m' +
+    'warning' +
+    String.fromCharCode(27) +
+    '[39m';
+  // If there were errors, omit any warnings.
+  if (isError) {
+    lines = lines.filter(function(line) {
+      return line.indexOf(ESLINT_WARNING_LABEL) === -1;
+    });
+  }
 
   // Prepend filename with an explanation.
   lines[0] =


### PR DESCRIPTION
This fixes https://github.com/facebookincubator/create-react-app/issues/2056.
It's not really maintainable—I'll file another issue to rewrite this to a custom ESLint formatter.

Just warnings:

<img width="703" alt="screen shot 2017-05-11 at 1 56 27 pm" src="https://cloud.githubusercontent.com/assets/810438/25950083/ac602bc0-3651-11e7-8299-c1dd8580eced.png">

Now I make an error:

<img width="690" alt="screen shot 2017-05-11 at 1 56 20 pm" src="https://cloud.githubusercontent.com/assets/810438/25950088/b181dafe-3651-11e7-87ba-bb55b0891728.png">

(Before, they would all be displayed together.)

After fixing the error:

<img width="703" alt="screen shot 2017-05-11 at 1 56 27 pm" src="https://cloud.githubusercontent.com/assets/810438/25950107/be53f10e-3651-11e7-88d6-35f3b6fc3b3d.png">
