### PR TITLE
Make error box messages friendlier

### DIFF
--- a/packages/react-error-overlay/src/components/frame.js
+++ b/packages/react-error-overlay/src/components/frame.js
@@ -127,8 +127,8 @@ function createFrame(
   lastElement: boolean
 ) {
   const { compiled } = frameSetting;
+  let { functionName } = frame;
   const {
-    functionName,
     fileName,
     lineNumber,
     columnNumber,
@@ -138,6 +138,14 @@ function createFrame(
     _originalColumnNumber: sourceColumnNumber,
     _originalScriptCode: sourceLines,
   } = frame;
+
+  // TODO: find a better place for this.
+  // Chrome has a bug with inferring function.name:
+  // https://github.com/facebookincubator/create-react-app/issues/2097
+  // Let's ignore a meaningless name we get for top-level modules.
+  if (functionName === 'Object.friendlySyntaxErrorLabel') {
+    functionName = '(anonymous function)';
+  }
 
   let url;
   if (!compiled && sourceFileName && sourceLineNumber) {

--- a/packages/react-error-overlay/src/components/overlay.js
+++ b/packages/react-error-overlay/src/components/overlay.js
@@ -50,11 +50,19 @@ function createOverlay(
   // Create header
   const header = document.createElement('div');
   applyStyles(header, headerStyle);
-  if (message.match(/^\w*:/)) {
-    header.appendChild(document.createTextNode(message));
-  } else {
-    header.appendChild(document.createTextNode(name + ': ' + message));
-  }
+
+  // Make message prettier
+  let finalMessage = message.match(/^\w*:/) ? name + ': ' + message : message;
+  finalMessage = finalMessage
+    // TODO: maybe remove this prefix from fbjs?
+    // It's just scaring people
+    .replace('Invariant Violation: ', '')
+    // Break the actionable part to the next line.
+    // AFAIK React 16+ should already do this.
+    .replace(' Check the render method', '\n\nCheck the render method');
+
+  // Put it in the DOM
+  header.appendChild(document.createTextNode(finalMessage));
   container.appendChild(header);
 
   // Create trace

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -65,6 +65,7 @@ const headerStyle = {
   'font-size': '1.7em',
   'font-weight': 'bold',
   color: red,
+  'white-space': 'pre-wrap',
 };
 
 const functionNameStyle = {


### PR DESCRIPTION
* Break `Check the render method` onto the next line (I think we already do this in React but haven't cherry-picked to 15.x). This is important because otherwise stack takes too much precious attention even when it's not actionable.

* Hide "Invariant Violation" completely. (This is college speak.)

* Add a hacky workaround for https://github.com/facebookincubator/create-react-app/issues/2097.

Before:

<img width="1120" alt="screen shot 2017-05-11 at 3 33 01 pm" src="https://cloud.githubusercontent.com/assets/810438/25954768/251bca08-365f-11e7-9286-a995481ae6e7.png">

After:

<img width="1126" alt="screen shot 2017-05-11 at 3 32 37 pm" src="https://cloud.githubusercontent.com/assets/810438/25954741/16e87044-365f-11e7-9e4d-0e466aa4614e.png">
