### PR TITLE
Only show the first compilation error

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -177,6 +177,11 @@ function formatWebpackMessages(json) {
     // preceding a much more useful Babel syntax error.
     result.errors = result.errors.filter(isLikelyASyntaxError);
   }
+  // Only keep the first error. Others are often indicative
+  // of the same problem, but confuse the reader with noise.
+  if (result.errors.length > 1) {
+    result.errors.length = 1;
+  }
   return result;
 }
 


### PR DESCRIPTION
Addresses https://github.com/facebookincubator/create-react-app/pull/1755#issuecomment-285179758.
Since I removed the duplicate filtering hack, this came up again.

Now I'm just showing the first compilation error.

This makes sense because in most cases it's the one you want to fix first anyway. And showing a list is not useful if it's repopulated on every change as you can't easily keep track of it.