### PR TITLE
Upgrade detect-port

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -33,7 +33,7 @@
     "connect-history-api-fallback": "1.3.0",
     "cross-spawn": "4.0.2",
     "css-loader": "0.28.0",
-    "detect-port": "1.1.1",
+    "detect-port": "1.1.2",
     "dotenv": "2.0.0",
     "eslint": "3.16.1",
     "eslint-config-react-app": "^0.6.1",


### PR DESCRIPTION
Upgrades detect port to resolve #2112.

Test plan: start two servers and expect the duplicate message, do the same with a different `HOST`.
It works.

I'm not sure about edge cases (like binding to a hostname instead of address, e.g. `boop.local`).