### PR TITLE
Allow overriding the hotDevClient URL from a global var

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -126,13 +126,13 @@ function destroyErrorOverlay() {
 
 // Connect to WebpackDevServer via a socket.
 var connection = new SockJS(
-  url.format({
+  url.format(Object.assign({
     protocol: window.location.protocol,
     hostname: window.location.hostname,
     port: window.location.port,
     // Hardcoded in WebpackDevServer
     pathname: '/sockjs-node',
-  })
+  }, window.webpackHotDevClientURL || {}))
 );
 
 // Unlike WebpackDevServer client, we won't try to reconnect


### PR DESCRIPTION
In multiple cases now I've wanted to use `create-react-app` but to build an app that's embedded in another context that won't work when served from `localhost`. The problem being that this script assumes `window.location.hostname` etc... will be the webpack dev server URL. 

In my particular case when developing a WordPress theme using React or a WordPress plugin with an embedded react app for some fancy admin UI.

In WP I enqueue the build file from `http://localhost:3000/build/js/main.js` when in debug mode. I then used `wp_localize_script()` to then add this global variable eg:

```php
wp_enqueue_script( 'react-app', 'http://localhost:3000/build/js/main.js' );
wp_localize_script( 'react-app', 'webpackHotDevClientURL', [
   'hostname' => 'localhost',
   'port' => 3000
] );
```

The project in question that this would benefit me on in particular is https://github.com/humanmade/Restsplain

I've searched around a lot and seems to come a fair bit on stackoverflow, [this post](http://code.fitness/post/2016/02/webpack-public-path-and-hot-reload.html) almost got me there but patching it like this would be way more straightforward IMO.