### PR TITLE
Skip React frames that are too close

### DIFF
--- a/packages/react-error-overlay/src/utils/warnings.js
+++ b/packages/react-error-overlay/src/utils/warnings.js
@@ -13,11 +13,26 @@ function massage(
 
   // Reassemble the stack with full filenames provided by React
   let stack = '';
+  let lastFilename;
+  let lastLineNumber;
   for (let index = 0; index < frames.length; ++index) {
     const { fileName, lineNumber } = frames[index];
     if (fileName == null || lineNumber == null) {
       continue;
     }
+
+    // TODO: instead, collapse them in the UI
+    if (
+      fileName === lastFilename &&
+      typeof lineNumber === 'number' &&
+      typeof lastLineNumber === 'number' &&
+      Math.abs(lineNumber - lastLineNumber) < 3
+    ) {
+      continue;
+    }
+    lastFilename = fileName;
+    lastLineNumber = lineNumber;
+
     let { functionName } = frames[index];
     functionName = functionName || '(anonymous function)';
     stack += `in ${functionName} (at ${fileName}:${lineNumber})\n`;


### PR DESCRIPTION
A cruder, but simple alternative to https://github.com/facebookincubator/create-react-app/pull/2142.
We can revisit https://github.com/facebookincubator/create-react-app/pull/2142 after https://github.com/facebookincubator/create-react-app/issues/2100.