### PR TITLE
Prefer localhost as an address

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -60,6 +60,19 @@ function run(port) {
     pathname: '/',
   });
 
+  let prettyHost;
+  if (HOST === '0.0.0.0' || HOST === '::') {
+    prettyHost = 'localhost';
+  } else {
+    prettyHost = HOST;
+  }
+  const prettyUrl = url.format({
+    protocol,
+    hostname: prettyHost,
+    port,
+    pathname: '/',
+  });
+
   // Create a webpack compiler that is configured with custom messages.
   const compiler = createWebpackCompiler(
     config,
@@ -100,7 +113,7 @@ function run(port) {
     console.log(chalk.cyan('Starting the development server...'));
     console.log();
 
-    openBrowser(formattedUrl);
+    openBrowser(prettyUrl);
   });
 }
 


### PR DESCRIPTION
Windows doesn't let you use `0.0.0.0` as a valid URL in the browser, unlike macOS.

When using the unspecified address (which binds to everything), we should switch to `localhost`. It's a saner default anyway and something people recognize.