### PR TITLE
Make error/warning output more useful

### DIFF
--- a/packages/react-dev-utils/eslintFormatter.js
+++ b/packages/react-dev-utils/eslintFormatter.js
@@ -30,13 +30,13 @@ function formatter(results) {
       }
 
       let line = message.line || 0;
-      let position = chalk.dim(`Line ${line}:`);
+      let position = chalk.bold('Line ' + line + ':');
       return [
         '',
         position,
         messageType,
         message.message.replace(/\.$/, ''),
-        chalk.cyan(message.ruleId || ''),
+        chalk.underline(message.ruleId || ''),
       ];
     });
 
@@ -47,7 +47,8 @@ function formatter(results) {
 
     // add color to messageTypes
     messages.forEach(m => {
-      m[2] = m[2] === 'error' ? chalk.red(m[2]) : chalk.yellow(m[2]);
+      m[3] = m[2] === 'error' ? chalk.red(m[3]) : chalk.yellow(m[3]);
+      m.splice(2, 1);
     });
 
     let outputTable = table(messages, {

--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -86,17 +86,7 @@ function formatMessage(message, isError) {
     );
   }
 
-  // Make filename nicer.
-  var slashIndex = Math.max(
-    lines[0].lastIndexOf('/'),
-    lines[0].lastIndexOf('\\')
-  );
-  var fileName = lines[0].substring(slashIndex + 1);
-  var path = lines[0].substring(0, slashIndex + 1);
-  lines[0] = chalk.dim(isError ? 'Found errors in ' : 'Found warnings in ') +
-    path +
-    (isError ? chalk.red : chalk.yellow)(fileName) +
-    chalk.dim(':');
+  lines[0] = chalk.inverse(lines[0]);
 
   // Reassemble the message.
   message = lines.join('\n');

--- a/packages/react-scripts/scripts/utils/createWebpackCompiler.js
+++ b/packages/react-scripts/scripts/utils/createWebpackCompiler.js
@@ -103,18 +103,14 @@ module.exports = function createWebpackCompiler(config, onReadyCallback) {
 
       // Teach some ESLint tricks.
       console.log(
-        chalk.dim(
-          'Search for the ' +
-            chalk.cyan('rule keywords') +
-            ' to learn more about each warning.'
-        )
+        'Search for the ' +
+          chalk.underline('rule keywords') +
+          ' to learn more about each warning.'
       );
       console.log(
-        chalk.dim(
-          'To ignore, add ' +
-            chalk.yellow('// eslint-disable-next-line') +
-            ' to the previous line.'
-        )
+        'To ignore, add ' +
+          chalk.yellow('// eslint-disable-next-line') +
+          ' to the previous line.'
       );
       console.log();
     }


### PR DESCRIPTION
Hopefully the last one for now.
I removed dimming, and instead I make the filenames inverse and line numbers bold.

<img width="508" alt="screen shot 2017-05-15 at 6 03 55 pm" src="https://cloud.githubusercontent.com/assets/810438/26069613/73f82f12-3999-11e7-89cb-56280c047ec9.png">
<img width="926" alt="screen shot 2017-05-15 at 6 04 12 pm" src="https://cloud.githubusercontent.com/assets/810438/26069612/73f523b2-3999-11e7-97be-5327a1644994.png">
<img width="732" alt="screen shot 2017-05-15 at 6 04 41 pm" src="https://cloud.githubusercontent.com/assets/810438/26069614/743599d8-3999-11e7-8819-395855647b73.png">
