### PR TITLE
Enable CSS sourcemaps in production

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -194,6 +194,7 @@ module.exports = {
                   options: {
                     importLoaders: 1,
                     minimize: true,
+                    sourceMap: true,
                   },
                 },
                 {


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/create-react-app/issues/2026.

From my understanding, caveats from https://github.com/facebookincubator/create-react-app/pull/591 apply to development only.

If this is buggy we can disable it in a patch.