### PR TITLE
Resolve regenerator runtime relative to react-scripts

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -8,8 +8,6 @@
  */
 'use strict';
 
-var path = require('path');
-
 const plugins = [
   // class { handleClick = () => { } }
   require.resolve('babel-plugin-transform-class-properties'),
@@ -36,8 +34,6 @@ const plugins = [
       helpers: false,
       polyfill: false,
       regenerator: true,
-      // Resolve the Babel runtime relative to the config.
-      moduleName: path.dirname(require.resolve('babel-runtime/package')),
     },
   ],
 ];

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -22,7 +22,9 @@
     "babel-plugin-transform-regenerator": "6.24.1",
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "1.4.0",
-    "babel-preset-react": "6.24.1",
-    "babel-runtime": "6.23.0"
+    "babel-preset-react": "6.24.1"
+  },
+  "peerDependencies": {
+    "babel-runtime": "^6.23.0"
   }
 }

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -93,6 +93,15 @@ module.exports = {
     // https://github.com/facebookincubator/create-react-app/issues/290
     extensions: ['.js', '.json', '.jsx'],
     alias: {
+      // @remove-on-eject-begin
+      // Resolve Babel runtime relative to react-scripts.
+      // It usually still works on npm 3 without this but it would be
+      // unfortunate to rely on, as react-scripts could be symlinked,
+      // and thus babel-runtime might not be resolvable from the source.
+      'babel-runtime': path.dirname(
+        require.resolve('babel-runtime/package.json')
+      ),
+      // @remove-on-eject-end
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -90,6 +90,15 @@ module.exports = {
     // https://github.com/facebookincubator/create-react-app/issues/290
     extensions: ['.js', '.json', '.jsx'],
     alias: {
+      // @remove-on-eject-begin
+      // Resolve Babel runtime relative to react-scripts.
+      // It usually still works on npm 3 without this but it would be
+      // unfortunate to rely on, as react-scripts could be symlinked,
+      // and thus babel-runtime might not be resolvable from the source.
+      'babel-runtime': path.dirname(
+        require.resolve('babel-runtime/package.json')
+      ),
+      // @remove-on-eject-end
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',


### PR DESCRIPTION
This removes a hack that caused an absolute path to be embedded in the modules after being processed by our Babel preset. This hack doesn’t matter for apps that are bundled, but it breaks libraries.

The hack was in the wrong place. We can’t really get around the fact that regenerator runtime is resolved from the consuming application. So instead we should embrace it, and redirect at the webpack config level instead. Additionally the preset should make it clear `babel-runtime` is meant to be installed by the app, so I moved it to the peer dependencies.