### PR TITLE
Tweaking error overlay styles

### DIFF
--- a/packages/react-dev-utils/ansiHTML.js
+++ b/packages/react-dev-utils/ansiHTML.js
@@ -15,18 +15,18 @@ var Anser = require('anser');
 // var base00 = 'ffffff'; // Default Background
 var base01 = 'f5f5f5'; // Lighter Background (Used for status bars)
 // var base02 = 'c8c8fa'; // Selection Background
-var base03 = '969896'; // Comments, Invisibles, Line Highlighting
+var base03 = '6e6e6e'; // Comments, Invisibles, Line Highlighting
 // var base04 = 'e8e8e8'; // Dark Foreground (Used for status bars)
 var base05 = '333333'; // Default Foreground, Caret, Delimiters, Operators
 // var base06 = 'ffffff'; // Light Foreground (Not often used)
 // var base07 = 'ffffff'; // Light Background (Not often used)
-var base08 = 'ed6a43'; // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+var base08 = '881280'; // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
 // var base09 = '0086b3'; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
 // var base0A = '795da3'; // Classes, Markup Bold, Search Text Background
-var base0B = '183691'; // Strings, Inherited Class, Markup Code, Diff Inserted
-var base0C = '183691'; // Support, Regular Expressions, Escape Characters, Markup Quotes
+var base0B = '1155cc'; // Strings, Inherited Class, Markup Code, Diff Inserted
+var base0C = '994500'; // Support, Regular Expressions, Escape Characters, Markup Quotes
 // var base0D = '795da3'; // Functions, Methods, Attribute IDs, Headings
-var base0E = 'a71d5d'; // Keywords, Storage, Selector, Markup Italic, Diff Changed
+var base0E = 'c80000'; // Keywords, Storage, Selector, Markup Italic, Diff Changed
 // var base0F = '333333'; // Deprecated, Opening/Closing Embedded Language Tags e.g. <?php ?>
 
 // Map ANSI colors from what babel-code-frame uses to base16-github

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -26,7 +26,7 @@ var Entities = require('html-entities').AllHtmlEntities;
 var ansiHTML = require('./ansiHTML');
 var entities = new Entities();
 
-var red = '#E36049';
+var red = '#ce1126';
 
 function createOverlayIframe(onIframeLoad) {
   var iframe = document.createElement('iframe');
@@ -59,13 +59,22 @@ function addOverlayDivTo(iframe) {
   div.style.backgroundColor = '#fafafa';
   div.style.color = '#333';
   div.style.fontFamily = 'Menlo, Consolas, monospace';
-  div.style.fontSize = 'large';
+  div.style.fontSize = '10px';
   div.style.padding = '2rem';
   div.style.lineHeight = '1.2';
-  div.style.whiteSpace = 'pre-wrap';
+  div.style.whiteSpace = 'pre';
   div.style.overflow = 'auto';
   iframe.contentDocument.body.appendChild(div);
   return div;
+}
+
+function overlayHeaderStyle() {
+  return 'font-size: 1.7em;' +
+    'font-family: sans-serif;' +
+    'color: ' +
+    red +
+    ';' +
+    'white-space: pre-wrap;';
 }
 
 var overlayIframe = null;
@@ -104,8 +113,8 @@ function ensureOverlayDivExists(onOverlayDivReady) {
 function showErrorOverlay(message) {
   ensureOverlayDivExists(function onOverlayDivReady(overlayDiv) {
     // Make it look similar to our terminal.
-    overlayDiv.innerHTML = '<span style="color: ' +
-      red +
+    overlayDiv.innerHTML = '<span style="' +
+      overlayHeaderStyle() +
       '">Failed to compile.</span><br><br>' +
       ansiHTML(entities.encode(message));
   });

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -62,7 +62,7 @@ function addOverlayDivTo(iframe) {
   div.style.fontSize = '10px';
   div.style.padding = '2rem';
   div.style.lineHeight = '1.2';
-  div.style.whiteSpace = 'pre';
+  div.style.whiteSpace = 'pre-wrap';
   div.style.overflow = 'auto';
   iframe.contentDocument.body.appendChild(div);
   return div;

--- a/packages/react-error-overlay/src/components/overlay.js
+++ b/packages/react-error-overlay/src/components/overlay.js
@@ -84,14 +84,6 @@ function createOverlay(
   // Show message
   container.appendChild(createFooter(document));
 
-  // Clicks to background overlay should dismiss error popup.
-  overlay.addEventListener('click', closeCallback);
-
-  // Clicks within the popup should not dismiss it.
-  container.addEventListener('click', function(event: Event) {
-    event.stopPropagation();
-  });
-
   return {
     overlay,
     additional,

--- a/packages/react-error-overlay/src/components/overlay.js
+++ b/packages/react-error-overlay/src/components/overlay.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { applyStyles } from '../utils/dom/css';
 import {
-  craContainer,
+  containerStyle,
   overlayStyle,
   headerStyle,
   additionalStyle,
@@ -32,19 +32,13 @@ function createOverlay(
   const frameSettings: FrameSetting[] = frames.map(() => ({ compiled: false }));
   // Create overlay
   const overlay = document.createElement('div');
-  overlay.addEventListener('click', function(event: Event) {
-    // Clicks to background layer dismiss the popup
-    // Prevent clicks within the panel from accidentally dismissing
-    event.stopPropagation();
-  });
   applyStyles(overlay, overlayStyle);
-  overlay.appendChild(createClose(document, closeCallback));
 
   // Create container
   const container = document.createElement('div');
-  applyStyles(container, craContainer);
-  container.className = 'cra-container';
+  applyStyles(container, containerStyle);
   overlay.appendChild(container);
+  container.appendChild(createClose(document, closeCallback));
 
   // Create additional
   const additional = document.createElement('div');
@@ -89,6 +83,14 @@ function createOverlay(
 
   // Show message
   container.appendChild(createFooter(document));
+
+  // Clicks to background overlay should dismiss error popup.
+  overlay.addEventListener('click', closeCallback);
+
+  // Clicks within the popup should not dismiss it.
+  container.addEventListener('click', function(event: Event) {
+    event.stopPropagation();
+  });
 
   return {
     overlay,

--- a/packages/react-error-overlay/src/components/overlay.js
+++ b/packages/react-error-overlay/src/components/overlay.js
@@ -1,6 +1,11 @@
 /* @flow */
 import { applyStyles } from '../utils/dom/css';
-import { overlayStyle, headerStyle, additionalStyle } from '../styles';
+import {
+  craContainer,
+  overlayStyle,
+  headerStyle,
+  additionalStyle,
+} from '../styles';
 import { createClose } from './close';
 import { createFrames } from './frames';
 import { createFooter } from './footer';
@@ -32,6 +37,7 @@ function createOverlay(
 
   // Create container
   const container = document.createElement('div');
+  applyStyles(container, craContainer);
   container.className = 'cra-container';
   overlay.appendChild(container);
 

--- a/packages/react-error-overlay/src/components/overlay.js
+++ b/packages/react-error-overlay/src/components/overlay.js
@@ -32,6 +32,11 @@ function createOverlay(
   const frameSettings: FrameSetting[] = frames.map(() => ({ compiled: false }));
   // Create overlay
   const overlay = document.createElement('div');
+  overlay.addEventListener('click', function(event: Event) {
+    // Clicks to background layer dismiss the popup
+    // Prevent clicks within the panel from accidentally dismissing
+    event.stopPropagation();
+  });
   applyStyles(overlay, overlayStyle);
   overlay.appendChild(createClose(document, closeCallback));
 

--- a/packages/react-error-overlay/src/overlay.js
+++ b/packages/react-error-overlay/src/overlay.js
@@ -80,9 +80,11 @@ function render(name: ?string, message: string, resolvedFrames: StackFrame[]) {
     }
     if (document.body != null) {
       document.body.style.margin = '0';
-      document.body.appendChild(overlay);
-      // Clicks to background overlay should dismiss error popup
-      (document.body: any).addEventListener('click', unmount);
+      // Keep popup within body boundaries for iOS Safari
+      // $FlowFixMe
+      document.body.style['max-width'] = '100vw';
+
+      (document.body: any).appendChild(overlay);
     }
     additionalReference = additional;
   };

--- a/packages/react-error-overlay/src/overlay.js
+++ b/packages/react-error-overlay/src/overlay.js
@@ -79,8 +79,10 @@ function render(name: ?string, message: string, resolvedFrames: StackFrame[]) {
       };
     }
     if (document.body != null) {
-      document.body.style.margin = 0;
+      document.body.style.margin = '0';
       document.body.appendChild(overlay);
+      // Clicks to background overlay should dismiss error popup
+      (document.body: any).addEventListener('click', unmount);
     }
     additionalReference = additional;
   };

--- a/packages/react-error-overlay/src/overlay.js
+++ b/packages/react-error-overlay/src/overlay.js
@@ -45,33 +45,6 @@ let additionalReference = null;
 let errorReferences: ErrorRecordReference[] = [];
 let currReferenceIndex: number = -1;
 
-const css = [
-  '.cra-container {',
-  '  padding-right: 15px;',
-  '  padding-left: 15px;',
-  '  margin-right: auto;',
-  '  margin-left: auto;',
-  '}',
-  '',
-  '@media (min-width: 768px) {',
-  '  .cra-container {',
-  '    width: calc(750px - 6em);',
-  '  }',
-  '}',
-  '',
-  '@media (min-width: 992px) {',
-  '  .cra-container {',
-  '    width: calc(970px - 6em);',
-  '  }',
-  '}',
-  '',
-  '@media (min-width: 1200px) {',
-  '  .cra-container {',
-  '    width: calc(1170px - 6em);',
-  '  }',
-  '}',
-].join('\n');
-
 function render(name: ?string, message: string, resolvedFrames: StackFrame[]) {
   disposeCurrentView();
 
@@ -105,8 +78,8 @@ function render(name: ?string, message: string, resolvedFrames: StackFrame[]) {
         keyEventHandler(type => shortcutHandler(type), event);
       };
     }
-    injectCss(iframeReference.contentDocument, css);
     if (document.body != null) {
+      document.body.style.margin = 0;
       document.body.appendChild(overlay);
     }
     additionalReference = additional;

--- a/packages/react-error-overlay/src/overlay.js
+++ b/packages/react-error-overlay/src/overlay.js
@@ -35,7 +35,7 @@ import type { ErrorRecordReference } from './utils/errorRegister';
 
 import type { StackFrame } from './utils/stack-frame';
 import { iframeStyle } from './styles';
-import { injectCss, applyStyles } from './utils/dom/css';
+import { applyStyles } from './utils/dom/css';
 import { createOverlay } from './components/overlay';
 import { updateAdditional } from './components/additional';
 

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -1,7 +1,6 @@
 /* @flow */
 const black = '#293238',
   darkGray = '#878e91',
-  lightGray = '#fafafa',
   red = '#ce1126',
   lightRed = '#fccfcf',
   yellow = '#fbf5b4',
@@ -64,7 +63,6 @@ const hintStyle = {
 };
 
 const closeButtonStyle = {
-  'font-size': '26px',
   color: black,
   'line-height': '1rem',
   'font-size': '1.5rem',
@@ -120,17 +118,18 @@ const secondaryErrorStyle = {
 
 const omittedFramesStyle = {
   color: black,
-  margin: '1.5em 0',
   cursor: 'pointer',
 };
 
 const preStyle = {
   display: 'block',
   padding: '0.5em',
-  'margin-top': '1.5em',
-  'margin-bottom': '0px',
+  'margin-top': '0.5em',
+  'margin-bottom': '0.5em',
   'overflow-x': 'auto',
   'white-space': 'pre',
+  'border-radius': '0.25rem',
+  'background-color': 'rgba(206, 17, 38, .05)',
 };
 
 const toggleStyle = {

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -37,7 +37,7 @@ const containerStyle = {
   'box-sizing': 'border-box',
   'text-align': 'start',
   'font-family': 'Consolas, Menlo, monospace',
-  'font-size': '10px',
+  'font-size': '11px',
   'white-space': 'pre-wrap',
   'word-break': 'break-word',
   'line-height': 1.5,
@@ -77,7 +77,7 @@ const headerStyle = {
   'font-family': 'sans-serif',
   color: red,
   'white-space': 'pre-wrap',
-  margin: '0.25rem 2rem 0 0', // Prevent overlap with close button
+  margin: '0.75rem 2rem 0 0', // Prevent overlap with close button
   flex: '0 0 auto',
 };
 

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -77,7 +77,7 @@ const headerStyle = {
   'font-family': 'sans-serif',
   color: red,
   'white-space': 'pre-wrap',
-  margin: '0.75rem 2rem 0 0', // Prevent overlap with close button
+  margin: '0.25rem 2rem 0 0', // Prevent overlap with close button
   flex: '0 0 auto',
 };
 
@@ -171,7 +171,6 @@ const footerStyle = {
   'font-family': 'sans-serif',
   color: darkGray,
   'margin-top': '0.5rem',
-  'margin-bottom': '1rem',
   flex: '0 0 auto',
 };
 

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -122,7 +122,7 @@ const preStyle = {
   'margin-top': '0.5em',
   'margin-bottom': '0.5em',
   'overflow-x': 'auto',
-  'white-space': 'pre',
+  'white-space': 'pre-wrap',
   'border-radius': '0.25rem',
   'background-color': 'rgba(206, 17, 38, .05)',
 };

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -20,16 +20,16 @@ const overlayStyle = {
   width: '100%',
   height: '100%',
   'box-sizing': 'border-box',
-  'background-color': 'rgba(0,0,0,.5)',
-  padding: '0.5rem',
   'text-align': 'center',
+  'background-color': white,
 };
 
 const containerStyle = {
   position: 'relative',
   display: 'inline-flex',
   'flex-direction': 'column',
-  'max-height': '100%',
+  height: '100%',
+  width: '1024px',
   'max-width': '100%',
   'overflow-x': 'hidden',
   'overflow-y': 'auto',
@@ -41,10 +41,7 @@ const containerStyle = {
   'white-space': 'pre-wrap',
   'word-break': 'break-word',
   'line-height': 1.5,
-  'background-color': white,
   color: black,
-  'border-radius': '0.25rem',
-  'box-shadow': '0 0 10px 0 rgba(0, 0, 0, 0.15)',
 };
 
 const hintsStyle = {
@@ -73,12 +70,14 @@ const additionalStyle = {
 };
 
 const headerStyle = {
-  'font-size': '1.7em',
+  'font-size': '2em',
   'font-family': 'sans-serif',
   color: red,
   'white-space': 'pre-wrap',
   margin: '0.75rem 2rem 0 0', // Prevent overlap with close button
   flex: '0 0 auto',
+  'max-height': '35%',
+  overflow: 'auto',
 };
 
 const functionNameStyle = {

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -7,50 +7,44 @@ const black = '#293238',
   white = '#ffffff';
 
 const iframeStyle = {
-  'background-color': 'rgba(0,0,0,.5)',
   position: 'fixed',
-  top: '1em',
-  left: '1em',
-  bottom: '1em',
-  right: '1em',
-  width: 'calc(100% - 2em)',
-  height: 'calc(100% - 2em)',
+  top: '0',
+  left: '0',
+  width: '100%',
+  height: '100%',
   border: 'none',
-  'border-radius': '3px',
-  'box-shadow': '0 0 6px 0 rgba(0, 0, 0, 0.5)',
   'z-index': 1337,
 };
 
 const overlayStyle = {
-  position: 'absolute',
-  top: '0.5rem',
-  left: '50%',
-  'margin-left': '0',
-  'margin-right': '-50%',
-  transform: 'translate(-50%, 0)',
-  display: 'inline-block',
-  margin: '0.5rem',
-  'max-height': 'calc(100% - 1rem)',
-  'max-width': 'calc(100% - 1rem)',
+  width: '100%',
+  height: '100%',
   'box-sizing': 'border-box',
-  padding: '0 1rem',
+  'background-color': 'rgba(0,0,0,.5)',
+  padding: '0.5rem',
+  'text-align': 'center',
+};
+
+const containerStyle = {
+  position: 'relative',
+  display: 'inline-flex',
+  'flex-direction': 'column',
+  'max-height': '100%',
+  'max-width': '100%',
+  'overflow-x': 'hidden',
+  'overflow-y': 'auto',
+  padding: '0.5rem',
+  'box-sizing': 'border-box',
+  'text-align': 'start',
   'font-family': 'Consolas, Menlo, monospace',
   'font-size': '10px',
-  color: black,
   'white-space': 'pre-wrap',
-  overflow: 'auto',
-  'overflow-x': 'hidden',
   'word-break': 'break-word',
   'line-height': 1.5,
   'background-color': white,
+  color: black,
   'border-radius': '0.25rem',
   'box-shadow': '0 0 10px 0 rgba(0, 0, 0, 0.15)',
-};
-
-const craContainer = {
-  display: 'flex',
-  'flex-direction': 'column',
-  'max-height': '100%',
 };
 
 const hintsStyle = {
@@ -83,8 +77,8 @@ const headerStyle = {
   'font-family': 'sans-serif',
   color: red,
   'white-space': 'pre-wrap',
+  margin: '0.75rem 2rem 0 0', // Prevent overlap with close button
   flex: '0 0 auto',
-  margin: '0.75rem 0 0',
 };
 
 const functionNameStyle = {
@@ -102,8 +96,9 @@ const anchorStyle = {
 
 const traceStyle = {
   'font-size': '1em',
+  flex: '0 1 auto',
+  'min-height': '0px',
   overflow: 'auto',
-  flex: '1 1 auto',
 };
 
 const depStyle = {};
@@ -175,13 +170,13 @@ const groupElemRight = Object.assign({}, _groupElemStyle, {
 const footerStyle = {
   'font-family': 'sans-serif',
   color: darkGray,
-  flex: '0 0 auto',
   'margin-top': '0.5rem',
   'margin-bottom': '1rem',
+  flex: '0 0 auto',
 };
 
 export {
-  craContainer,
+  containerStyle,
   iframeStyle,
   overlayStyle,
   hintsStyle,

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -4,10 +4,11 @@ const black = '#293238',
   lightGray = '#fafafa',
   red = '#ce1126',
   lightRed = '#fccfcf',
-  yellow = '#fbf5b4';
+  yellow = '#fbf5b4',
+  white = '#ffffff';
 
 const iframeStyle = {
-  'background-color': lightGray,
+  'background-color': 'rgba(0,0,0,.5)',
   position: 'fixed',
   top: '1em',
   left: '1em',
@@ -22,22 +23,38 @@ const iframeStyle = {
 };
 
 const overlayStyle = {
+  position: 'absolute',
+  top: '0.5rem',
+  left: '50%',
+  'margin-left': '0',
+  'margin-right': '-50%',
+  transform: 'translate(-50%, 0)',
+  display: 'inline-block',
+  margin: '0.5rem',
+  'max-height': 'calc(100% - 1rem)',
+  'max-width': 'calc(100% - 1rem)',
   'box-sizing': 'border-box',
-  padding: '4rem',
+  padding: '0 1rem',
   'font-family': 'Consolas, Menlo, monospace',
+  'font-size': '10px',
   color: black,
   'white-space': 'pre-wrap',
   overflow: 'auto',
   'overflow-x': 'hidden',
   'word-break': 'break-word',
   'line-height': 1.5,
+  'background-color': white,
+  'border-radius': '0.25rem',
+  'box-shadow': '0 0 10px 0 rgba(0, 0, 0, 0.15)',
+};
+
+const craContainer = {
+  display: 'flex',
+  'flex-direction': 'column',
+  'max-height': '100%',
 };
 
 const hintsStyle = {
-  'font-size': '0.8em',
-  'margin-top': '-3em',
-  'margin-bottom': '3em',
-  'text-align': 'right',
   color: darkGray,
 };
 
@@ -49,7 +66,9 @@ const hintStyle = {
 const closeButtonStyle = {
   'font-size': '26px',
   color: black,
-  padding: '0.5em 1em',
+  'line-height': '1rem',
+  'font-size': '1.5rem',
+  padding: '1rem',
   cursor: 'pointer',
   position: 'absolute',
   right: 0,
@@ -63,14 +82,15 @@ const additionalStyle = {
 
 const headerStyle = {
   'font-size': '1.7em',
-  'font-weight': 'bold',
+  'font-family': 'sans-serif',
   color: red,
   'white-space': 'pre-wrap',
+  flex: '0 0 auto',
+  margin: '0.75rem 0 0',
 };
 
 const functionNameStyle = {
   'margin-top': '1em',
-  'font-size': '1.2em',
 };
 
 const linkStyle = {
@@ -84,11 +104,11 @@ const anchorStyle = {
 
 const traceStyle = {
   'font-size': '1em',
+  overflow: 'auto',
+  flex: '1 1 auto',
 };
 
-const depStyle = {
-  'font-size': '1.2em',
-};
+const depStyle = {};
 
 const primaryErrorStyle = {
   'background-color': lightRed,
@@ -100,7 +120,6 @@ const secondaryErrorStyle = {
 
 const omittedFramesStyle = {
   color: black,
-  'font-size': '0.9em',
   margin: '1.5em 0',
   cursor: 'pointer',
 };
@@ -111,7 +130,6 @@ const preStyle = {
   'margin-top': '1.5em',
   'margin-bottom': '0px',
   'overflow-x': 'auto',
-  'font-size': '1.1em',
   'white-space': 'pre',
 };
 
@@ -156,11 +174,15 @@ const groupElemRight = Object.assign({}, _groupElemStyle, {
 });
 
 const footerStyle = {
-  'text-align': 'center',
+  'font-family': 'sans-serif',
   color: darkGray,
+  flex: '0 0 auto',
+  'margin-top': '0.5rem',
+  'margin-bottom': '1rem',
 };
 
 export {
+  craContainer,
   iframeStyle,
   overlayStyle,
   hintsStyle,


### PR DESCRIPTION
This is kind of quick and dirty. Basically just editing style values inline.

I'd be happy to brainstorm ways to clean up some of the styling to make it more maintainable if you're interested? 😁

### Demos

##### Scrolling demo

<img alt="Scrolling demo" src="https://cloud.githubusercontent.com/assets/29597/26160088/986388a0-3b20-11e7-9cc9-1a0489cf4c3e.gif" width="318" height="567">

##### Chrome

<img width="432" height="702" alt="Chrome screenshot" src="https://cloud.githubusercontent.com/assets/29597/26160213/ebda3574-3b20-11e7-8f35-b58a7777198f.png">

##### iPhone

<img width="485" height="303" alt="Phone screenshot" src="https://cloud.githubusercontent.com/assets/29597/26160170/d0cc2080-3b20-11e7-9317-f8d0ed50b166.png">