### PR TITLE
Tidy up some build logs

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -65,7 +65,8 @@ function formatMessage(message, isError) {
       lines[1]
         .replace("Cannot resolve 'file' or 'directory' ", '')
         .replace('Cannot resolve module ', '')
-        .replace('Error: ', ''),
+        .replace('Error: ', '')
+        .replace('[CaseSensitivePathsPlugin] ', ''),
     ];
   }
 

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -305,6 +305,13 @@ module.exports = {
       // about it being stale, and the cache-busting can be skipped.
       dontCacheBustUrlsMatching: /\.\w{8}\./,
       filename: 'service-worker.js',
+      logger(message) {
+        if (message.indexOf('Total precache size is') === 0) {
+          // This message occurs for every build and is a bit too noisy.
+          return;
+        }
+        console.log(message);
+      },
       minify: true,
       navigateFallback: publicUrl + '/index.html',
       staticFileGlobsIgnorePatterns: [/\.map$/, /asset-manifest\.json$/],


### PR DESCRIPTION
* Hides `[CaseSensitivePathsPlugin]` prefix for errors from `case-sensitive-paths-webpack-plugin` since the messages are descriptive enough.
* Hides the `Total precache size is [...]` message from `sw-precache` which is noisy on every build. I let the other messages pass through as ejected users might misconfigure it and will likely want to see them in this case.