### PR TITLE
Disable Uglify reduce_vars

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -280,6 +280,10 @@ module.exports = {
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false,
+        // This feature has been reported as buggy a few times, such as:
+        // https://github.com/mishoo/UglifyJS2/issues/1964
+        // We'll wait with enabling it by default until it is more solid.
+        reduce_vars: false,
       },
       output: {
         comments: false,


### PR DESCRIPTION
A temporary workaround to fix https://github.com/facebookincubator/create-react-app/issues/2199.
We can revisit when https://github.com/mishoo/UglifyJS2/issues/1964 is solved.