### PR TITLE
Tweaked error overlay styles (pt2)

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -85,7 +85,7 @@ function overlayHeaderStyle() {
     'font-family: sans-serif;' +
     'color: rgb(206, 17, 38);' +
     'white-space: pre-wrap;' +
-    'margin: 0.75rem 2rem 0px 0px;' +
+    'margin: 0 2rem 0.75rem 0px;' +
     'flex: 0 0 auto;' +
     'max-height: 35%;' +
     'overflow: auto;';
@@ -129,9 +129,9 @@ function showErrorOverlay(message) {
     // TODO: unify this with our runtime overlay
     overlayDiv.innerHTML = '<div style="' +
       overlayHeaderStyle() +
-      '">Failed to compile</div><br><br>' +
+      '">Failed to compile</div>' +
       '<pre style="' +
-      'display: block; padding: 0.5em; margin-top: 0.5em; ' +
+      'display: block; padding: 0.5em; margin-top: 0; ' +
       'margin-bottom: 0.5em; overflow-x: auto; white-space: pre-wrap; ' +
       'border-radius: 0.25rem; background-color: rgba(206, 17, 38, 0.05)">' +
       '<code style="font-family: Consolas, Menlo, monospace;">' +

--- a/packages/react-error-overlay/src/components/code.js
+++ b/packages/react-error-overlay/src/components/code.js
@@ -3,10 +3,11 @@ import type { ScriptLine } from '../utils/stack-frame';
 import { applyStyles } from '../utils/dom/css';
 import { absolutifyCaret } from '../utils/dom/absolutifyCaret';
 import {
-  preStyle,
   codeStyle,
   primaryErrorStyle,
+  primaryPreStyle,
   secondaryErrorStyle,
+  secondaryPreStyle,
 } from '../styles';
 
 import generateAnsiHtml from 'react-dev-utils/ansiHTML';
@@ -82,7 +83,7 @@ function createCode(
     }
   }
   const pre = document.createElement('pre');
-  applyStyles(pre, preStyle);
+  applyStyles(pre, main ? primaryPreStyle : secondaryPreStyle);
   pre.appendChild(code);
 
   if (typeof onSourceClick === 'function') {

--- a/packages/react-error-overlay/src/components/frame.js
+++ b/packages/react-error-overlay/src/components/frame.js
@@ -6,7 +6,8 @@ import type { StackFrame } from '../utils/stack-frame';
 import type { FrameSetting, OmitsObject } from './frames';
 import { applyStyles } from '../utils/dom/css';
 import {
-  omittedFramesStyle,
+  omittedFramesExpandedStyle,
+  omittedFramesCollapsedStyle,
   functionNameStyle,
   depStyle,
   linkStyle,
@@ -39,12 +40,14 @@ function getGroupToggle(
     if (hide) {
       text1.textContent = text1.textContent.replace(/▲/, '▶');
       text1.textContent = text1.textContent.replace(/expanded/, 'collapsed');
+      applyStyles(omittedFrames, omittedFramesCollapsedStyle);
     } else {
       text1.textContent = text1.textContent.replace(/▶/, '▲');
       text1.textContent = text1.textContent.replace(/collapsed/, 'expanded');
+      applyStyles(omittedFrames, omittedFramesExpandedStyle);
     }
   });
-  applyStyles(omittedFrames, omittedFramesStyle);
+  applyStyles(omittedFrames, omittedFramesCollapsedStyle);
   return omittedFrames;
 }
 
@@ -73,7 +76,7 @@ function insertBeforeBundle(
   div.addEventListener('click', function() {
     return actionElement.click();
   });
-  applyStyles(div, omittedFramesStyle);
+  applyStyles(div, omittedFramesExpandedStyle);
   div.style.display = 'none';
 
   parent.insertBefore(div, first);

--- a/packages/react-error-overlay/src/components/overlay.js
+++ b/packages/react-error-overlay/src/components/overlay.js
@@ -40,6 +40,18 @@ function createOverlay(
   overlay.appendChild(container);
   container.appendChild(createClose(document, closeCallback));
 
+  // Create "Errors X of Y" in case of multiple errors
+  const additional = document.createElement('div');
+  applyStyles(additional, additionalStyle);
+  updateAdditional(
+    document,
+    additional,
+    currentError,
+    totalErrors,
+    switchCallback
+  );
+  container.appendChild(additional);
+
   // Create header
   const header = document.createElement('div');
   applyStyles(header, headerStyle);
@@ -63,18 +75,6 @@ function createOverlay(
   // Put it in the DOM
   header.appendChild(document.createTextNode(finalMessage));
   container.appendChild(header);
-
-  // Create "Errors X of Y" in case of multiple errors
-  const additional = document.createElement('div');
-  applyStyles(additional, additionalStyle);
-  updateAdditional(
-    document,
-    additional,
-    currentError,
-    totalErrors,
-    switchCallback
-  );
-  container.appendChild(additional);
 
   // Create trace
   container.appendChild(

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -64,7 +64,9 @@ const closeButtonStyle = {
   top: 0,
 };
 
-const additionalStyle = {};
+const additionalStyle = {
+  'margin-bottom': '0.5rem',
+};
 
 const headerStyle = {
   'font-size': '2em',

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -71,15 +71,15 @@ const headerStyle = {
   'font-family': 'sans-serif',
   color: red,
   'white-space': 'pre-wrap',
-  margin: '0.75rem 2rem 0 0', // Prevent overlap with close button
+  // Top bottom margin spaces header
+  // Right margin revents overlap with close button
+  margin: '0 2rem 0.75rem 0',
   flex: '0 0 auto',
-  'max-height': '35%',
+  'max-height': '50%',
   overflow: 'auto',
 };
 
-const functionNameStyle = {
-  'margin-top': '1em',
-};
+const functionNameStyle = {};
 
 const linkStyle = {
   'font-size': '0.9em',
@@ -113,7 +113,7 @@ const omittedFramesStyle = {
   cursor: 'pointer',
 };
 
-const preStyle = {
+const primaryPreStyle = {
   display: 'block',
   padding: '0.5em',
   'margin-top': '0.5em',
@@ -122,6 +122,16 @@ const preStyle = {
   'white-space': 'pre-wrap',
   'border-radius': '0.25rem',
   'background-color': 'rgba(206, 17, 38, .05)',
+};
+const secondaryPreStyle = {
+  display: 'block',
+  padding: '0.5em',
+  'margin-top': '0.5em',
+  'margin-bottom': '0.5em',
+  'overflow-x': 'auto',
+  'white-space': 'pre-wrap',
+  'border-radius': '0.25rem',
+  'background-color': 'rgba(251, 245, 180,.3)',
 };
 
 const toggleStyle = {
@@ -186,9 +196,10 @@ export {
   traceStyle,
   depStyle,
   primaryErrorStyle,
+  primaryPreStyle,
   secondaryErrorStyle,
+  secondaryPreStyle,
   omittedFramesStyle,
-  preStyle,
   toggleStyle,
   codeStyle,
   hiddenStyle,

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -108,9 +108,16 @@ const secondaryErrorStyle = {
   'background-color': yellow,
 };
 
-const omittedFramesStyle = {
+const omittedFramesCollapsedStyle = {
   color: black,
   cursor: 'pointer',
+  'margin-bottom': '1.5em',
+};
+
+const omittedFramesExpandedStyle = {
+  color: black,
+  cursor: 'pointer',
+  'margin-bottom': '0.6em',
 };
 
 const primaryPreStyle = {
@@ -199,7 +206,8 @@ export {
   primaryPreStyle,
   secondaryErrorStyle,
   secondaryPreStyle,
-  omittedFramesStyle,
+  omittedFramesCollapsedStyle,
+  omittedFramesExpandedStyle,
   toggleStyle,
   codeStyle,
   hiddenStyle,


### PR DESCRIPTION
Follow up from PR #2201

I think I addressed the critical things and some of the nits, including:

- [x] Moved margin between header and file name to header, so when content was scrolled, the header would remain more separate
- [x] Made build-time and runtime overlays better match
- [x] Secondary error `<pre>` style now uses yellow bg instead of red
- [x] "Scrollable Header" (see above comment to why this is necessary) but I did increase the `max-height` from 35% to 50%.
- [x] Fixed header and "X" button vertical alignment

Did not address:

- [ ] Selected Line Alignment (works for me)
- [ ] IE testing (no VM)

##### Runtime error (iOS)

<img width="321" alt="screen shot 2017-05-18 at 12 05 12 pm" src="https://cloud.githubusercontent.com/assets/29597/26197463/89cf3878-3bc2-11e7-9385-c065e17b08ba.png">

##### Runtime error (desktop)

<img width="1054" alt="screen shot 2017-05-18 at 12 05 27 pm" src="https://cloud.githubusercontent.com/assets/29597/26197412/637cc726-3bc2-11e7-9ef7-746faf9c2129.png">

##### Build error (iOS)

<img width="320" alt="screen shot 2017-05-18 at 12 09 33 pm" src="https://cloud.githubusercontent.com/assets/29597/26197547/e884fb3c-3bc2-11e7-942d-a10cc2a0a723.png">

##### Build error (desktop)

<img width="1041" alt="screen shot 2017-05-18 at 12 09 26 pm" src="https://cloud.githubusercontent.com/assets/29597/26197554/f2533dfe-3bc2-11e7-895e-608becec3a4e.png">
