### PR TITLE
Add temporary support for Node 4.x to global CLI

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -44,13 +44,13 @@ var currentNodeVersion = process.versions.node;
 var semver = currentNodeVersion.split('.');
 var major = semver[0];
 
-if (major < 6) {
+if (major < 4) {
   console.error(
     chalk.red(
       'You are running Node ' +
         currentNodeVersion +
         '.\n' +
-        'Create React App requires Node 6 or higher. \n' +
+        'Create React App requires Node 4 or higher. \n' +
         'Please update your version of Node.'
     )
   );

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -8,7 +8,7 @@
   "repository": "facebookincubator/create-react-app",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=4"
   },
   "bugs": {
     "url": "https://github.com/facebookincubator/create-react-app/issues"


### PR DESCRIPTION
Dropping support for Node 6 is breaking for CLI, so we'll bump it to 2.x.
But then even people with CLI 1.x would get `react-scripts@1.0` which isn't Node 4 compatible.

To solve this, we will release the last CLI 1.x which falls back to `react-scripts@0.9.x` on old environments.

Then we'll bump CLI to 2.x and remove support for Node 4 in it. 