### PR TITLE
Improve interaction between compile and runtime overlays

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -38,7 +38,7 @@ function createOverlayIframe(onIframeLoad) {
   iframe.style.width = '100vw';
   iframe.style.height = '100vh';
   iframe.style.border = 'none';
-  iframe.style.zIndex = 9999999999;
+  iframe.style.zIndex = 2147483647;
   iframe.onload = onIframeLoad;
   return iframe;
 }
@@ -192,7 +192,6 @@ function clearOutdatedErrors() {
 // Successful compilation.
 function handleSuccess() {
   clearOutdatedErrors();
-  destroyErrorOverlay();
 
   var isHotUpdate = !isFirstCompilation;
   isFirstCompilation = false;
@@ -200,14 +199,17 @@ function handleSuccess() {
 
   // Attempt to apply hot updates or reload.
   if (isHotUpdate) {
-    tryApplyUpdates();
+    tryApplyUpdates(function onHotUpdateSuccess() {
+      // Only destroy it when we're sure it's a hot update.
+      // Otherwise it would flicker right before the reload.
+      destroyErrorOverlay();
+    });
   }
 }
 
 // Compilation with warnings (e.g. ESLint).
 function handleWarnings(warnings) {
   clearOutdatedErrors();
-  destroyErrorOverlay();
 
   var isHotUpdate = !isFirstCompilation;
   isFirstCompilation = false;
@@ -231,6 +233,9 @@ function handleWarnings(warnings) {
       // Only print warnings if we aren't refreshing the page.
       // Otherwise they'll disappear right away anyway.
       printWarnings();
+      // Only destroy it when we're sure it's a hot update.
+      // Otherwise it would flicker right before the reload.
+      destroyErrorOverlay();
     });
   } else {
     // Print initial warnings immediately.

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -15,7 +15,7 @@ const iframeStyle = {
   width: '100%',
   height: '100%',
   border: 'none',
-  'z-index': 1337,
+  'z-index': 2147483647 - 1, // below the compile error overlay
 };
 
 const overlayStyle = {


### PR DESCRIPTION
Last thing I wanted to fix before cutting 1.0.

This changes `z-index` to the actual max possible value (and one below for runtime overlay).

It also changes the logic to prevent dismissing the syntax overlay right before the page reloads. Now we only dismiss it when the page is guaranteed to stay (which is when? I’m not sure but maybe it’ll make more sense in the future). Anyway, the point is that compile overlay should no longer disappear in flicker, just to be refreshed a few milliseconds later.