### PR TITLE
Fix shortcut handling in react-error-overlay

### DIFF
--- a/packages/react-error-overlay/src/overlay.js
+++ b/packages/react-error-overlay/src/overlay.js
@@ -110,6 +110,10 @@ function renderErrorByIndex(index: number) {
 }
 
 function switchError(offset) {
+  if (errorReferences.length === 0) {
+    return;
+  }
+
   let nextView = currReferenceIndex + offset;
 
   if (nextView < 0) {


### PR DESCRIPTION
In regard to #2231, I tried to write a quick fix for the error, by not handling shortcuts if the error list is empty.

Tested by rebuilding `react-error-overlay`, and testing shortcuts.

If you think they're is a better way to do this, i'm completely open for suggestions, as I am new to create-react-app codebase !

Thanks 😄  
