### PR TITLE
Gracefully shut down the server on signals

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -84,6 +84,14 @@ choosePort(HOST, DEFAULT_PORT)
       console.log(chalk.cyan('Starting the development server...\n'));
       openBrowser(urls.localUrlForBrowser);
     });
+
+    ['SIGINT', 'SIGTERM'].forEach(function(sig) {
+      process.on(sig, function() {
+        console.log(`Gracefully shutting down server after ${sig}...`);
+        server.close();
+        process.exit();
+      });
+    });
   })
   .catch(err => {
     if (err && err.message) {


### PR DESCRIPTION
Inspired by #787 as suggested in https://github.com/facebookincubator/create-react-app/issues/1753#issuecomment-285882292.

I think this fixes https://github.com/facebookincubator/create-react-app/issues/1753 and https://github.com/facebookincubator/create-react-app/issues/932.

I have not verified, but I’ll just go ahead and close them, and if it doesn’t work we can reopen.