### PR TITLE
Ignore .env.local in test environment

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -27,9 +27,13 @@ if (!NODE_ENV) {
 var dotenvFiles = [
   `${paths.dotenv}.${NODE_ENV}.local`,
   `${paths.dotenv}.${NODE_ENV}`,
-  `${paths.dotenv}.local`,
+  // Don't include `.env.local` for `test` environment
+  // since normally you expect tests to produce the same
+  // results for everyone
+  NODE_ENV !== 'test' && `${paths.dotenv}.local`,
   paths.dotenv,
-];
+].filter(Boolean);
+
 // Load environment variables from .env* files. Suppress warnings using silent
 // if this file is missing. dotenv will never modify any environment variables
 // that have already been set.


### PR DESCRIPTION
This matches both what https://github.com/bkeepers/dotenv does, and what we claim we do in the docs. Fixes https://github.com/facebookincubator/create-react-app/issues/2249.