### PR TITLE
Turn off operator-assignment stylistic rule

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -210,7 +210,6 @@ module.exports = {
     ],
     'no-with': 'warn',
     'no-whitespace-before-property': 'warn',
-    'operator-assignment': ['warn', 'always'],
     radix: 'warn',
     'require-yield': 'warn',
     'rest-spread-spacing': ['warn', 'never'],


### PR DESCRIPTION
It's just a style rule.
Fixes https://github.com/facebookincubator/create-react-app/issues/2245.