### PR TITLE
Fix missing dependency on npm 2

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -45,6 +45,7 @@
     "recursive-readdir": "2.2.1",
     "shell-quote": "1.6.1",
     "sockjs-client": "1.1.4",
-    "strip-ansi": "3.0.1"
+    "strip-ansi": "3.0.1",
+    "text-table": "~0.2.0"
   }
 }

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -46,6 +46,6 @@
     "shell-quote": "1.6.1",
     "sockjs-client": "1.1.4",
     "strip-ansi": "3.0.1",
-    "text-table": "~0.2.0"
+    "text-table": "0.2.0"
   }
 }


### PR DESCRIPTION
On npm 2.15.11 I'm getting an "Error: Cannot find module 'text-table'", from react-dev-utils/eslintFormatter.js:4:15). This fixes that error.