### PR TITLE
Fix incompatibility with node 4

### DIFF
--- a/packages/react-dev-utils/ModuleScopePlugin.js
+++ b/packages/react-dev-utils/ModuleScopePlugin.js
@@ -18,7 +18,7 @@ class ModuleScopePlugin {
   }
 
   apply(resolver) {
-    const { appSrc } = this;
+    const appSrc = this.appSrc;
     resolver.plugin('file', (request, callback) => {
       // Unknown issuer, probably webpack internals
       if (!request.context.issuer) {


### PR DESCRIPTION
It sounds like Node 4 may no longer be supported, but so far this is the only incompatibility I've found. It seems a shame to break Node 4 use just for a single destructuring statement.