### PR TITLE
Provide a no-op SW that will be served by the dev environment.

### DIFF
--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -240,6 +240,10 @@ getProcessForPort(3000);
 
 On macOS, tries to find a known running editor process and opens the file in it. It can also be explicitly configured by `REACT_EDITOR`, `VISUAL`, or `EDITOR` environment variables. For example, you can put `REACT_EDITOR=atom` in your `.env.local` file, and Create React App will respect that.
 
+#### `noopServiceWorkerMiddleware(): ExpressMiddleware`
+
+Returns Express middleware that serves a `/service-worker.js` that resets any previously set service worker configuration. Useful for development.
+
 #### `openBrowser(url: string): boolean`
 
 Attempts to open the browser with a given URL.<br>

--- a/packages/react-dev-utils/noopServiceWorkerMiddleware.js
+++ b/packages/react-dev-utils/noopServiceWorkerMiddleware.js
@@ -1,4 +1,20 @@
-// This service worker file is effectively a 'no-op' that will reset any
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = function createNoopServiceWorkerMiddleware() {
+  return function noopServiceWorkerMiddleware(req, res, next) {
+    if (req.url === '/service-worker.js') {
+      res.setHeader('Content-Type', 'text/javascript');
+      res.send(
+        `// This service worker file is effectively a 'no-op' that will reset any
 // previous service worker registered for the same host:port combination.
 // In the production build, this file is replaced with an actual service worker
 // file that will precache your site's local assets.
@@ -15,3 +31,10 @@ self.addEventListener('activate', () => {
     }
   });
 });
+`
+      );
+    } else {
+      next();
+    }
+  };
+};

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -21,6 +21,7 @@
     "getProcessForPort.js",
     "InterpolateHtmlPlugin.js",
     "launchEditor.js",
+    "noopServiceWorkerMiddleware.js",
     "ModuleScopePlugin.js",
     "openBrowser.js",
     "openChrome.applescript",

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const errorOverlayMiddleware = require('react-error-overlay/middleware');
+const noopServiceWorkerMiddleware = require('react-dev-utils/noopServiceWorkerMiddleware');
 const config = require('./webpack.config.dev');
 const paths = require('./paths');
 
@@ -72,6 +73,12 @@ module.exports = function(proxy, allowedHost) {
     setup(app) {
       // This lets us open files from the runtime error overlay.
       app.use(errorOverlayMiddleware());
+      // This service worker file is effectively a 'no-op' that will reset any
+      // previous service worker registered for the same host:port combination.
+      // We do this in development to avoid hitting the production cache if
+      // it used the same host and port.
+      // https://github.com/facebookincubator/create-react-app/issues/2272#issuecomment-302832432
+      app.use(noopServiceWorkerMiddleware());
     },
   };
 };

--- a/packages/react-scripts/template/public/service-worker.js
+++ b/packages/react-scripts/template/public/service-worker.js
@@ -1,0 +1,17 @@
+// This service worker file is effectively a 'no-op' that will reset any
+// previous service worker registered for the same host:port combination.
+// In the production build, this file is replaced with an actual service worker
+// file that will precache your site's local assets.
+// See https://github.com/facebookincubator/create-react-app/issues/2272#issuecomment-302832432
+
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', () => {
+  self.clients.matchAll({ type: 'window' }).then(windowClients => {
+    for (let windowClient of windowClients) {
+      // Force open pages to refresh, so that they have a chance to load the
+      // fresh navigation response from the local dev server.
+      windowClient.navigate(windowClient.url);
+    }
+  });
+});


### PR DESCRIPTION
R: @gaearon @Timer 

This adds in a "no-op" `service-worker.js` at the root of the dev environment's web server.

It works around the issue of someone serving their dev and prod environments from the same port and ending up with a production service worker that controls their dev environment.

If a user finds themselves in that situation, then the next time the browser checks for an updated service worker, the "no-op" version will be installed instead, and immediately force any open pages to reload, so that they're once again talking directly to the dev server.

(The caveat here is that, as with all things service worker-y, this assumes that `build/service-worker.js` was served [using reasonable cache headers](https://github.com/facebookincubator/create-react-app/tree/master/packages/react-scripts/template#offline-first-considerations). I took a look at how the recommended `serve` module responds to requests for the `build/service-worker.js`, and it does appear to use a very short cache lifetime, so that's good!)

Fixes #2272 