### PR TITLE
Add changelog for 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,57 @@
+## 1.0.2 (May 20, 2017)
+
+#### :bug: Bug Fix
+
+* `react-dev-utils`, `react-scripts`
+
+  * [#2276](https://github.com/facebookincubator/create-react-app/pull/2276) Serve a no-op service worker in development to ensure it doesn't cache the production build even if it was served on the same port. ([@jeffposnick](https://github.com/jeffposnick))
+
+* `react-dev-utils`, `react-error-overlay`
+
+  * [#2290](https://github.com/facebookincubator/create-react-app/pull/2290) Wrap console calls into a check for IE9. ([@gaearon](https://github.com/gaearon))
+
+* `react-dev-utils`
+
+  * [#2282](https://github.com/facebookincubator/create-react-app/pull/2282) Add Windows Subsystem for Linux support to the error overlay. ([@noinkling](https://github.com/noinkling))
+  * [#2269](https://github.com/facebookincubator/create-react-app/pull/2269) Fix a missing package dependency. ([@GreenGremlin](https://github.com/GreenGremlin))
+
+#### :nail_care: Enhancement
+
+* `react-scripts`
+
+  * [#2221](https://github.com/facebookincubator/create-react-app/pull/2221) Ejecting should ensure you have clean `git status`. ([@milocosmopolitan](https://github.com/milocosmopolitan))
+  * [#2288](https://github.com/facebookincubator/create-react-app/pull/2288) Only enable host check if you use proxy, and add a way to opt out of it. ([@gaearon](https://github.com/gaearon))
+
+#### :house: Internal
+
+* `react-dev-utils`, `react-scripts`
+
+  * [#2283](https://github.com/facebookincubator/create-react-app/pull/2283) Remove unnecessary dependencies(#751). ([@pmadar](https://github.com/pmadar))
+
+#### Committers: 6
+- Dan Abramov ([gaearon](https://github.com/gaearon))
+- Jeffrey Posnick ([jeffposnick](https://github.com/jeffposnick))
+- Jonathan ([GreenGremlin](https://github.com/GreenGremlin))
+- Malcolm ([noinkling](https://github.com/noinkling))
+- Milo Kang ([milocosmopolitan](https://github.com/milocosmopolitan))
+- [pmadar](https://github.com/pmadar)
+
+### Migrating from 1.0.1 to 1.0.2
+
+Inside any created project that has not been ejected, run:
+
+```
+npm install --save-dev --save-exact react-scripts@1.0.2
+```
+
+or
+
+```
+yarn add --dev --exact react-scripts@1.0.2
+```
+
+If you previously had issues with an `Invalid Host Header` error, [follow these new instructions](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#invalid-host-header-errors-after-configuring-proxy) to fix it.
+
 ## 1.0.1 (May 19, 2017)
 
 #### :bug: Bug Fix


### PR DESCRIPTION
## 1.0.2 (May 20, 2017)

#### :bug: Bug Fix

* `react-dev-utils`, `react-scripts`

  * [#2276](https://github.com/facebookincubator/create-react-app/pull/2276) Serve a no-op service worker in development to ensure it doesn't cache the production build even if it was served on the same port. ([@jeffposnick](https://github.com/jeffposnick))

* `react-dev-utils`, `react-error-overlay`

  * [#2290](https://github.com/facebookincubator/create-react-app/pull/2290) Wrap console calls into a check for IE9. ([@gaearon](https://github.com/gaearon))

* `react-dev-utils`

  * [#2282](https://github.com/facebookincubator/create-react-app/pull/2282) Add Windows Subsystem for Linux support to the error overlay. ([@noinkling](https://github.com/noinkling))
  * [#2269](https://github.com/facebookincubator/create-react-app/pull/2269) Fix a missing package dependency. ([@GreenGremlin](https://github.com/GreenGremlin))

#### :nail_care: Enhancement

* `react-scripts`

  * [#2221](https://github.com/facebookincubator/create-react-app/pull/2221) Ejecting should ensure you have clean `git status`. ([@milocosmopolitan](https://github.com/milocosmopolitan))
  * [#2288](https://github.com/facebookincubator/create-react-app/pull/2288) Only enable host check if you use proxy, and add a way to opt out of it. ([@gaearon](https://github.com/gaearon))

#### :house: Internal

* `react-dev-utils`, `react-scripts`

  * [#2283](https://github.com/facebookincubator/create-react-app/pull/2283) Remove unnecessary dependencies(#751). ([@pmadar](https://github.com/pmadar))

#### Committers: 6
- Dan Abramov ([gaearon](https://github.com/gaearon))
- Jeffrey Posnick ([jeffposnick](https://github.com/jeffposnick))
- Jonathan ([GreenGremlin](https://github.com/GreenGremlin))
- Malcolm ([noinkling](https://github.com/noinkling))
- Milo Kang ([milocosmopolitan](https://github.com/milocosmopolitan))
- [pmadar](https://github.com/pmadar)

### Migrating from 1.0.1 to 1.0.2

Inside any created project that has not been ejected, run:

```
npm install --save-dev --save-exact react-scripts@1.0.2
```

or

```
yarn add --dev --exact react-scripts@1.0.2
```

If you previously had issues with an `Invalid Host Header` error, [follow these new instructions](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#invalid-host-header-errors-after-configuring-proxy) to fix it.
