### PR TITLE
Updated command to check if Yarn is present.

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -192,7 +192,7 @@ function createApp(name, verbose, version, template) {
 
 function shouldUseYarn() {
   try {
-    execSync('yarnpkg --version', { stdio: 'ignore' });
+    execSync('yarn version', { stdio: 'ignore' });
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
"yarnpkg --version" command is not valid to check if Yarn exists, or to output its version. Without this, "create-react-app" always uses npm to install dependencies, even if Yarn is present. This fix will return proper result if Yarn was present and whether it should be used to install dependencies.

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
