### PR TITLE
Remove `flowtype/require-valid-file-annotation` temporarily.

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -282,7 +282,8 @@ module.exports = {
 
     // https://github.com/gajus/eslint-plugin-flowtype
     'flowtype/define-flow-type': 'warn',
-    'flowtype/require-valid-file-annotation': 'warn',
+    // TODO: Reenable once https://github.com/gajus/eslint-plugin-flowtype/issues/165 is fixed
+    //'flowtype/require-valid-file-annotation': 'warn',
     'flowtype/use-flow-type': 'warn',
   },
 };


### PR DESCRIPTION
Until this issue (https://github.com/gajus/eslint-plugin-flowtype/issues/165) is fixed we're disabling `flowtype/require-valid-file-annotation`.

(For future tracking this came out of a twitter thread: https://twitter.com/robdel12/status/866073982801502209)