### PR TITLE
Roll back to an older version of case-sensitive-paths-webpack-plugin

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -28,7 +28,7 @@
     "babel-loader": "7.0.0",
     "babel-preset-react-app": "^3.0.0",
     "babel-runtime": "6.23.0",
-    "case-sensitive-paths-webpack-plugin": "2.0.0",
+    "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",
     "connect-history-api-fallback": "1.3.0",
     "cross-spawn": "4.0.2",


### PR DESCRIPTION
This works around https://github.com/facebookincubator/create-react-app/issues/2302.