### PR TITLE
Changes no-unused-expressions lint from warning to error

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -181,7 +181,7 @@ module.exports = {
     'no-unexpected-multiline': 'warn',
     'no-unreachable': 'warn',
     'no-unused-expressions': [
-      'warn',
+      'error',
       {
         allowShortCircuit: true,
         allowTernary: true,

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -184,7 +184,6 @@ module.exports = {
       'error',
       {
         allowShortCircuit: true,
-        allowTaggedTemplates: true,
         allowTernary: true,
       },
     ],

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -184,6 +184,7 @@ module.exports = {
       'error',
       {
         allowShortCircuit: true,
+        allowTaggedTemplates: true,
         allowTernary: true,
       },
     ],


### PR DESCRIPTION
Build crashes whenever JSX is not returned as proposed here: #2303. 

The build crashes whenever JSX isn't returned, as opposed to just giving a warning.

![screenshot](https://cloud.githubusercontent.com/assets/13624905/26294330/7235efcc-3e88-11e7-9a3c-1cf39ce14aa6.png)

## To test:
Create a stateless component without a return clause.
For example:
` import React from 'react';`
`export default function Logo(){`
`    <div className="App-header">`
`        <img src="./logo.svg" className="App-logo" alt="logo" />`
`        <h2>Welcome to React</h2>`
`    </div>`
`}`

