### PR TITLE
Remove connect-history-api-fallback and cross-spawn dependencies (#751)

### DIFF
--- a/packages/react-dev-utils/crossSpawn.js
+++ b/packages/react-dev-utils/crossSpawn.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var crossSpawn = require('cross-spawn');
+
+module.exports = crossSpawn;

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -15,6 +15,7 @@
     "checkRequiredFiles.js",
     "clearConsole.js",
     "crashOverlay.js",
+    "crossSpawn.js",
     "eslintFormatter.js",
     "FileSizeReporter.js",
     "formatWebpackMessages.js",

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const spawn = require('cross-spawn');
+const spawn = require('react-dev-utils/crossSpawn');
 const script = process.argv[2];
 const args = process.argv.slice(3);
 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -30,8 +30,6 @@
     "babel-runtime": "6.23.0",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",
-    "connect-history-api-fallback": "1.3.0",
-    "cross-spawn": "4.0.2",
     "css-loader": "0.28.1",
     "dotenv": "4.0.0",
     "eslint": "3.19.0",

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -19,11 +19,11 @@ process.on('unhandledRejection', err => {
 const fs = require('fs-extra');
 const path = require('path');
 const execSync = require('child_process').execSync;
-const spawnSync = require('cross-spawn').sync;
 const chalk = require('chalk');
 const paths = require('../config/paths');
 const createJestConfig = require('./utils/createJestConfig');
 const inquirer = require('react-dev-utils/inquirer');
+const spawnSync = require('react-dev-utils/crossSpawn').sync;
 
 const green = chalk.green;
 const cyan = chalk.cyan;

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -18,8 +18,8 @@ process.on('unhandledRejection', err => {
 
 const fs = require('fs-extra');
 const path = require('path');
-const spawn = require('cross-spawn');
 const chalk = require('chalk');
+const spawn = require('react-dev-utils/crossSpawn');
 
 module.exports = function(
   appPath,


### PR DESCRIPTION
Unused dependency `connect-history-api-fallback` was removed from `react-scripts`. Next I removed `cross-spawn` dependency from `react-scripts` and use re-exported version from `react-dev-utils` instead as we discussed in my last PR (#2283).
But one think I observed is that after ejecting an app all the dependencies from react-dev-scripts remain in the yarn.lock. Is it ok?

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
