### PR TITLE
Remove tarec from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ Notable alternatives also include:
 * [aik](https://github.com/d4rkr00t/aik)
 * [react-app](https://github.com/kriasoft/react-app)
 * [dev-toolkit](https://github.com/stoikerty/dev-toolkit)
-* [tarec](https://github.com/geowarin/tarec)
 * [sku](https://github.com/seek-oss/sku)
 
 You can also use module bundlers like [webpack](http://webpack.github.io) and [Browserify](http://browserify.org/) directly.<br>


### PR DESCRIPTION
I no longer support this package.

Create-react-app is so great I can no longer call tarec a credible alternative :smile:

