### PR TITLE
Allow declaring variables before use in a scope above

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -195,7 +195,14 @@ module.exports = {
         ignoreRestSiblings: true,
       },
     ],
-    'no-use-before-define': ['warn', 'nofunc'],
+    'no-use-before-define': [
+      'warn',
+      {
+        functions: false,
+        classes: false,
+        variables: false,
+      },
+    ],
     'no-useless-computed-key': 'warn',
     'no-useless-concat': 'warn',
     'no-useless-constructor': 'warn',


### PR DESCRIPTION
Addresses the use case described in https://github.com/facebookincubator/create-react-app/issues/2157#issuecomment-303106812.
We still catch the mistakes in the same scope.