### PR TITLE
Limit console warnings to 5 files at most

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -228,6 +228,13 @@ function handleWarnings(warnings) {
 
     if (typeof console !== 'undefined' && typeof console.warn === 'function') {
       for (var i = 0; i < formatted.warnings.length; i++) {
+        if (i === 5) {
+          console.warn(
+            'There were more warnings in other files.\n' +
+              'You can find a complete log in the terminal.'
+          );
+          break;
+        }
         console.warn(stripAnsi(formatted.warnings[i]));
       }
     }


### PR DESCRIPTION
As discussed in https://github.com/facebookincubator/create-react-app/issues/2157#issuecomment-303131618.
You can still see them all in the terminal, but there's no use littering the browser console.