### PR TITLE
Resolve flow errors in eslint JSX a11y

### DIFF
--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -15,7 +15,7 @@
     "eslint": "^3.19.0",
     "eslint-plugin-flowtype": "^2.33.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-react": "^7.0.1"
   }
 }

--- a/packages/react-error-overlay/.flowconfig
+++ b/packages/react-error-overlay/.flowconfig
@@ -1,5 +1,4 @@
 [ignore]
-<PROJECT_ROOT>/node_modules/eslint-plugin-jsx-a11y/.*
 
 [include]
 src/**/*.js

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -47,7 +47,7 @@
     "eslint-config-react-app": "^1.0.3",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-import": "2.2.0",
-    "eslint-plugin-jsx-a11y": "5.0.1",
+    "eslint-plugin-jsx-a11y": "5.0.3",
     "eslint-plugin-react": "7.0.1",
     "flow-bin": "0.46.0",
     "jest": "20.0.1",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -37,7 +37,7 @@
     "eslint-loader": "1.7.1",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-import": "2.2.0",
-    "eslint-plugin-jsx-a11y": "5.0.1",
+    "eslint-plugin-jsx-a11y": "5.0.3",
     "eslint-plugin-react": "7.0.1",
     "extract-text-webpack-plugin": "2.1.0",
     "file-loader": "0.11.1",


### PR DESCRIPTION
Background
------------

After upgrading my app to `create-react-app` 1.0.0, I started seeing flow errors, coming from `eslint-plugin-jsx-a11y` that's bundled with `create-react-app`. I've been able to reproduce in [a simple test app](https://github.com/iainbeeston/eslint-plugin-jsx-a11y-241), and you can see the flow errors raised in [the circleci build for it](https://circleci.com/gh/iainbeeston/eslint-plugin-jsx-a11y-241).

What went wrong?
-------------------

`create-react-app` currently uses `eslint-plugin-jsx-a11y` locked to version 5.0.1, which has [a bug](https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/241) with it's flow types. This issue was fixed in version [5.0.2](https://github.com/evcohen/eslint-plugin-jsx-a11y/commit/d70ac7d7975819e7a52b85465ec67a0d93eb962a).

How have I fixed it?
-------------------

I've updated the `package.json` file for each of the packages in `create-react-app` to use the latest version (5.0.3) of `eslint-plugin-jsx-a11y`, which has the fix. I've also removed some flow config from `react-error-overlay` that was explicitly ignoring the flow errors that I've been seeing (no longer needed now the underlying issue in `eslint-plugin-jsx-a11y` has been fixed).