### PR TITLE
Add navigateFallbackWhitelist /__* to SW Precache config

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -320,6 +320,7 @@ module.exports = {
       },
       minify: true,
       navigateFallback: publicUrl + '/index.html',
+      navigateFallbackWhitelist: [/^(?!\/__).*/],
       staticFileGlobsIgnorePatterns: [/\.map$/, /asset-manifest\.json$/],
       // Work around Windows path issue in SWPrecacheWebpackPlugin:
       // https://github.com/facebookincubator/create-react-app/issues/2235

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -319,8 +319,12 @@ module.exports = {
         console.log(message);
       },
       minify: true,
+      // For unknown URLs, fallback to the index page
       navigateFallback: publicUrl + '/index.html',
+      // Ignores URLs starting from /__ (useful for Firebase):
+      // https://github.com/facebookincubator/create-react-app/issues/2237#issuecomment-302693219
       navigateFallbackWhitelist: [/^(?!\/__).*/],
+      // Don't precache sourcemaps (they're large) and build asset manifest:
       staticFileGlobsIgnorePatterns: [/\.map$/, /asset-manifest\.json$/],
       // Work around Windows path issue in SWPrecacheWebpackPlugin:
       // https://github.com/facebookincubator/create-react-app/issues/2235


### PR DESCRIPTION
Adds `navigateFallbackWhitelist` to service worker precache config options in Webpack config for production builds. This solves an issue with [Firebase reserved URLs](https://firebase.google.com/docs/hosting/reserved-urls) not working due to the PWA service worker serving the `navigateFallback` URL (/index.html) when non-cached URLs are requested.

Fixes part of https://github.com/facebookincubator/create-react-app/issues/2237, specifically https://github.com/facebookincubator/create-react-app/issues/2237#issuecomment-302693219.