### PR TITLE
Add changelog for 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,46 @@
+## 1.0.6 (May 24, 2017)
+
+#### :bug: Bug Fix
+
+* `eslint-config-react-app`, `react-error-overlay`, `react-scripts`
+
+  * [#2346](https://github.com/facebookincubator/create-react-app/pull/2346) Resolve Flow errors in an ESLint plugin. ([@iainbeeston](https://github.com/iainbeeston))
+
+* `react-dev-utils`
+
+  * [#2332](https://github.com/facebookincubator/create-react-app/pull/2332) Fix proxying issues with backends that don't support IPv6. ([@Timer](https://github.com/Timer))
+
+#### :nail_care: Enhancement
+* `react-scripts`
+
+  * [#2347](https://github.com/facebookincubator/create-react-app/pull/2347) Don't precache `/__*` URLs to fix Firebase hosting. ([@ryansully](https://github.com/ryansully))
+
+#### :memo: Documentation
+
+* README
+
+  * [#2334](https://github.com/facebookincubator/create-react-app/pull/2334) Add missing files to the list. ([@jesselpalmer](https://github.com/jesselpalmer))
+
+#### Committers: 4
+- Iain Beeston ([iainbeeston](https://github.com/iainbeeston))
+- Jesse Palmer ([jesselpalmer](https://github.com/jesselpalmer))
+- Joe Haddad ([Timer](https://github.com/Timer))
+- Ryan Sullivan ([ryansully](https://github.com/ryansully))
+
+### Migrating from 1.0.5 to 1.0.6
+
+Inside any created project that has not been ejected, run:
+
+```
+npm install --save-dev --save-exact react-scripts@1.0.6
+```
+
+or
+
+```
+yarn add --dev --exact react-scripts@1.0.6
+```
+
 ## 1.0.5 (May 22, 2017)
 
 #### :bug: Bug Fix


### PR DESCRIPTION
## 1.0.6 (May 24, 2017)

#### :bug: Bug Fix

* `eslint-config-react-app`, `react-error-overlay`, `react-scripts`

  * [#2346](https://github.com/facebookincubator/create-react-app/pull/2346) Resolve Flow errors in an ESLint plugin. ([@iainbeeston](https://github.com/iainbeeston))

* `react-dev-utils`

  * [#2332](https://github.com/facebookincubator/create-react-app/pull/2332) Fix proxying issues with backends that don't support IPv6. ([@Timer](https://github.com/Timer))

#### :nail_care: Enhancement
* `react-scripts`

  * [#2347](https://github.com/facebookincubator/create-react-app/pull/2347) Don't precache `/__*` URLs to fix Firebase hosting. ([@ryansully](https://github.com/ryansully))

#### :memo: Documentation

* README

  * [#2334](https://github.com/facebookincubator/create-react-app/pull/2334) Add missing files to the list. ([@jesselpalmer](https://github.com/jesselpalmer))

#### Committers: 4
- Iain Beeston ([iainbeeston](https://github.com/iainbeeston))
- Jesse Palmer ([jesselpalmer](https://github.com/jesselpalmer))
- Joe Haddad ([Timer](https://github.com/Timer))
- Ryan Sullivan ([ryansully](https://github.com/ryansully))

### Migrating from 1.0.5 to 1.0.6

Inside any created project that has not been ejected, run:

```
npm install --save-dev --save-exact react-scripts@1.0.6
```

or

```
yarn add --dev --exact react-scripts@1.0.6
```