### PR TITLE
Update webpack to v2.6.0 in react-scripts

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -53,7 +53,7 @@
     "style-loader": "0.17.0",
     "sw-precache-webpack-plugin": "0.9.1",
     "url-loader": "0.5.8",
-    "webpack": "2.5.1",
+    "webpack": "2.6.0",
     "webpack-dev-server": "2.4.5",
     "webpack-manifest-plugin": "1.1.0",
     "whatwg-fetch": "2.0.3"


### PR DESCRIPTION
This [update](https://github.com/webpack/webpack/releases/tag/v2.6.0) of webpack unlocks some new features to better handle dynamic imports. 

Not sure what should do to test it, I've ran `npm test` with no errors but `npm run e2e` fails both on windows and on WSL.