### PR TITLE
Removed the overriding of reduce_vars since webpack v2.6.0 included fix of Uglify

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -282,10 +282,6 @@ module.exports = {
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false,
-        // This feature has been reported as buggy a few times, such as:
-        // https://github.com/mishoo/UglifyJS2/issues/1964
-        // We'll wait with enabling it by default until it is more solid.
-        reduce_vars: false,
       },
       output: {
         comments: false,


### PR DESCRIPTION
This is a fix for #2293 

[Webpack v2.6.0](https://github.com/webpack/webpack/releases/tag/v2.6.0) included the [fix](https://github.com/webpack/webpack/pull/4902) of `Uglify` so we removed `reduce_vars: false` to restore the default back to `true`.
