### PR TITLE
Add yarn example under "Installing a Dependency"

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -281,6 +281,12 @@ The generated project includes React and ReactDOM as dependencies. It also inclu
 npm install --save <library-name>
 ```
 
+Alternatively you may also use `yarn`:
+
+```
+yarn add <library-name>
+```
+
 ## Importing a Component
 
 This project setup supports ES6 modules thanks to Babel.<br>


### PR DESCRIPTION
Due to many of the other examples in the README showing both `npm` and `yarn` commands.
I have added an example of how to install a dependency using `yarn`.

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
