### PR TITLE
Disable comparisons feature in uglify compression in production

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -282,6 +282,10 @@ module.exports = {
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false,
+        // Disabled because of an issue with Uglify breaking seemingly valid code:
+        // https://github.com/facebookincubator/create-react-app/issues/2376
+        // Pending further investigation:
+        // https://github.com/mishoo/UglifyJS2/issues/2011
         comparisons: false,
         // This feature has been reported as buggy a few times, such as:
         // https://github.com/mishoo/UglifyJS2/issues/1964

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -259,6 +259,9 @@ module.exports = {
     // Generates an `index.html` file with the <script> injected.
     new HtmlWebpackPlugin({
       inject: true,
+      compress: {
+        comparisons: false
+      },
       template: paths.appHtml,
       minify: {
         removeComments: true,

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -259,9 +259,6 @@ module.exports = {
     // Generates an `index.html` file with the <script> injected.
     new HtmlWebpackPlugin({
       inject: true,
-      compress: {
-        comparisons: false
-      },
       template: paths.appHtml,
       minify: {
         removeComments: true,
@@ -285,6 +282,7 @@ module.exports = {
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false,
+        comparisons: false,
         // This feature has been reported as buggy a few times, such as:
         // https://github.com/mishoo/UglifyJS2/issues/1964
         // We'll wait with enabling it by default until it is more solid.


### PR DESCRIPTION
Testing: I created an equivalent repo to the repo described in https://github.com/facebookincubator/create-react-app/issues/2376 but using this version of create-react-app, and its production build doesn't exhibit the bug mentioned in that bug.
