### PR TITLE
Consistently set environment variables

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -11,6 +11,7 @@
 'use strict';
 
 // Do this as the first thing so that any code reading it knows the right env.
+process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';
 
 // Makes the script crash on unhandled rejections instead of silently

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -10,14 +10,16 @@
 // @remove-on-eject-end
 'use strict';
 
+// Do this as the first thing so that any code reading it knows the right env.
+process.env.BABEL_ENV = 'development';
+process.env.NODE_ENV = 'development';
+
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
 process.on('unhandledRejection', err => {
   throw err;
 });
-
-process.env.NODE_ENV = 'development';
 
 // Ensure environment variables are read.
 require('../config/env');

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -10,6 +10,8 @@
 // @remove-on-eject-end
 'use strict';
 
+// Do this as the first thing so that any code reading it knows the right env.
+process.env.BABEL_ENV = 'test';
 process.env.NODE_ENV = 'test';
 process.env.PUBLIC_URL = '';
 


### PR DESCRIPTION
This ensures we set both `BABEL_ENV` and `NODE_ENV` in case the preset reads `BABEL_ENV` instead.

This probably fixes https://github.com/facebookincubator/create-react-app/issues/2377 although I still don’t understand why `BABEL_ENV=undefined` (visible in the message) was preferred to an existing `NODE_ENV`. Perhaps it only fixes it for some cases.