### PR TITLE
Suggest just "yarn build"

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -107,7 +107,7 @@ function printInstructions(appName, urls, useYarn) {
   console.log('Note that the development build is not optimized.');
   console.log(
     `To create a production build, use ` +
-      `${chalk.cyan(`${useYarn ? 'yarn' : 'npm'} run build`)}.`
+      `${chalk.cyan(`${useYarn ? 'yarn' : 'npm run'} build`)}.`
   );
   console.log();
 }


### PR DESCRIPTION
AFAIK yarn doesn't need the "run" prefix.