### PR TITLE
Catch "No tests found" during CI

### DIFF
--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -158,6 +158,16 @@ REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
   NODE_ENV=test \
   npm test -- --no-cache --testPathPattern="/src/"
 
+# Catch when no tests are detected
+testsList=$(REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
+  CI=true \
+  NODE_PATH=src \
+  npm test -- --no-cache --testPathPattern="/src/" --listTests)
+
+if [[ ${testsList} =~ "[]" ]]; then
+  exit 1
+fi
+
 # Test "development" environment
 tmp_server_log=`mktemp`
 PORT=3001 \


### PR DESCRIPTION
As noted in #2285, [appveyor tests are failing](https://ci.appveyor.com/project/gaearon/create-react-app-a3khu/build/1.0.811/job/iyhmu4pwoa9leiu2#L1415).

This PR is intended as a patch to cover this case, while the kitchensink CI tests are fixed. 