### PR TITLE
Use Babel compact mode in production

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -186,12 +186,13 @@ module.exports = {
         test: /\.(js|jsx)$/,
         include: paths.appSrc,
         loader: require.resolve('babel-loader'),
-        // @remove-on-eject-begin
         options: {
+          // @remove-on-eject-begin
           babelrc: false,
           presets: [require.resolve('babel-preset-react-app')],
+          // @remove-on-eject-end
+          compact: true,
         },
-        // @remove-on-eject-end
       },
       // The notation here is somewhat confusing.
       // "postcss" loader applies autoprefixer to our CSS.


### PR DESCRIPTION
This doesn't really make any difference AFAIK but prevents an annoying warning when the result file is too large and Babel switches this mode on automatically.