### PR TITLE
Revert "Catch "No tests found" during CI"

### DIFF
--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -158,16 +158,6 @@ REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
   NODE_ENV=test \
   npm test -- --no-cache --testPathPattern="/src/"
 
-# Catch when no tests are detected
-testsList=$(REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
-  CI=true \
-  NODE_PATH=src \
-  npm test -- --no-cache --testPathPattern="/src/" --listTests)
-
-if [[ ${testsList} =~ "[]" ]]; then
-  exit 1
-fi
-
 # Test "development" environment
 tmp_server_log=`mktemp`
 PORT=3001 \


### PR DESCRIPTION
Reverts facebookincubator/create-react-app#2387

It seems like actually fixing the issue causes a test failure with a weird message.
Let's just remove this for now.