### PR TITLE
docs: update `jest-enzyme` section

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1171,10 +1171,10 @@ Additionally, you might find [jest-enzyme](https://github.com/blainekasten/enzym
 expect(wrapper).toContainReact(welcome)
 ```
 
-To setup jest-enzyme with Create React App, follow the instructions for [initializing your test environment](#initializing-test-environment) to import `jest-enzyme`. **Note that currently only version 2.x is compatible with Create React App.**
+To setup jest-enzyme with Create React App, follow the instructions for [initializing your test environment](#initializing-test-environment) to import `jest-enzyme`.
 
 ```sh
-npm install --save-dev jest-enzyme@2.x
+npm install --save-dev jest-enzyme
 ```
 
 ```js


### PR DESCRIPTION
since CRA now uses the latest version of Jest under the hood,
`jest-enzyme` v3.2.0 is now also working perfectly fine


I've made a PR to update their docs too
https://github.com/blainekasten/enzyme-matchers/pull/99


`package.json`
![screen shot 2017-05-28 at 14 51 55](https://cloud.githubusercontent.com/assets/22868432/26527033/4b6d8062-43b5-11e7-8789-58c876bb7d47.png)

`.test.js file`
![screen shot 2017-05-28 at 14 52 57](https://cloud.githubusercontent.com/assets/22868432/26527037/678da998-43b5-11e7-8355-f30d35782697.png)

![screen shot 2017-05-28 at 14 53 59](https://cloud.githubusercontent.com/assets/22868432/26527042/90cf1b3e-43b5-11e7-943f-22f3590ee5e6.png)
*note: I intentionally make the test failed (string vs number)*