### PR TITLE
Fix Jest crashing on projects with large node_modules folders

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -26,10 +26,11 @@ module.exports = (resolve, rootDir, isEjecting) => {
     collectCoverageFrom: ['src/**/*.{js,jsx}'],
     setupFiles: [resolve('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,
-    testMatch: [
-      '<rootDir>/src/**/__tests__/**/*.js?(x)',
-      '<rootDir>/src/**/?(*.)(spec|test).js?(x)',
-    ],
+    // the `testMatches` option currently watches node_modules
+    // Which causes crashes on large projects on MacOS.
+    // Once this is fixes we can change from `modulePathIgnorePatterns` to `testMatches`.
+    // See facebook/jest/issues/1767 & facebookincubator/create-react-app/pull/2395
+    modulePathIgnorePatterns: ['<rootDir>\/(?!src).*\/.*'],
     testEnvironment: 'node',
     testURL: 'http://localhost',
     transform: {


### PR DESCRIPTION
Fixes #2393 

This PR fixes an ongoing issue with large `node_modules` folders and `create-react-app` tests.

The underlining issue is with Jest and how it watches files, and the current method that is used for [`testMatches`](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/scripts/utils/createJestConfig.js#L29-L32) means that files in `node_modules` are watched and crashes jest.

@thisconnect created issue #2393 that shows how to reproduce the error and included an example repo.

This PR uses `modulePathIgnorePatterns` to decide what to watch/not-watch instead of `testMatches` and correctly ignores `node_modules`. As seen in Jest issue facebook/jest/issues/1767