### PR TITLE
Fix kill command in e2e-kitchensink.sh cleanup

### DIFF
--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -22,7 +22,7 @@ temp_module_path=`mktemp -d 2>/dev/null || mktemp -d -t 'temp_module_path'`
 
 function cleanup {
   echo 'Cleaning up.'
-  ps -ef | grep 'react-scripts' | grep -v grep | awk '{print $2}' | xargs kill -s 9
+  ps -ef | grep 'react-scripts' | grep -v grep | awk '{print $2}' | xargs kill -9
   cd "$root_path"
   # TODO: fix "Device or resource busy" and remove ``|| $CI`
   rm -rf "$temp_cli_path" "$temp_app_path" "$temp_module_path" || $CI


### PR DESCRIPTION
This fixes #1672, the cleanup command for the kitchensink e2e tests.

The command should be either be `xargs kill -s SIGKILL` or `xargs kill -9`.

I believe this was causing issues with running e2e test locally where clean ups were partially failing and causing re-running of the tests to include old files/data.