### PR TITLE
Added cache clear to e2e scripts

### DIFF
--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -83,6 +83,17 @@ set -x
 cd ..
 root_path=$PWD
 
+# Clear cache to avoid issues with incorrect packages being used
+if hash yarnpkg 2>/dev/null
+then
+  yarn cache clean
+fi
+
+if hash npm 2>/dev/null
+then
+  npm cache clean
+fi
+
 # Prevent lerna bootstrap, we only want top-level dependencies
 cp package.json package.json.bak
 grep -v "lerna bootstrap" package.json > temp && mv temp package.json

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -86,7 +86,10 @@ root_path=$PWD
 # Clear cache to avoid issues with incorrect packages being used
 if hash yarnpkg 2>/dev/null
 then
-  yarn cache clean
+  # AppVeyor uses old version on yarn.
+  # Once updated to 0.24.3 or above install can be removed.
+  npm install -g yarn@latest
+  yarnpkg cache clean
 fi
 
 if hash npm 2>/dev/null

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -86,10 +86,20 @@ root_path=$PWD
 # Clear cache to avoid issues with incorrect packages being used
 if hash yarnpkg 2>/dev/null
 then
-  # AppVeyor uses old version on yarn.
-  # Once updated to 0.24.3 or above install can be removed.
-  npm install -g yarn@latest
-  yarnpkg cache clean
+  # AppVeyor uses an old version of yarn.
+  # Once updated to 0.24.3 or above, the workaround can be removed
+  # and replaced with `yarnpkg cache clean`
+  # Issues: 
+  #    https://github.com/yarnpkg/yarn/issues/2591
+  #    https://github.com/appveyor/ci/issues/1576
+  #    https://github.com/facebookincubator/create-react-app/pull/2400
+  # When removing workaround, you may run into
+  #    https://github.com/facebookincubator/create-react-app/issues/2030
+  case "$(uname -s)" in
+    *CYGWIN*|MSYS*|MINGW*) yarn=yarn.cmd;;
+    *) yarn=yarnpkg;;
+  esac
+  $yarn cache clean
 fi
 
 if hash npm 2>/dev/null

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -66,6 +66,17 @@ set -x
 cd ..
 root_path=$PWD
 
+# Clear cache to avoid issues with incorrect packages being used
+if hash yarnpkg 2>/dev/null
+then
+  yarn cache clean
+fi
+
+if hash npm 2>/dev/null
+then
+  npm cache clean
+fi
+
 # Prevent lerna bootstrap, we only want top-level dependencies
 cp package.json package.json.bak
 grep -v "lerna bootstrap" package.json > temp && mv temp package.json

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -69,10 +69,20 @@ root_path=$PWD
 # Clear cache to avoid issues with incorrect packages being used
 if hash yarnpkg 2>/dev/null
 then
-  # AppVeyor uses old version on yarn.
-  # Once updated to 0.24.3 or above install can be removed.
-  npm install -g yarn@latest
-  yarnpkg cache clean
+  # AppVeyor uses an old version of yarn.
+  # Once updated to 0.24.3 or above, the workaround can be removed
+  # and replaced with `yarnpkg cache clean`
+  # Issues: 
+  #    https://github.com/yarnpkg/yarn/issues/2591
+  #    https://github.com/appveyor/ci/issues/1576
+  #    https://github.com/facebookincubator/create-react-app/pull/2400
+  # When removing workaround, you may run into
+  #    https://github.com/facebookincubator/create-react-app/issues/2030
+  case "$(uname -s)" in
+    *CYGWIN*|MSYS*|MINGW*) yarn=yarn.cmd;;
+    *) yarn=yarnpkg;;
+  esac
+  $yarn cache clean
 fi
 
 if hash npm 2>/dev/null

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -69,7 +69,10 @@ root_path=$PWD
 # Clear cache to avoid issues with incorrect packages being used
 if hash yarnpkg 2>/dev/null
 then
-  yarn cache clean
+  # AppVeyor uses old version on yarn.
+  # Once updated to 0.24.3 or above install can be removed.
+  npm install -g yarn@latest
+  yarnpkg cache clean
 fi
 
 if hash npm 2>/dev/null

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -68,10 +68,20 @@ root_path=$PWD
 # Clear cache to avoid issues with incorrect packages being used
 if hash yarnpkg 2>/dev/null
 then
-  # AppVeyor uses old version on yarn.
-  # Once updated to 0.24.3 or above install can be removed.
-  npm install -g yarn@latest
-  yarnpkg cache clean
+  # AppVeyor uses an old version of yarn.
+  # Once updated to 0.24.3 or above, the workaround can be removed
+  # and replaced with `yarnpkg cache clean`
+  # Issues: 
+  #    https://github.com/yarnpkg/yarn/issues/2591
+  #    https://github.com/appveyor/ci/issues/1576
+  #    https://github.com/facebookincubator/create-react-app/pull/2400
+  # When removing workaround, you may run into
+  #    https://github.com/facebookincubator/create-react-app/issues/2030
+  case "$(uname -s)" in
+    *CYGWIN*|MSYS*|MINGW*) yarn=yarn.cmd;;
+    *) yarn=yarnpkg;;
+  esac
+  $yarn cache clean
 fi
 
 if hash npm 2>/dev/null

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -68,7 +68,10 @@ root_path=$PWD
 # Clear cache to avoid issues with incorrect packages being used
 if hash yarnpkg 2>/dev/null
 then
-  yarn cache clean
+  # AppVeyor uses old version on yarn.
+  # Once updated to 0.24.3 or above install can be removed.
+  npm install -g yarn@latest
+  yarnpkg cache clean
 fi
 
 if hash npm 2>/dev/null

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -65,6 +65,17 @@ set -x
 cd ..
 root_path=$PWD
 
+# Clear cache to avoid issues with incorrect packages being used
+if hash yarnpkg 2>/dev/null
+then
+  yarn cache clean
+fi
+
+if hash npm 2>/dev/null
+then
+  npm cache clean
+fi
+
 # Prevent lerna bootstrap, we only want top-level dependencies
 cp package.json package.json.bak
 grep -v "lerna bootstrap" package.json > temp && mv temp package.json


### PR DESCRIPTION
Fixes #2399 

Yarn is caching old react-scripts when running the e2e tests, which means old versions are being used during the build process. Fine for CI where each build is on a clean machine but breaks e2e in unforeseen ways on local machines.

This might be related to yarnpkg/yarn#2165

The fix is to run `yarn clean cache` before running the e2e tests.