### PR TITLE
Added `gluestick` to the alternatives section

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Notable alternatives also include:
 * [react-app](https://github.com/kriasoft/react-app)
 * [dev-toolkit](https://github.com/stoikerty/dev-toolkit)
 * [sku](https://github.com/seek-oss/sku)
+* [gluestick] (https://github.com/TrueCar/gluestick)
 
 You can also use module bundlers like [webpack](http://webpack.github.io) and [Browserify](http://browserify.org/) directly.<br>
 React documentation includes [a walkthrough](https://facebook.github.io/react/docs/package-management.html) on this topic.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Notable alternatives also include:
 * [react-app](https://github.com/kriasoft/react-app)
 * [dev-toolkit](https://github.com/stoikerty/dev-toolkit)
 * [sku](https://github.com/seek-oss/sku)
-* [gluestick] (https://github.com/TrueCar/gluestick)
+* [gluestick](https://github.com/TrueCar/gluestick)
 
 You can also use module bundlers like [webpack](http://webpack.github.io) and [Browserify](http://browserify.org/) directly.<br>
 React documentation includes [a walkthrough](https://facebook.github.io/react/docs/package-management.html) on this topic.


### PR DESCRIPTION
**Documentation: ReadMe update**

Gluestick is a notable alternative actively used and maintained by TrueCar

https://github.com/TrueCar/gluestick
<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
