### PR TITLE
Move eslint-plugins to peer/dev dependencies

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -35,10 +35,6 @@
     "eslint": "3.19.0",
     "eslint-config-react-app": "^1.0.4",
     "eslint-loader": "1.7.1",
-    "eslint-plugin-flowtype": "2.33.0",
-    "eslint-plugin-import": "2.2.0",
-    "eslint-plugin-jsx-a11y": "5.0.3",
-    "eslint-plugin-react": "7.0.1",
     "extract-text-webpack-plugin": "2.1.0",
     "file-loader": "0.11.1",
     "fs-extra": "3.0.1",
@@ -58,7 +54,17 @@
     "webpack-manifest-plugin": "1.1.0",
     "whatwg-fetch": "2.0.3"
   },
+  "peerDependencies": {
+    "eslint-plugin-flowtype": "2.33.0",
+    "eslint-plugin-import": "2.2.0",
+    "eslint-plugin-jsx-a11y": "5.0.3",
+    "eslint-plugin-react": "7.0.1"
+  },
   "devDependencies": {
+    "eslint-plugin-flowtype": "2.33.0",
+    "eslint-plugin-import": "2.2.0",
+    "eslint-plugin-jsx-a11y": "5.0.3",
+    "eslint-plugin-react": "7.0.1",
     "react": "^15.5.4",
     "react-dom": "^15.5.4"
   },


### PR DESCRIPTION
Moved all `eslint-plugin-*` to peer/dev dependency section of `package.json` as stated in the official documentation, see http://eslint.org/docs/developer-guide/working-with-plugins#peer-dependency

Changes are motivated by the following issue of breaking the lint command if packages were installed with `yarn`, see https://github.com/eslint/eslint/issues/8547

Maybe it would be better to define a more generic version range for the packages, just let me know what you think is best.