### PR TITLE
Add WebStorm >2017 launchEditor Support

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -72,6 +72,12 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
         ['-g', fileName + ':' + lineNumber],
         workspace
       );
+    case 'webstorm':
+    case 'webstorm64':
+      return addWorkspaceToArgumentsIfExists(
+        ['--line', lineNumber, fileName],
+        workspace
+      );
   }
 
   // For all others, drop the lineNumber until we have


### PR DESCRIPTION
WebStorm changed the format to open files from the command line in the latest versions.

Relates to #2406.

https://www.jetbrains.com/help/webstorm/2017.1/opening-files-from-command-line.html

Tested manually on my windows machine.