### PR TITLE
Update sw-precache-webpack-plugin to lastest version

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -327,9 +327,6 @@ module.exports = {
       navigateFallbackWhitelist: [/^(?!\/__).*/],
       // Don't precache sourcemaps (they're large) and build asset manifest:
       staticFileGlobsIgnorePatterns: [/\.map$/, /asset-manifest\.json$/],
-      // Work around Windows path issue in SWPrecacheWebpackPlugin:
-      // https://github.com/facebookincubator/create-react-app/issues/2235
-      stripPrefix: paths.appBuild.replace(/\\/g, '/') + '/',
     }),
     // Moment.js is an extremely popular library that bundles large locale files
     // by default due to how Webpack interprets its code. This is a practical

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -51,7 +51,7 @@
     "react-dev-utils": "^3.0.0",
     "react-error-overlay": "^1.0.7",
     "style-loader": "0.17.0",
-    "sw-precache-webpack-plugin": "0.9.1",
+    "sw-precache-webpack-plugin": "^0.11.3",
     "url-loader": "0.5.8",
     "webpack": "2.6.1",
     "webpack-dev-server": "2.4.5",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -51,7 +51,7 @@
     "react-dev-utils": "^3.0.0",
     "react-error-overlay": "^1.0.7",
     "style-loader": "0.17.0",
-    "sw-precache-webpack-plugin": "^0.11.3",
+    "sw-precache-webpack-plugin": "0.11.3",
     "url-loader": "0.5.8",
     "webpack": "2.6.1",
     "webpack-dev-server": "2.4.5",


### PR DESCRIPTION
Updating sw-precache-webpack-plugin to `v0.11.3` will fix the following related issues:

Windows path: https://github.com/facebookincubator/create-react-app/issues/2235
Duplicate builds: https://github.com/facebookincubator/create-react-app/pull/1728#issuecomment-301998584

I have tested by running `/bin/react-scripts.js build` and asserting that the build log message is not emitted twice. The problem was discovered in this https://github.com/goldhand/sw-precache-webpack-plugin/pull/78 we were calling the webpack `done` callback twice.

I do not have a windows machine to test the windows fix but the fix is exactly the same as in this configuration. The fix is [here](https://github.com/goldhand/sw-precache-webpack-plugin/blob/ea47cec497ed2fbed1dee962df325b3fdbf785ee/src/index.js#L114) and has been published for a couple weeks now with no issue.

In addition to these fixes, updating to `0.11.3` will allow chunk's with hashes to be "precached" and used in `importScripts`.
