### PR TITLE
webpack no need for `ident` if using complex options anymore

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -217,7 +217,6 @@ module.exports = {
           {
             loader: require.resolve('postcss-loader'),
             options: {
-              ident: 'postcss', // https://webpack.js.org/guides/migrating/#complex-options
               plugins: () => [
                 require('postcss-flexbugs-fixes'),
                 autoprefixer({

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -223,7 +223,6 @@ module.exports = {
                 {
                   loader: require.resolve('postcss-loader'),
                   options: {
-                    ident: 'postcss', // https://webpack.js.org/guides/migrating/#complex-options
                     plugins: () => [
                       require('postcss-flexbugs-fixes'),
                       autoprefixer({


### PR DESCRIPTION
Since `v2.2.1` of Webpack, the need for `ident` for complex options is no longer required. See

https://webpack.js.org/guides/migrating/#complex-options

Steps ran to check if `postcss-loader` and its plugins still work.

- `npm start`. 
- Add to `App.css`. 
```
display: flex;
user-select: none;
flex: 1 0 calc(1vw - 1px);
```
- Check chrome dev tools and select element too see if `postcss-flexbugs-fixes` & `autoprefixer` work. See screenshot.

<img width="766" alt="react_app_and_luisrudge_postcss-flexbugs-fixes__postcss_plugin_that_tries_to_fix_all_of_flexbug_s_issues" src="https://cloud.githubusercontent.com/assets/4893048/26652704/b379d27e-4648-11e7-8e92-15c7bcfd835d.png">

Then checked build version
- `npm run build`
- `serve -s build`
- Check chrome dev tools and select element. See screenshot
<img width="784" alt="react_app" src="https://cloud.githubusercontent.com/assets/4893048/26652903/5a1ab576-4649-11e7-8809-b866ab3db4c2.png">


