### PR TITLE
Determines whether PUBLIC_URL is same-origin before registering SW.

### DIFF
--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -10,6 +10,15 @@
 
 export default function register() {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+    // The URL constructor is available in all browsers that support SW.
+    const publicUrl = new URL(process.env.PUBLIC_URL, window.location);
+    if (publicUrl.origin !== window.location.origin) {
+      // Our service worker won't work if PUBLIC_URL is on a different origin
+      // from what our page is served on. This might happen if a CDN is used to
+      // serve assets; see https://github.com/facebookincubator/create-react-app/issues/2374
+      return;
+    }
+
     window.addEventListener('load', () => {
       const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
       navigator.serviceWorker


### PR DESCRIPTION
R: @Timer @gaearon 
FYI: @addyosmani

This is a bit more explicit than trying to use a regular expression. It uses the `URL` object inside of a block that first checks to see if `navigator.serviceWorker` is defined; `URL` should always exist in browsers that support service workers.

From testing locally, I saw scenarios in which `process.env.PUBLIC_URL` wasn't set at all (which contradicts what @Timer [suggested in the issue](https://github.com/facebookincubator/create-react-app/issues/2374#issuecomment-304362666)).

The code in this PR should behave properly regardless of whether it's unset, whether it's set to a local path, or whether it's set to a full URL.

Fixes #2374 