### PR TITLE
Add cache invalidation based on service work url

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -67,7 +67,7 @@ process.env.NODE_PATH = (process.env.NODE_PATH || '')
 // injected into the application via DefinePlugin in Webpack configuration.
 const REACT_APP = /^REACT_APP_/i;
 
-function getClientEnvironment(publicUrl) {
+function getClientEnvironment(publicUrl, packageName) {
   const raw = Object.keys(process.env)
     .filter(key => REACT_APP.test(key))
     .reduce(
@@ -84,6 +84,9 @@ function getClientEnvironment(publicUrl) {
         // This should only be used as an escape hatch. Normally you would put
         // images into the `src` and `import` them in code to get their paths.
         PUBLIC_URL: publicUrl,
+        // package.json name property.
+        // Used by service worker to know the name of the generated service worker.
+        PACKAGE_NAME: packageName,
       }
     );
   // Stringify all values so we can feed into Webpack DefinePlugin

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -29,8 +29,10 @@ const publicPath = '/';
 // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
 // Omit trailing slash as %PUBLIC_PATH%/xyz looks better than %PUBLIC_PATH%xyz.
 const publicUrl = '';
+// Get packageName from package.json
+const packageName = require(paths.appPackageJson).name;
 // Get environment variables to inject into our app.
-const env = getClientEnvironment(publicUrl);
+const env = getClientEnvironment(publicUrl, packageName);
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -35,6 +35,8 @@ const shouldUseRelativeAssetPaths = publicPath === './';
 const publicUrl = publicPath.slice(0, -1);
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
+// Get packageName from package.json
+const packageName = require(paths.appPackageJson).name;
 
 // Assert this just to be safe.
 // Development builds of React are slow and not intended for production.
@@ -311,7 +313,7 @@ module.exports = {
       // If a URL is already hashed by Webpack, then there is no concern
       // about it being stale, and the cache-busting can be skipped.
       dontCacheBustUrlsMatching: /\.\w{8}\./,
-      filename: 'service-worker.js',
+      filename: `service-worker-${packageName}.js`,
       logger(message) {
         if (message.indexOf('Total precache size is') === 0) {
           // This message occurs for every build and is a bit too noisy.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -33,10 +33,11 @@ const shouldUseRelativeAssetPaths = publicPath === './';
 // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
 // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
 const publicUrl = publicPath.slice(0, -1);
-// Get environment variables to inject into our app.
-const env = getClientEnvironment(publicUrl);
 // Get packageName from package.json
 const packageName = require(paths.appPackageJson).name;
+
+// Get environment variables to inject into our app.
+const env = getClientEnvironment(publicUrl, packageName);
 
 // Assert this just to be safe.
 // Development builds of React are slow and not intended for production.

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -17,27 +17,38 @@ export default function register() {
         // No service worker yet
         registerServiceWorker(swUrl);
       } else {
-        fetch(swUrl).then(res => {
-          // Check to see if the SW URL is valid
-          if (res.ok) {
-            // Matches. All good. Continue with registering SW
-            registerServiceWorker(swUrl);
-          } else {
-            // SW URL was invalid.
-            fetch(
-              `${window.location.protocol}//${window.location.host}`
-            ).then(res2 => {
-              // Just check if online
-              if (res2.ok) {
-                // Unregister and refresh page
-                unregister();
-                window.location.reload(true);
-              } else {
-                console.log('Offline. Using cached copy');
-              }
-            });
-          }
-        });
+        fetch(swUrl)
+          .then(res => {
+            // Check to see if the SW URL is valid
+            if (res.ok) {
+              // Matches. All good. Continue with registering SW
+              registerServiceWorker(swUrl);
+            } else {
+              // SW URL was invalid.
+              fetch(`${window.location.protocol}//${window.location.host}`)
+                .then(res2 => {
+                  // Just check if online
+                  if (res2.ok) {
+                    // Unregister and refresh page
+                    unregister();
+                    window.location.reload(true);
+                  } else {
+                    console.log('Offline. Using cached copy');
+                  }
+                })
+                .catch(err => {
+                  // Host down. Do nothing.
+                  console.log(
+                    `Caught - fetch ${window.location.protocol}//${window.location.host}`,
+                    err
+                  );
+                });
+            }
+          })
+          .catch(err => {
+            // Couldn't access service worker url becaose of timeout/fetch error. Do nothing.
+            console.log(`Caught - fetch ${swUrl}`, err);
+          });
       }
     });
   }
@@ -47,7 +58,7 @@ function registerServiceWorker(url) {
   navigator.serviceWorker
     .register(url)
     .then(registration => {
-      console.log('reg.scope', registration.scope);
+      console.log('register', registration);
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
         installingWorker.onstatechange = () => {

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -11,35 +11,67 @@
 export default function register() {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     window.addEventListener('load', () => {
+      // this would become service-work-hash.js
       const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
-      navigator.serviceWorker
-        .register(swUrl)
-        .then(registration => {
-          registration.onupdatefound = () => {
-            const installingWorker = registration.installing;
-            installingWorker.onstatechange = () => {
-              if (installingWorker.state === 'installed') {
-                if (navigator.serviceWorker.controller) {
-                  // At this point, the old content will have been purged and
-                  // the fresh content will have been added to the cache.
-                  // It's the perfect time to display a "New content is
-                  // available; please refresh." message in your web app.
-                  console.log('New content is available; please refresh.');
-                } else {
-                  // At this point, everything has been precached.
-                  // It's the perfect time to display a
-                  // "Content is cached for offline use." message.
-                  console.log('Content is cached for offline use.');
-                }
+      if (!navigator.serviceWorker.controller) {
+        // No service worker yet
+        registerServiceWorker(swUrl);
+      } else {
+        fetch(swUrl).then(res => {
+          // Check to see if the SW URL is valid
+          if (res.ok) {
+            // Matches. All good. Continue with registering SW
+            registerServiceWorker(swUrl);
+          } else {
+            // SW URL was invalid.
+            fetch(
+              `${window.location.protocol}//${window.location.host}`
+            ).then(res2 => {
+              // Just check if online
+              if (res2.ok) {
+                // Unregister and refresh page
+                unregister();
+                window.location.reload(true);
+              } else {
+                console.log('Offline. Using cached copy');
               }
-            };
-          };
-        })
-        .catch(error => {
-          console.error('Error during service worker registration:', error);
+            });
+          }
         });
+      }
     });
   }
+}
+
+function registerServiceWorker(url) {
+  navigator.serviceWorker
+    .register(url)
+    .then(registration => {
+      console.log('reg.scope', registration.scope);
+      registration.onupdatefound = () => {
+        const installingWorker = registration.installing;
+        installingWorker.onstatechange = () => {
+          if (installingWorker.state === 'installed') {
+            if (navigator.serviceWorker.controller) {
+              // At this point, the old content will have been purged and
+              // the fresh content will have been added to the cache.
+              // It's the perfect time to display a "New content is
+              // available; please refresh." message in your web app.
+              console.log('New content is available; please refresh.');
+            } else {
+              // At this point, everything has been precached.
+              // It's the perfect time to display a
+              // "Content is cached for offline use." message.
+              console.log('Content is cached for offline use.');
+            }
+          }
+        };
+      };
+    })
+    .catch(error => {
+      console.log('No service worker found');
+      console.error('Error during service worker registration:', error);
+    });
 }
 
 export function unregister() {

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -12,7 +12,7 @@ export default function register() {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       // this would become service-work-hash.js
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker-${process.env.PACKAGE_NAME}.js`;
       if (!navigator.serviceWorker.controller) {
         // No service worker yet
         registerServiceWorker(swUrl);


### PR DESCRIPTION
Addresses some of the issues raised in #2398 

Specifically, that service workers are
- Showing the wrong page when a non-CRA app is hosted at the same url + port, with manually deleting the SW the only way to fix it.
- Showing an old CRA project if you are hosting a new on at the CRA on first visit. When refreshed the new project will show.

This adds the following checks when using service workers to fix these issues
 - Check if service worker already exists
 - If no service work, add service worker
 - If service worker is found, check the serviceworker url. 
 - If its finds a 200 ok at the url. Then use the service worker as normal. (Same app)
 - If it doesn't doesn't get a 200 ok. Then check if the domain is working.
 - If domain responses with 200 ok. Then remove service worker and refresh the page (different app)
 - If anything else. Assume domain or user is offline and used service worker to provide cache.

For this to work properly, we'd need to give the service-worker.js a unique name such as `service-worker-[projectname].js`. This way each project as a unique service worker URL and we can tell if we are using the correct service worker.

For the webpack setup, we can just create a customer name for the generated the service worker using (`service-worker-${packageName}]`. 

For the `registerServiceWorker.js` we create an environment variable that contains the projects package.json name, and use this to know the right file to look for.

@gaearon @Timer @jeffposnick -  ~~Any ideas how we can name/rename the `service-worker.js`?~~
- [x] Make it work
- [x] How to correctly name `service-worker.js`
- [ ] Think of edge cases and how to handle them - Currently handles offline and website down
- [ ] How big is the slowdown in using fetch before we load the service worker? Especially if we are offline.
- [x] Is the a quicker way to tell if a device is offline? *If offline we should catch immediately*
- [ ] Tests?
- [ ] Are there other ways to deterministically tell what project a cached service worker is attributed to?

 