### PR TITLE
Fix wrong comment on Proxy guide

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -972,7 +972,7 @@ You may also narrow down matches using `*` and/or `**`, to match the path exactl
       "target": "<url_3>",
       // ...
     },
-    // Matches /bar/abc.html and /bar/sub/def.html
+    // Matches /baz/abc.html and /baz/sub/def.html
     "/baz/**/*.html": {
       "target": "<url_4>"
       // ...


### PR DESCRIPTION
It should be `baz` instead of `bar` on last example.

```
    // Matches /bar/abc.html and /bar/sub/def.html <- wrong
    "/baz/**/*.html": {
      "target": "<url_4>"
      // ...
    }
```