### PR TITLE
Update Travis CI Node versions in User Guide

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1244,7 +1244,6 @@ Popular CI servers already set the environment variable `CI` by default but you 
 ```
 language: node_js
 node_js:
-  - 4
   - 6
 cache:
   directories:


### PR DESCRIPTION
Removed Node v4 (CRA only supports Node >= 6)