### PR TITLE
Added NamedModulesPlugin in webpack.config.dev.js

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -249,6 +249,8 @@ module.exports = {
       inject: true,
       template: paths.appHtml,
     }),
+    // Display better module name in profiler
+    new webpack.NamedModulesPlugin(),
     // Makes some environment variables available to the JS code, for example:
     // if (process.env.NODE_ENV === 'development') { ... }. See `./env.js`.
     new webpack.DefinePlugin(env.stringified),

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -249,7 +249,7 @@ module.exports = {
       inject: true,
       template: paths.appHtml,
     }),
-    // Display better module name in profiler
+    // Add module names to factory functions so they appear in browser profiler.
     new webpack.NamedModulesPlugin(),
     // Makes some environment variables available to the JS code, for example:
     // if (process.env.NODE_ENV === 'development') { ... }. See `./env.js`.


### PR DESCRIPTION
Added `webpack.NamedModulesPlugin()` according to #2448 

Profiler now look like this instead of anonymous:
![updated-profiler](https://cloud.githubusercontent.com/assets/11663635/26734741/bc742546-47f1-11e7-9e2e-19161f4c4986.png)
