### PR TITLE
Prioritize index.css over the implicit App.css

### DIFF
--- a/packages/react-scripts/template/src/index.js
+++ b/packages/react-scripts/template/src/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import './index.css';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
-import './index.css';
 
 ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();


### PR DESCRIPTION
Hi. I'm under the assumption that `index.css` is used for global styles not associated with any component. This is where I import 3rd party css libraries as well. However, I noticed that it would override the styles in `App.css`.