### PR TITLE
Remove module field in production webpack config

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -115,6 +115,12 @@ module.exports = {
       // Make sure your source files are compiled, as they will not be processed in any way.
       new ModuleScopePlugin(paths.appSrc),
     ],
+    // webpack includes 'module' by default. However, this corresponds to ES6+ modules,
+    // which are unsupported by uglify. Should be reverted if/when ES6+ is targeted and/or
+    // uglify-es used, see:
+    // https://webpack.js.org/configuration/resolve/#resolve-mainfields
+    // https://github.com/facebookincubator/create-react-app/issues/2108
+    mainFields: ['browser', 'main'],
   },
   module: {
     strictExportPresence: true,


### PR DESCRIPTION
This crops up in the form of uglify errors during a production build, e.g. #2236, #2433, #2475. The suggestion there is to transpile deps down to ES5 and/or remove `module`. This is correct with respect to `main`, however `module` is there specifically to indicate ES module support, which uglify doesn't support. Therefore, ask webpack not to resolve it.

You can test this by depending on a package that ships with multiple targets i.e. `main` pointing to a transpiled/common JS target and `module` targeting ES6+, e.g. [tlvince-reduced-test-case-cra-module](https://github.com/tlvince/tlvince-reduced-test-case-cra-module):

`src/index.js`
```
import test from 'tlvince-reduced-test-case-cra-module' 
test()
```

Before:

```
> react-scripts build

Creating an optimized production build...

Failed to compile.

static/js/main.1b21038d.js from UglifyJs
Unexpected token: punc (}) [./~/tlvince-reduced-test-case-cra-module/dist/tlvince-reduced-test-case-cra-module.es.js:1,14][static/js/main.1b21038d.js:79667,19]
```

After:

```
> react-scripts build

Creating an optimized production build...
Compiled successfully.
```