### PR TITLE
Removed default options from some Babel plugins

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -33,7 +33,6 @@ const plugins = [
     {
       helpers: false,
       polyfill: false,
-      regenerator: true,
     },
   ],
 ];
@@ -104,8 +103,6 @@ if (env === 'test') {
             // Remove after https://github.com/mishoo/UglifyJS2/issues/448
             uglify: true,
           },
-          // Disable polyfill transforms
-          useBuiltIns: false,
           // Do not transform modules to CJS
           modules: false,
         },


### PR DESCRIPTION
<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
This PR removes default config options from some Babel plugins in `babel-preset-react-app`:

- Removed the `regenerator` option for `babel-plugin-transform-runtime` ([defaults to `true`](https://babeljs.io/docs/plugins/transform-runtime/#optionsregenerator)).
- Removed the `useBuiltIns` option for `babel-preset-env` ([defaults to `false`](https://github.com/babel/babel-preset-env#usebuiltins)).

I tested these changes by running `npm test` in the `create-react-app` root dir (tests passed), and transpiling a simple file (verified that the output was the same before and after these changes).

Here's the file I used:
```javascript
// src/foo.js

import 'babel-polyfill';

function *foo() {
    yield 42;
}
```
**BEFORE**

`$ NODE_ENV=production ./node_modules/.bin/babel src/foo.js` yields:
```
import _regeneratorRuntime from 'babel-runtime/regenerator';

var _marked = [foo].map(_regeneratorRuntime.mark);

import 'babel-polyfill';

function foo() {
    return _regeneratorRuntime.wrap(function foo$(_context) {
        while (1) {
            switch (_context.prev = _context.next) {
                case 0:
                    _context.next = 2;
                    return 42;

                case 2:
                case 'end':
                    return _context.stop();
            }
        }
    }, _marked[0], this);
}
```
`$ NODE_ENV=development ./node_modules/.bin/babel src/foo.js` yields:
```
import _regeneratorRuntime from 'babel-runtime/regenerator';

var _marked = [foo].map(_regeneratorRuntime.mark);

import 'babel-polyfill';

function foo() {
    return _regeneratorRuntime.wrap(function foo$(_context) {
        while (1) {
            switch (_context.prev = _context.next) {
                case 0:
                    _context.next = 2;
                    return 42;

                case 2:
                case 'end':
                    return _context.stop();
            }
        }
    }, _marked[0], this);
}
```
`$ NODE_ENV=test ./node_modules/.bin/babel src/foo.js` yields:
```
'use strict';

var _regenerator = require('babel-runtime/regenerator');

var _regenerator2 = _interopRequireDefault(_regenerator);

require('babel-polyfill');

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

var _marked = [foo].map(_regenerator2.default.mark);

function foo() {
    return _regenerator2.default.wrap(function foo$(_context) {
        while (1) {
            switch (_context.prev = _context.next) {
                case 0:
                    _context.next = 2;
                    return 42;

                case 2:
                case 'end':
                    return _context.stop();
            }
        }
    }, _marked[0], this);
}
```

**AFTER**

`$ NODE_ENV=production ./node_modules/.bin/babel src/foo.js` yields:
```
import _regeneratorRuntime from 'babel-runtime/regenerator';

var _marked = [foo].map(_regeneratorRuntime.mark);

import 'babel-polyfill';

function foo() {
    return _regeneratorRuntime.wrap(function foo$(_context) {
        while (1) {
            switch (_context.prev = _context.next) {
                case 0:
                    _context.next = 2;
                    return 42;

                case 2:
                case 'end':
                    return _context.stop();
            }
        }
    }, _marked[0], this);
}
```
`$ NODE_ENV=development ./node_modules/.bin/babel src/foo.js` yields:
```
import _regeneratorRuntime from 'babel-runtime/regenerator';

var _marked = [foo].map(_regeneratorRuntime.mark);

import 'babel-polyfill';

function foo() {
    return _regeneratorRuntime.wrap(function foo$(_context) {
        while (1) {
            switch (_context.prev = _context.next) {
                case 0:
                    _context.next = 2;
                    return 42;

                case 2:
                case 'end':
                    return _context.stop();
            }
        }
    }, _marked[0], this);
}
```
`$ NODE_ENV=test ./node_modules/.bin/babel src/foo.js` yields:
```
'use strict';

var _regenerator = require('babel-runtime/regenerator');

var _regenerator2 = _interopRequireDefault(_regenerator);

require('babel-polyfill');

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

var _marked = [foo].map(_regenerator2.default.mark);

function foo() {
    return _regenerator2.default.wrap(function foo$(_context) {
        while (1) {
            switch (_context.prev = _context.next) {
                case 0:
                    _context.next = 2;
                    return 42;

                case 2:
                case 'end':
                    return _context.stop();
            }
        }
    }, _marked[0], this);
}
```
Outputs for all envs seem to be the same.