### PR TITLE
Convert any env var string containing only digits to a number

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -72,7 +72,15 @@ function getClientEnvironment(publicUrl) {
     .filter(key => REACT_APP.test(key))
     .reduce(
       (env, key) => {
-        env[key] = process.env[key];
+        var value = process.env[key];
+        // Convert any string containing only digits to int or float
+        if (value.match(/^[0-9]+$/)) {
+          value = parseInt(value, 10);
+        }
+        else if (value.match(/^([0-9]+.?[0-9]*)|([0-9]*.?[0-9]+)$/)) {
+          value = parseFloat(value);
+        }
+        env[key] = value;
         return env;
       },
       {


### PR DESCRIPTION
This would be a breaking change and also prevents separation of obtaining env vars from parsing env vars.  Having said that I find this very convenient to use in my own projects and am interested to hear what others think about it.  For example making boolean flags is trivial:  `REACT_APP_SEND_EMAIL=0` then in code `if (process.env.REACT_APP_SEND_EMAIL) { ... } else { // not sending email }` and validations used in front and back end code have the same value `if (password.length < process.env.REACT_APP_MIN_PASSWORD_LENGTH) { ... }`.

Will add docs if there's interest in this otherwise will close and leave for others to find and use as they wish.

Note this correctly handles non numbers such as random strings `47cbe9fb2a5c`, ip addresses `234.234.234.234`, and octal / file permissions / non numbers `0644` or `123   123` by leaving them as strings.

Additionally if someone is already using `parseInt(ENV_VAR)` this remains unchanged however `ENV_VAR === "1"` would break hence the breaking change statement.