### PR TITLE
Better React Native Web support

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -94,7 +94,9 @@ module.exports = {
     // We also include JSX as a common component filename extension to support
     // some tools, although we do not recommend using it, see:
     // https://github.com/facebookincubator/create-react-app/issues/290
-    extensions: ['.js', '.json', '.jsx'],
+    // `web` extension prefixes have been added for better support
+    // for React Native Web.
+    extensions: ['.web.js', '.js', '.json', '.web.jsx', '.jsx'],
     alias: {
       // @remove-on-eject-begin
       // Resolve Babel runtime relative to react-scripts.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -92,7 +92,9 @@ module.exports = {
     // We also include JSX as a common component filename extension to support
     // some tools, although we do not recommend using it, see:
     // https://github.com/facebookincubator/create-react-app/issues/290
-    extensions: ['.js', '.json', '.jsx'],
+    // `web` extension prefixes have been added for better support
+    // for React Native Web.
+    extensions: ['.web.js', '.js', '.json', '.web.jsx', '.jsx'],
     alias: {
       // @remove-on-eject-begin
       // Resolve Babel runtime relative to react-scripts.

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -43,6 +43,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
     },
+    moduleFileExtensions: ['web.js', 'js', 'json', 'web.jsx', 'jsx'],
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
This PR will be fixing a pain point I've been experiencing in code reuse of React Native projects with Create React App projects. The React Native bundler will allow Android specific code to resolve with a prefixed `.android` on the default `.js`/`.jsx` extension. This PR is allowing that same functionality but with web specific code.

While React Native Web support has been added in in the past, the addition did not follow 
_https://github.com/necolas/react-native-web/blob/master/docs/guides/getting-started.md_ exactly, missing the added extensions options to the webpack config.

Something I may have missed in the PR is making any additional changes to the file `/create-react-app/packages/react-scripts/scripts/utils/createJestConfig.js`. Will there need to be any additional extension resolving here? I'm not too familiar with Jest setups but would be happy to add anything in if I could be pointed in the right direction.

Thanks for looking this PR over, lemme know if there's any problems with the changes here. Excited to contribute. 😄