### PR TITLE
Show warning when trying to run on port below 1024 without admin permissions under Linux/macOS

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -14,6 +14,7 @@ const path = require('path');
 const url = require('url');
 const chalk = require('chalk');
 const detect = require('detect-port-alt');
+const isRoot = require('is-root');
 const inquirer = require('inquirer');
 const clearConsole = require('./clearConsole');
 const formatWebpackMessages = require('./formatWebpackMessages');
@@ -378,6 +379,11 @@ function choosePort(host, defaultPort) {
       if (port === defaultPort) {
         return resolve(port);
       }
+      const message = process.platform !== 'win32' &&
+        defaultPort < 1024 &&
+        !isRoot()
+        ? `Admin permissions are required to run a server on a port below 1024.`
+        : `Something is already running on port ${defaultPort}.`;
       if (isInteractive) {
         clearConsole();
         const existingProcess = getProcessForPort(defaultPort);
@@ -385,7 +391,7 @@ function choosePort(host, defaultPort) {
           type: 'confirm',
           name: 'shouldChangePort',
           message: chalk.yellow(
-            `Something is already running on port ${defaultPort}.` +
+            message +
               `${existingProcess ? ` Probably:\n  ${existingProcess}` : ''}`
           ) + '\n\nWould you like to run the app on another port instead?',
           default: true,
@@ -398,9 +404,7 @@ function choosePort(host, defaultPort) {
           }
         });
       } else {
-        console.log(
-          chalk.red(`Something is already running on port ${defaultPort}.`)
-        );
+        console.log(chalk.red(message));
         resolve(null);
       }
     }),

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -44,6 +44,7 @@
     "gzip-size": "3.0.0",
     "html-entities": "1.2.1",
     "inquirer": "3.0.6",
+    "is-root": "1.0.0",
     "opn": "5.0.0",
     "recursive-readdir": "2.2.1",
     "shell-quote": "1.6.1",


### PR DESCRIPTION
On Linux/macOS (and WSL too) it requires admin permissions to run a server on a port below 1024.
I'm shifting my development stuff to WSL on Windows at the moment and didn't know that so it would be nice to show another message in this case.

![image](https://user-images.githubusercontent.com/9491603/27012674-a24fd4a0-4ed4-11e7-97f2-459ea53b769f.png)

- [x] Tested on WSL
- [x] Tested on Linux
- [x] Tested on macOS (I cannot do this. No Mac.)

ref #2512 