### PR TITLE
Upgrade fsevents to 1.1.2

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -63,6 +63,6 @@
     "react-dom": "^15.5.4"
   },
   "optionalDependencies": {
-    "fsevents": "1.0.17"
+    "fsevents": "1.1.2"
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

This eliminates a `yarn` warning on OSX machines running Node.js 8. See
here for details: https://github.com/strongloop/fsevents/issues/170

You can see an example of the warning in the second screenshot in
https://github.com/facebookincubator/create-react-app/issues/2422#issuecomment-305218252

I verified this by running:

```bash
npm run create-react-app my-app
cd my-app
yarn
```