### PR TITLE
Add simplified service worker invalidation

### DIFF
--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -21,34 +21,59 @@ export default function register() {
 
     window.addEventListener('load', () => {
       const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
-      navigator.serviceWorker
-        .register(swUrl)
-        .then(registration => {
-          registration.onupdatefound = () => {
-            const installingWorker = registration.installing;
-            installingWorker.onstatechange = () => {
-              if (installingWorker.state === 'installed') {
-                if (navigator.serviceWorker.controller) {
-                  // At this point, the old content will have been purged and
-                  // the fresh content will have been added to the cache.
-                  // It's the perfect time to display a "New content is
-                  // available; please refresh." message in your web app.
-                  console.log('New content is available; please refresh.');
-                } else {
-                  // At this point, everything has been precached.
-                  // It's the perfect time to display a
-                  // "Content is cached for offline use." message.
-                  console.log('Content is cached for offline use.');
-                }
-              }
-            };
-          };
+
+      fetch(swUrl)
+        .then(response => {
+          // Ensure service worker exists, and that we really are getting a JS file.
+          if (
+            response.status === 404 ||
+            response.headers.get('content-type').indexOf('javascript') === -1
+          ) {
+            navigator.serviceWorker.ready.then(registration => {
+              registration.unregister().then(() => {
+                window.location.reload();
+              });
+            });
+          } else {
+            registerValidSW(swUrl);
+          }
         })
-        .catch(error => {
-          console.error('Error during service worker registration:', error);
+        .catch(() => {
+          console.log(
+            'No internet connection found. App is running in offline mode.'
+          );
         });
     });
   }
+}
+
+function registerValidSW(swUrl) {
+  navigator.serviceWorker
+    .register(swUrl)
+    .then(registration => {
+      registration.onupdatefound = () => {
+        const installingWorker = registration.installing;
+        installingWorker.onstatechange = () => {
+          if (installingWorker.state === 'installed') {
+            if (navigator.serviceWorker.controller) {
+              // At this point, the old content will have been purged and
+              // the fresh content will have been added to the cache.
+              // It's the perfect time to display a "New content is
+              // available; please refresh." message in your web app.
+              console.log('New content is available; please refresh.');
+            } else {
+              // At this point, everything has been precached.
+              // It's the perfect time to display a
+              // "Content is cached for offline use." message.
+              console.log('Content is cached for offline use.');
+            }
+          }
+        };
+      };
+    })
+    .catch(error => {
+      console.error('Error during service worker registration:', error);
+    });
 }
 
 export function unregister() {

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -8,6 +8,16 @@
 // To learn more about the benefits of this model, read https://goo.gl/KwvDNy.
 // This link also includes instructions on opting out of this behavior.
 
+const isLocalhost = Boolean(
+  window.location.hostname === 'localhost' ||
+    // [::1] is the IPv6 localhost address.
+    window.location.hostname === '[::1]' ||
+    // 127.0.0.1/8 is considered localhost for IPv4.
+    window.location.hostname.match(
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+    )
+);
+
 export default function register() {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
@@ -22,27 +32,13 @@ export default function register() {
     window.addEventListener('load', () => {
       const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
 
-      fetch(swUrl)
-        .then(response => {
-          // Ensure service worker exists, and that we really are getting a JS file.
-          if (
-            response.status === 404 ||
-            response.headers.get('content-type').indexOf('javascript') === -1
-          ) {
-            navigator.serviceWorker.ready.then(registration => {
-              registration.unregister().then(() => {
-                window.location.reload();
-              });
-            });
-          } else {
-            registerValidSW(swUrl);
-          }
-        })
-        .catch(() => {
-          console.log(
-            'No internet connection found. App is running in offline mode.'
-          );
-        });
+      if (!isLocalhost) {
+        // Is not local host. Just register service worker
+        registerValidSW(swUrl);
+      } else {
+        // This is running on localhost. Lets check if a service worker still exists or not.
+        checkValidServiceWorker(swUrl);
+      }
     });
   }
 }
@@ -73,6 +69,33 @@ function registerValidSW(swUrl) {
     })
     .catch(error => {
       console.error('Error during service worker registration:', error);
+    });
+}
+
+function checkValidServiceWorker(swUrl) {
+  // Check if the service worker can be found. If it can't reload the page.
+  fetch(swUrl)
+    .then(response => {
+      // Ensure service worker exists, and that we really are getting a JS file.
+      if (
+        response.status === 404 ||
+        response.headers.get('content-type').indexOf('javascript') === -1
+      ) {
+        // No service worker found. Probably a different app. Reload the page.
+        navigator.serviceWorker.ready.then(registration => {
+          registration.unregister().then(() => {
+            window.location.reload();
+          });
+        });
+      } else {
+        // Service worker found. Proceed as normal.
+        registerValidSW(swUrl);
+      }
+    })
+    .catch(() => {
+      console.log(
+        'No internet connection found. App is running in offline mode.'
+      );
     });
 }
 


### PR DESCRIPTION
Adds invalidation of service workers based on by attempting to `fetch` `service-worker.js` and if its receives a 404, or if its the wrong content type (e.g. all not found urls are being redirected to index.html or serving a 404 page without a 404 code) it unregistered the current service worker and reloads the page.

This issues the issue where sites hosted on the same `url:port` (e.g. `localhost:5000`) are incorrectly displaying`create-react-app` instead of the hosted page.

This was addressed in a more complex manner in #2438. However, this is a simplified version based on the feedback of @jeffposnick.

Note: I created a new PR/Branch because I believe #2438 addresses more cases, however it also adds complexity. This PR should fix most use cases when combined with #2426.
