### PR TITLE
Auto-detect running editor on Windows for error overlay

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -8,12 +8,12 @@
  */
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var child_process = require('child_process');
-var os = require('os');
-var chalk = require('chalk');
-var shellQuote = require('shell-quote');
+const fs = require('fs');
+const path = require('path');
+const child_process = require('child_process');
+const os = require('os');
+const chalk = require('chalk');
+const shellQuote = require('shell-quote');
 
 function isTerminalEditor(editor) {
   switch (editor) {
@@ -28,13 +28,19 @@ function isTerminalEditor(editor) {
 // Map from full process name to binary that starts the process
 // We can't just re-use full process name, because it will spawn a new instance
 // of the app every time
-var COMMON_EDITORS = {
+const COMMON_EDITORS_OSX = {
   '/Applications/Atom.app/Contents/MacOS/Atom': 'atom',
   '/Applications/Atom Beta.app/Contents/MacOS/Atom Beta': '/Applications/Atom Beta.app/Contents/MacOS/Atom Beta',
   '/Applications/Sublime Text.app/Contents/MacOS/Sublime Text': '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl',
   '/Applications/Sublime Text 2.app/Contents/MacOS/Sublime Text 2': '/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl',
   '/Applications/Visual Studio Code.app/Contents/MacOS/Electron': 'code',
 };
+
+const COMMON_EDITORS_WIN = [
+  'Code.exe',
+  'atom.exe',
+  'sublime_text.exe'
+];
 
 function addWorkspaceToArgumentsIfExists(args, workspace) {
   if (workspace) {
@@ -44,7 +50,7 @@ function addWorkspaceToArgumentsIfExists(args, workspace) {
 }
 
 function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
-  var editorBasename = path.basename(editor).replace(/\.(exe|cmd|bat)$/i, '');
+  const editorBasename = path.basename(editor).replace(/\.(exe|cmd|bat)$/i, '');
   switch (editorBasename) {
     case 'vim':
     case 'mvim':
@@ -54,6 +60,7 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
     case 'Atom Beta':
     case 'subl':
     case 'sublime':
+    case 'sublime_text':
     case 'wstorm':
     case 'appcode':
     case 'charm':
@@ -68,6 +75,7 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
     case 'mine':
       return ['--line', lineNumber, fileName];
     case 'code':
+    case 'Code':
       return addWorkspaceToArgumentsIfExists(
         ['-g', fileName + ':' + lineNumber],
         workspace
@@ -92,21 +100,37 @@ function guessEditor() {
     return shellQuote.parse(process.env.REACT_EDITOR);
   }
 
-  // Using `ps x` on OSX we can find out which editor is currently running.
-  // Potentially we could use similar technique for Windows and Linux
-  if (process.platform === 'darwin') {
-    try {
-      var output = child_process.execSync('ps x').toString();
-      var processNames = Object.keys(COMMON_EDITORS);
-      for (var i = 0; i < processNames.length; i++) {
-        var processName = processNames[i];
+  // Using `ps x` on OSX or `Get-Process` on Windows we can find out which editor is currently running.
+  // Potentially we could use similar technique for Linux
+  try {
+    if (process.platform === 'darwin') {
+      const output = child_process.execSync('ps x').toString();
+      const processNames = Object.keys(COMMON_EDITORS_OSX);
+      for (let i = 0; i < processNames.length; i++) {
+        const processName = processNames[i];
         if (output.indexOf(processName) !== -1) {
-          return [COMMON_EDITORS[processName]];
+          return [COMMON_EDITORS_OSX[processName]];
         }
       }
-    } catch (error) {
-      // Ignore...
+    } else if (process.platform === 'win32') {
+      const output = child_process.execSync('powershell -Command "Get-Process | Select-Object Path"').toString();
+      const runningProcesses = output.split('\r\n');
+      for (let i = 0; i < runningProcesses.length; i++) {
+        // `Get-Process` sometimes returns empty lines
+        if (!runningProcesses[i]) {
+          continue; 
+        }
+
+        const fullProcessPath = runningProcesses[i].trim();
+        const shortProcessName = path.basename(fullProcessPath);
+
+        if (COMMON_EDITORS_WIN.indexOf(shortProcessName) !== -1) {
+          return [fullProcessPath];
+        }
+      }
     }
+  } catch (error) {
+    // Ignore...
   }
 
   // Last resort, use old skool env vars
@@ -144,7 +168,7 @@ function printInstructions(fileName, errorMessage) {
   console.log();
 }
 
-var _childProcess = null;
+let _childProcess = null;
 function launchEditor(fileName, lineNumber) {
   if (!fs.existsSync(fileName)) {
     return;
@@ -176,7 +200,7 @@ function launchEditor(fileName, lineNumber) {
     fileName = path.relative('', fileName);
   }
 
-  var workspace = null;
+  let workspace = null;
   if (lineNumber) {
     args = args.concat(
       getArgumentsForLineNumber(editor, fileName, lineNumber, workspace)

--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -36,11 +36,7 @@ const COMMON_EDITORS_OSX = {
   '/Applications/Visual Studio Code.app/Contents/MacOS/Electron': 'code',
 };
 
-const COMMON_EDITORS_WIN = [
-  'Code.exe',
-  'atom.exe',
-  'sublime_text.exe'
-];
+const COMMON_EDITORS_WIN = ['Code.exe', 'atom.exe', 'sublime_text.exe'];
 
 function addWorkspaceToArgumentsIfExists(args, workspace) {
   if (workspace) {
@@ -113,12 +109,16 @@ function guessEditor() {
         }
       }
     } else if (process.platform === 'win32') {
-      const output = child_process.execSync('powershell -Command "Get-Process | Select-Object Path"').toString();
+      const output = child_process
+        .execSync('powershell -Command "Get-Process | Select-Object Path"', {
+          stdio: ['pipe', 'pipe', 'ignore'],
+        })
+        .toString();
       const runningProcesses = output.split('\r\n');
       for (let i = 0; i < runningProcesses.length; i++) {
         // `Get-Process` sometimes returns empty lines
         if (!runningProcesses[i]) {
-          continue; 
+          continue;
         }
 
         const fullProcessPath = runningProcesses[i].trim();

--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -36,7 +36,12 @@ const COMMON_EDITORS_OSX = {
   '/Applications/Visual Studio Code.app/Contents/MacOS/Electron': 'code',
 };
 
-const COMMON_EDITORS_WIN = ['Code.exe', 'atom.exe', 'sublime_text.exe'];
+const COMMON_EDITORS_WIN = [
+  'Code.exe',
+  'atom.exe',
+  'sublime_text.exe',
+  'notepad++.exe',
+];
 
 function addWorkspaceToArgumentsIfExists(args, workspace) {
   if (workspace) {
@@ -62,6 +67,8 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
     case 'charm':
     case 'idea':
       return [fileName + ':' + lineNumber];
+    case 'notepad++':
+      return ['-n' + lineNumber, fileName];
     case 'joe':
     case 'emacs':
     case 'emacsclient':


### PR DESCRIPTION
I decided to go with an a bit different approach for Windows than on macOS. This resolves the first two issues mentioned below.

The new approach detects only by the file name and re-uses the whole path found in the process list to launch the editor. On macOS this was not possible because some executables did not match the command needed to run (if I understood that right).

Regarding the third one:
We could improve that by launching a PowerShell at the beginning in the background and just pipe the commands in then. This would require to switch to a Promise/callback-based implementation of the whole feature. I would pick that up in a second PR later on if you're okay with it 🙂 

Tested on Windows 10 with latest VS Code, Atom and Sublime Text 3.

_The original content of this PR:_
> So, this is a first try to get the auto-detect feature of the editor for the error overlay working on Windows. There are a few issues with the current implementation so I would like to discuss these issues first.
> 
> - At the moment it's only working if the found editor has its executable on `PATH`. Unfortunately we have drive letters on Windows so we cannot hardcode a path.
> - For example Atom installs itself into the user profile and has one folder per version. The current implemented detection does not work here. Do we need to require the full path for the detection or can we just search by the executable's name?
> - The whole process feels somehow slow. Mostly caused by the PowerShell's startup time (about 500 ms on my system).

_Also you can find the previous code here: levrik/create-react-app@adee1d0_

![2017-06-17_12-25-40](https://user-images.githubusercontent.com/9491603/27252197-3d378eae-5358-11e7-93a7-b88d7874400c.gif)