### PR TITLE
Fix eject command updating scripts output

### DIFF
--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -169,6 +169,9 @@ inquirer
     Object.keys(appPackage.scripts).forEach(key => {
       Object.keys(ownPackage.bin).forEach(binKey => {
         const regex = new RegExp(binKey + ' (\\w+)', 'g');
+        if (!regex.test(appPackage.scripts[key])) {
+          return;
+        }
         appPackage.scripts[key] = appPackage.scripts[key].replace(
           regex,
           'node scripts/$1.js'


### PR DESCRIPTION
Hi :) I've a spotted a small bug in eject command output.
Steps to reproduce:

Given the `package.json` file:
```json
"start": "react-scripts start",
"build": "react-scripts build",
"test": "react-scripts test --env=jsdom",
"eject": "react-scripts eject",
"stylelint": "node ./node_modules/stylelint/bin/stylelint.js src/**/*.scss",
"eslint": "node ./node_modules/eslint/bin/eslint.js src/**/*.js"
```
As you can see there are two custom scripts that were added after the project was created.
The output of `npm run eject` is:
```
Replacing "react-scripts start" with "node scripts/start.js"
Replacing "react-scripts build" with "node scripts/build.js"
Replacing "react-scripts test" with "node scripts/test.js"
Replacing "react-scripts stylelint" with "node scripts/stylelint.js"
Replacing "react-scripts eslint" with "node scripts/eslint.js"
```
While the updated `package.json` looks like:
```json
"start": "node scripts/start.js",
"build": "node scripts/build.js",
"test": "node scripts/test.js --env=jsdom",
"stylelint": "node ./node_modules/stylelint/bin/stylelint.js src/**/*.scss",
"eslint": "node ./node_modules/eslint/bin/eslint.js src/**/*.js"
```
so those two custom scripts were untouched and it's ok, because they are not related to the Create React App.

I have added a simple check to fix the misleading message. After the fix the output looks like:
```
Replacing "react-scripts start" with "node scripts/start.js"
Replacing "react-scripts build" with "node scripts/build.js"
Replacing "react-scripts test" with "node scripts/test.js"
```

Cheers,