### PR TITLE
Fix a potential issue

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -112,7 +112,12 @@ function build(previousFileSizes) {
       if (messages.errors.length) {
         return reject(new Error(messages.errors.join('\n\n')));
       }
-      if (process.env.CI && process.env.CI.toLowerCase() !== 'false' && messages.warnings.length) {
+      if (
+        process.env.CI &&
+        (typeof process.env.CI !== 'string' ||
+          process.env.CI.toLowerCase() !== 'false') &&
+        messages.warnings.length
+      ) {
         console.log(
           chalk.yellow(
             '\nTreating warnings as errors because process.env.CI = true.\n' +


### PR DESCRIPTION
In the rare case that the environment variable has been defined as a non-string, we don't want to cause an error.