### PR TITLE
Update Now description

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1787,6 +1787,8 @@ When you build the project, Create React App will place the `public` folder cont
     ```
 
     Paste that URL into your browser when the build is complete, and you will see your deployed app.
+    
+Please note: Your deploy will fail if you have `NODE_ENV` set to production in `now.json` as `devDependencies` will not install.
 
 Details are available in [this article.](https://zeit.co/blog/unlimited-static)
 


### PR DESCRIPTION
Myself and a few others have stumbled at the point of deploying to Now.

Quite often the case `NODE_ENV` has been set to `production` inside the `package.json` or `now.json` file which NPM will not allow devDependencies to install.