### PR TITLE
Support PhpStorm in launchEditor

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -74,6 +74,8 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
       );
     case 'webstorm':
     case 'webstorm64':
+    case 'phpstorm':
+    case 'phpstorm64':
       return addWorkspaceToArgumentsIfExists(
         ['--line', lineNumber, fileName],
         workspace


### PR DESCRIPTION
https://www.jetbrains.com/help/webstorm/opening-files-from-command-line.html
https://www.jetbrains.com/help/phpstorm/opening-files-from-command-line.html

Both editors have the same signature `<editor> <projectPath> --line <number> <filePath>` to open file from the command line.
It seems to work even if `<projectPath>` is omitted (commit 02f88ba15701f70e613137dd5a3d81caba9d9eb8).

Tested on `Win10`+`PhpStorm2016` and `macOS 10.12`+`PhpStorm2017`.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
