### PR TITLE
eslint command added to package.json

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -47,6 +47,7 @@ module.exports = function(
     build: 'react-scripts build',
     test: 'react-scripts test --env=jsdom',
     eject: 'react-scripts eject',
+    eslint: 'node node_modules/eslint/bin/eslint.js --config node_modules/eslint-config-react-app/index.js',
   };
 
   fs.writeFileSync(


### PR DESCRIPTION
Ability to run Eslint from command contained in package.json

Connected with discussion: https://github.com/facebookincubator/create-react-app/issues/1217
