### PR TITLE
Don't run yarn after ejecting

### DIFF
--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -220,8 +220,21 @@ inquirer
     }
 
     if (fs.existsSync(paths.yarnLockFile)) {
-      console.log(cyan('Running yarn...'));
-      spawnSync('yarnpkg', [], { stdio: 'inherit' });
+      // TODO: this is disabled for three reasons.
+      //
+      // 1. It produces garbage warnings on Windows on some systems:
+      //    https://github.com/facebookincubator/create-react-app/issues/2030
+      //
+      // 2. For the above reason, it breaks Windows CI:
+      //    https://github.com/facebookincubator/create-react-app/issues/2624
+      //
+      // 3. It is wrong anyway: re-running yarn will respect the lockfile
+      //    rather than package.json we just updated. Instead we should have
+      //    updated the lockfile. So we might as well not do it while it's broken.
+      //    https://github.com/facebookincubator/create-react-app/issues/2627
+      //
+      // console.log(cyan('Running yarn...'));
+      // spawnSync('yarnpkg', [], { stdio: 'inherit' });
     } else {
       console.log(cyan('Running npm install...'));
       spawnSync('npm', ['install'], { stdio: 'inherit' });


### PR DESCRIPTION
This should fix https://github.com/facebookincubator/create-react-app/issues/2624 and work around https://github.com/facebookincubator/create-react-app/issues/2030.

Obviously it's not a very good workaround, but I'm running out of options and we need the CI to be working. The reason I'm okay with this solution is because current behavior is broken anyway. Re-running `yarn` makes no difference since we didn't change the lockfile, so it might as well be a no-op.

See https://github.com/facebookincubator/create-react-app/issues/2627 for discussion of the proper fix.