### PR TITLE
Set npm loglevel to 'error'

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -218,7 +218,13 @@ function install(useYarn, dependencies, verbose, isOnline) {
       }
     } else {
       command = 'npm';
-      args = ['install', '--save', '--save-exact'].concat(dependencies);
+      args = [
+        'install',
+        '--save',
+        '--save-exact',
+        '--loglevel',
+        'error',
+      ].concat(dependencies);
     }
 
     if (verbose) {

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -237,7 +237,9 @@ inquirer
       // spawnSync('yarnpkg', [], { stdio: 'inherit' });
     } else {
       console.log(cyan('Running npm install...'));
-      spawnSync('npm', ['install'], { stdio: 'inherit' });
+      spawnSync('npm', ['install', '--loglevel', 'error'], {
+        stdio: 'inherit',
+      });
     }
     console.log(green('Ejected successfully!'));
     console.log();


### PR DESCRIPTION
This should hide useless warnings like https://github.com/facebookincubator/create-react-app/issues/2613#issuecomment-311315516.
npm discussion https://github.com/npm/npm/issues/11632.

Yarn doesn't support this yet AFAIK but I filed https://github.com/yarnpkg/yarn/issues/3738.