### PR TITLE
Ignore "Skipping static resource" message from SW precache

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -77,7 +77,9 @@ module.exports = {
     publicPath: publicPath,
     // Point sourcemap entries to original disk location (format as URL on Windows)
     devtoolModuleFilenameTemplate: info =>
-      path.relative(paths.appSrc, info.absoluteResourcePath).replace(/\\/g, '/'),
+      path
+        .relative(paths.appSrc, info.absoluteResourcePath)
+        .replace(/\\/g, '/'),
   },
   resolve: {
     // This allows you to set a fallback for where Webpack should look for modules.
@@ -318,6 +320,11 @@ module.exports = {
       logger(message) {
         if (message.indexOf('Total precache size is') === 0) {
           // This message occurs for every build and is a bit too noisy.
+          return;
+        }
+        if (message.indexOf('Skipping static resource') === 0) {
+          // This message obscures real errors so we ignore it.
+          // https://github.com/facebookincubator/create-react-app/issues/2612
           return;
         }
         console.log(message);


### PR DESCRIPTION
For some reason it comes up as false positive on Uglify errors which is bad: https://github.com/facebookincubator/create-react-app/issues/2433.
It is also not very meaningful to most users (skipping what? why?)

For now I'm muting it, but we can consider adding our own warnings for large bundles in the future.