### PR TITLE
Local testing docker links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ and then run `npm start` or `npm run build`.
 
 ## Contributing to E2E (end to end) tests
 
-**TL;DR** use the command yarn e2e:docker to run unit and e2e tests.
+**TL;DR** use the command `yarn e2e:docker` to run unit and e2e tests.
 
 More detailed information are in the dedicated [README](/packages/react-scripts/fixtures/kitchensink/README.md).
 

--- a/packages/react-scripts/fixtures/kitchensink/README.md
+++ b/packages/react-scripts/fixtures/kitchensink/README.md
@@ -10,6 +10,8 @@ In order to run them locally, without having to manually install and configure e
 This is a simple script that runs a **Docker** container, where the node version, git branch to clone, test suite, and whether to run it with `yarn` or `npm` can be chosen.  
 Simply run `yarn e2e:docker -- --help` to get additional info.
 
+If you need guidance installing **Docker**, you should follow their [official docs](https://docs.docker.com/engine/installation/).
+
 ## Writing tests
 
 Each time a new feature is added, it is advised to add at least one test covering it.


### PR DESCRIPTION
I've added a link to **Docker**'s installation docs, as requested in https://github.com/facebookincubator/create-react-app/pull/2408#issuecomment-311672317.
