### PR TITLE
Bootstrap with Yarn

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -26,7 +26,14 @@ function shouldUseNpmConcurrently() {
 }
 
 const yarn = shouldUseYarn();
-const lerna = resolve(__dirname, 'node_modules', '.bin', 'lerna');
+const windows = platform() === 'win32';
+const lerna = resolve(
+  __dirname,
+  'node_modules',
+  '.bin',
+  windows ? 'lerna.cmd' : 'lerna'
+);
+
 if (!existsSync(lerna)) {
   if (yarn) {
     console.log('Cannot find lerna. Please run `yarn --check-files`.');
@@ -48,7 +55,7 @@ if (yarn) {
   let args = ['bootstrap'];
   if (
     // The Window's filesystem does not handle concurrency well
-    platform() === 'win32' ||
+    windows ||
     // Only certain npm versions support concurrency
     !shouldUseNpmConcurrently()
   ) {

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -54,9 +54,9 @@ if (yarn) {
 } else {
   let args = ['bootstrap'];
   if (
-    // The Window's filesystem does not handle concurrency well
+    // The Windows filesystem does not handle concurrency well
     windows ||
-    // Only certain npm versions support concurrency
+    // Only newer npm versions support concurrency
     !shouldUseNpmConcurrently()
   ) {
     args.push('--concurrency=1');

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { execSync, spawn } = require('child_process');
+const { resolve } = require('path');
+const { existsSync } = require('fs');
+
+function shouldUseYarn() {
+  try {
+    execSync('yarnpkg --version', { stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+const yarn = shouldUseYarn();
+const lerna = resolve(__dirname, 'node_modules', '.bin', 'lerna');
+if (!existsSync(lerna)) {
+  if (yarn) {
+    console.log('Cannot find lerna. Please run `yarn --check-files`.');
+  } else {
+    console.log(
+      'Cannot find lerna. Please remove `node_modules` and run `npm install`.'
+    );
+  }
+  process.exit(1);
+}
+
+let child;
+if (yarn) {
+  child = spawn(lerna, ['bootstrap', '--npm-client=yarn'], {
+    stdio: 'inherit',
+  });
+} else {
+  child = spawn(lerna, ['bootstrap'], { stdio: 'inherit' });
+}
+
+child.on('close', code => process.exit(code));

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.38",
+  "lerna": "2.0.0-rc.5",
   "version": "independent",
   "changelog": {
     "repo": "facebookincubator/create-react-app",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "create-react-app": "tasks/cra.sh",
     "e2e": "tasks/e2e-simple.sh",
     "e2e:docker": "tasks/local-test.sh",
-    "postinstall": "lerna bootstrap && cd packages/react-error-overlay/ && npm run build:prod",
+    "postinstall": "node bootstrap.js && cd packages/react-error-overlay/ && npm run build:prod",
     "publish": "tasks/release.sh",
     "start": "node packages/react-scripts/scripts/start.js",
     "test": "node packages/react-scripts/scripts/test.js --env=jsdom",
@@ -16,7 +16,7 @@
   "devDependencies": {
     "eslint": "3.19.0",
     "husky": "^0.13.2",
-    "lerna": "2.0.0-beta.38",
+    "lerna": "2.0.0-rc.5",
     "lerna-changelog": "^0.2.3",
     "lint-staged": "^3.3.1",
     "prettier": "^1.5.2"

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -80,7 +80,7 @@ then
   # AppVeyor uses an old version of yarn.
   # Once updated to 0.24.3 or above, the workaround can be removed
   # and replaced with `yarnpkg cache clean`
-  # Issues: 
+  # Issues:
   #    https://github.com/yarnpkg/yarn/issues/2591
   #    https://github.com/appveyor/ci/issues/1576
   #    https://github.com/facebookincubator/create-react-app/pull/2400
@@ -98,9 +98,9 @@ then
   npm cache clean
 fi
 
-# Prevent lerna bootstrap, we only want top-level dependencies
+# Prevent bootstrap, we only want top-level dependencies
 cp package.json package.json.bak
-grep -v "lerna bootstrap" package.json > temp && mv temp package.json
+grep -v "postinstall" package.json > temp && mv temp package.json
 npm install
 mv package.json.bak package.json
 
@@ -112,7 +112,7 @@ then
 fi
 
 # We removed the postinstall, so do it manually
-./node_modules/.bin/lerna bootstrap --concurrency=1
+node bootstrap.js
 
 cd packages/react-error-overlay/
 npm run build:prod

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -72,7 +72,7 @@ then
   # AppVeyor uses an old version of yarn.
   # Once updated to 0.24.3 or above, the workaround can be removed
   # and replaced with `yarnpkg cache clean`
-  # Issues: 
+  # Issues:
   #    https://github.com/yarnpkg/yarn/issues/2591
   #    https://github.com/appveyor/ci/issues/1576
   #    https://github.com/facebookincubator/create-react-app/pull/2400
@@ -90,9 +90,9 @@ then
   npm cache clean
 fi
 
-# Prevent lerna bootstrap, we only want top-level dependencies
+# Prevent bootstrap, we only want top-level dependencies
 cp package.json package.json.bak
-grep -v "lerna bootstrap" package.json > temp && mv temp package.json
+grep -v "postinstall" package.json > temp && mv temp package.json
 npm install
 mv package.json.bak package.json
 
@@ -104,7 +104,7 @@ then
 fi
 
 # We removed the postinstall, so do it manually
-./node_modules/.bin/lerna bootstrap --concurrency=1
+node bootstrap.js
 
 cd packages/react-error-overlay/
 npm run build:prod

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -71,7 +71,7 @@ then
   # AppVeyor uses an old version of yarn.
   # Once updated to 0.24.3 or above, the workaround can be removed
   # and replaced with `yarnpkg cache clean`
-  # Issues: 
+  # Issues:
   #    https://github.com/yarnpkg/yarn/issues/2591
   #    https://github.com/appveyor/ci/issues/1576
   #    https://github.com/facebookincubator/create-react-app/pull/2400
@@ -89,9 +89,9 @@ then
   npm cache clean
 fi
 
-# Prevent lerna bootstrap, we only want top-level dependencies
+# Prevent bootstrap, we only want top-level dependencies
 cp package.json package.json.bak
-grep -v "lerna bootstrap" package.json > temp && mv temp package.json
+grep -v "postinstall" package.json > temp && mv temp package.json
 npm install
 mv package.json.bak package.json
 
@@ -112,7 +112,7 @@ then
 fi
 
 # We removed the postinstall, so do it manually here
-./node_modules/.bin/lerna bootstrap --concurrency=1
+node bootstrap.js
 
 if [ "$USE_YARN" = "yes" ]
 then

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -111,15 +111,15 @@ then
   [[ $err_output =~ You\ are\ running\ Node ]] && exit 0 || exit 1
 fi
 
-# We removed the postinstall, so do it manually here
-node bootstrap.js
-
 if [ "$USE_YARN" = "yes" ]
 then
   # Install Yarn so that the test can use it to install packages.
   npm install -g yarn
   yarn cache clean
 fi
+
+# We removed the postinstall, so do it manually here
+node bootstrap.js
 
 # Lint own code
 ./node_modules/.bin/eslint --max-warnings 0 packages/babel-preset-react-app/


### PR DESCRIPTION
`lerna bootstrap` uses `npm` unless otherwise specified.
It also doesn't understand when it should or should not apply concurrency.

This PR polishes contributor workflow and addresses above issues (long time nit I've had but too lazy to do anything about).