### PR TITLE
Customize Webpack watchOptions via ENV variables

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -75,7 +75,9 @@ module.exports = function(proxy, allowedHost) {
     // Reportedly, this avoids CPU overload on some systems.
     // https://github.com/facebookincubator/create-react-app/issues/293
     watchOptions: {
+      aggregateTimeout: parseInt(process.env.WEBPACK_WATCH_AGGREGATE_TIMEOUT) || 300,
       ignored: /node_modules/,
+      poll: parseInt(process.env.WEBPACK_WATCH_POLL) || false
     },
     // Enable HTTPS if the HTTPS environment variable is set to 'true'
     https: protocol === 'https',


### PR DESCRIPTION
Because the note at the bottom of this page (https://webpack.js.org/configuration/watch/), I think would be beneficial to have this, especially inside Docker environments.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
