### PR TITLE
Downgrade `strip-ansi` package

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -49,7 +49,7 @@
     "recursive-readdir": "2.2.1",
     "shell-quote": "1.6.1",
     "sockjs-client": "1.1.4",
-    "strip-ansi": "4.0.0",
+    "strip-ansi": "3.0.1",
     "text-table": "0.2.0"
   }
 }


### PR DESCRIPTION
This should fix #2691.

`strip-ansi` v4.0.0 (used by `react-dev-utils`) updates `ansi-regex` to v3.0.0, which exports an arrow function instead of a regular function. Internet Explorer 11 doesn't support arrow functions, so in development the app throws a syntax error and won't load. Downgrading to the previous version of `strip-ansi` (v3.0.1) also downgrades `ansi-regex` and should resolve the issue.
