### PR TITLE
Changelog for 1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## 1.0.10 (June 29, 2017)
+
+#### :bug: Bug Fix
+
+* `react-dev-utils`
+
+  * [#2692](https://github.com/facebookincubator/create-react-app/pull/2692) Fix IE11 crash in development. ([@pdhoopr](https://github.com/pdhoopr))
+
+* `create-react-app`
+  * [#2683](https://github.com/facebookincubator/create-react-app/pull/2683) Fix a typo. ([@BenBrostoff](https://github.com/BenBrostoff))
+
+#### :memo: Documentation
+
+* README
+  * [#2402](https://github.com/facebookincubator/create-react-app/pull/2402) Added `gluestick` to the alternatives section. ([@JoeCortopassi](https://github.com/JoeCortopassi))
+
+#### Committers: 5
+- Ben Brostoff ([BenBrostoff](https://github.com/BenBrostoff))
+- Forbes Lindesay ([ForbesLindesay](https://github.com/ForbesLindesay))
+- Joe Haddad ([Timer](https://github.com/Timer))
+- Patrick Hooper ([pdhoopr](https://github.com/pdhoopr))
+- [JoeCortopassi](https://github.com/JoeCortopassi)
+create-react-app) 
+
+### Migrating from 1.0.9 to 1.0.10
+
+Inside any created project that has not been ejected, run:
+
+```
+npm install --save-dev --save-exact react-scripts@1.0.10
+```
+
+or
+
+```
+yarn add --dev --exact react-scripts@1.0.10
+```
+
 ## 1.0.9 (June 29, 2017)
 
 #### :bug: Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,13 @@ create-react-app)
 Inside any created project that has not been ejected, run:
 
 ```
-npm install --save-dev --save-exact react-scripts@1.0.10
+npm install --save --save-exact react-scripts@1.0.10
 ```
 
 or
 
 ```
-yarn add --dev --exact react-scripts@1.0.10
+yarn add --exact react-scripts@1.0.10
 ```
 
 ## 1.0.9 (June 29, 2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### :memo: Documentation
 
 * README
+
   * [#2402](https://github.com/facebookincubator/create-react-app/pull/2402) Added `gluestick` to the alternatives section. ([@JoeCortopassi](https://github.com/JoeCortopassi))
 
 #### Committers: 5
@@ -20,7 +21,6 @@
 - Joe Haddad ([Timer](https://github.com/Timer))
 - Patrick Hooper ([pdhoopr](https://github.com/pdhoopr))
 - [JoeCortopassi](https://github.com/JoeCortopassi)
-create-react-app) 
 
 ### Migrating from 1.0.9 to 1.0.10
 


### PR DESCRIPTION
## 1.0.10 (June 29, 2017)

#### :bug: Bug Fix

* `react-dev-utils`

  * [#2692](https://github.com/facebookincubator/create-react-app/pull/2692) Fix IE11 crash in development. ([@pdhoopr](https://github.com/pdhoopr))

* `create-react-app`
  * [#2683](https://github.com/facebookincubator/create-react-app/pull/2683) Fix a typo. ([@BenBrostoff](https://github.com/BenBrostoff))

#### :memo: Documentation

* README
  * [#2402](https://github.com/facebookincubator/create-react-app/pull/2402) Added `gluestick` to the alternatives section. ([@JoeCortopassi](https://github.com/JoeCortopassi))

#### Committers: 5
- Ben Brostoff ([BenBrostoff](https://github.com/BenBrostoff))
- Forbes Lindesay ([ForbesLindesay](https://github.com/ForbesLindesay))
- Joe Haddad ([Timer](https://github.com/Timer))
- Patrick Hooper ([pdhoopr](https://github.com/pdhoopr))
- [JoeCortopassi](https://github.com/JoeCortopassi)

### Migrating from 1.0.9 to 1.0.10

Inside any created project that has not been ejected, run:

```
npm install --save --save-exact react-scripts@1.0.10
```

or

```
yarn add --exact react-scripts@1.0.10
```
