### PR TITLE
Unstage yarn.lock pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "*.js": [
       "prettier --trailing-comma es5 --single-quote --write",
       "git add"
+    ],
+    "yarn.lock": [
+      "git rm --cached"
     ]
   }
 }


### PR DESCRIPTION
Since `yarn.lock` shouldn't be added to the repo, nor excluded via
`.gitignore`, lets take advantage of `lint-staged` to unstage any staged
`yarn.lock` files before they can even be committed.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
