### PR TITLE
ESLint: set allowTaggedTemplates to true

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -185,6 +185,7 @@ module.exports = {
       {
         allowShortCircuit: true,
         allowTernary: true,
+        allowTaggedTemplates: true,
       },
     ],
     'no-unused-labels': 'warn',


### PR DESCRIPTION
This PR should address #2647 by allowing tagged templates. This avoids ESLint warning about `styled-components`'s `injectGlobal`.