### PR TITLE
Reorder vim arguments in launchEditor so --remote works

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -58,9 +58,6 @@ function addWorkspaceToArgumentsIfExists(args, workspace) {
 function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
   const editorBasename = path.basename(editor).replace(/\.(exe|cmd|bat)$/i, '');
   switch (editorBasename) {
-    case 'vim':
-    case 'mvim':
-      return [fileName, '+' + lineNumber];
     case 'atom':
     case 'Atom':
     case 'Atom Beta':
@@ -74,6 +71,8 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
       return [fileName + ':' + lineNumber];
     case 'notepad++':
       return ['-n' + lineNumber, fileName];
+    case 'vim':
+    case 'mvim':
     case 'joe':
     case 'emacs':
     case 'emacsclient':


### PR DESCRIPTION
This allows you to set REACT_EDITOR to 'vim --remote', so the file can
be opened in an already running vim process. When using vim without
remote, it works in the same way as before.

When launching vim without --remote, the order of the line and path
arguments doesn't matter. However, when using --remote the line argument
has to precede the path. This happens to be the same as joe and emacs
uses, so the vim cases were just moved there.

I haven't tested this with mvim, but the documentation says the same as
the vim documentation, so I assume it works the same.
