### PR TITLE
Add “node” to Jest's moduleFileExtensions

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -43,7 +43,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
     },
-    moduleFileExtensions: ['web.js', 'js', 'json', 'web.jsx', 'jsx'],
+    moduleFileExtensions: ['web.js', 'js', 'json', 'web.jsx', 'jsx', 'node'],
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
Jest’s default value for its [`moduleFileExtensions`](https://facebook.github.io/jest/docs/en/configuration.html#modulefileextensions-array-string) option is `["js", "json", "jsx", "node"]`. CRA was not using this option before version 1.0.8, so this default list was used.

PR #2511 (merged in version 1.0.8) sets this option to `["web.js", "js", "json", "web.jsx", "jsx"]`. The PR is about adding `.web` extensions, but it is also removing `.node` because it is not included like other default extensions.

### Why is this a bug?

Packages using native code through `node-gyp` import files with `.node` extension. Using those packages fails the tests with a `Cannot find module …` error.

<img width="706" alt="screen shot 1396-04-16 at 10 09 13" src="https://user-images.githubusercontent.com/531910/27944520-ad10db1e-62fc-11e7-801b-3e89c457079c.png">

This used to work with version 1.0.7.

### Reproduction and testing

[This repo](https://github.com/mostafah/cra-jest-extensions-bug) is a minimal reproduction of this bug. Tests fail there. Changing `react-scripts` to 1.0.7 or manually applying this change to `node_modules/react-scripts/scripts/utils/createJestConfig.js` fixes the problem.