### PR TITLE
Exclude sourcemaps from production build

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -60,9 +60,6 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
 module.exports = {
   // Don't attempt to continue if there are any errors.
   bail: true,
-  // We generate sourcemaps in production. This is slow but gives good results.
-  // You can exclude the *.map files from the build during deployment.
-  devtool: 'source-map',
   // In production, we only want to load the polyfills and the app code.
   entry: [require.resolve('./polyfills'), paths.appIndexJs],
   output: {


### PR DESCRIPTION
In my opinion, sourcemaps in production aren't useful. People can get access to the source code.
In my projects, I don't want/need sourcemaps in production and every time I need to eject because it is not useful to exclude the sourcemaps files from the build folder. I think it might be a good idea to exclude them automatically from webpack.config.prod.js.