### PR TITLE
Autodetect JetBrains IDEs

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -38,6 +38,22 @@ const COMMON_EDITORS_OSX = {
   '/Applications/Sublime Text 2.app/Contents/MacOS/Sublime Text 2':
     '/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl',
   '/Applications/Visual Studio Code.app/Contents/MacOS/Electron': 'code',
+  '/Applications/AppCode.app/Contents/MacOS/appcode':
+    '/Applications/AppCode.app/Contents/MacOS/appcode',
+  '/Applications/CLion.app/Contents/MacOS/clion':
+    '/Applications/CLion.app/Contents/MacOS/clion',
+  '/Applications/IntelliJ IDEA.app/Contents/MacOS/idea':
+      '/Applications/IntelliJ IDEA.app/Contents/MacOS/idea',
+  '/Applications/PhpStorm.app/Contents/MacOS/phpstorm':
+    '/Applications/PhpStorm.app/Contents/MacOS/phpstorm',
+  '/Applications/PyCharm.app/Contents/MacOS/pycharm':
+    '/Applications/PyCharm.app/Contents/MacOS/pycharm',
+  '/Applications/PyCharm CE.app/Contents/MacOS/pycharm':
+    '/Applications/PyCharm CE.app/Contents/MacOS/pycharm',
+  '/Applications/RubyMine.app/Contents/MacOS/rubymine':
+    '/Applications/RubyMine.app/Contents/MacOS/rubymine',
+  '/Applications/WebStorm.app/Contents/MacOS/webstorm':
+      '/Applications/WebStorm.app/Contents/MacOS/webstorm',
 };
 
 const COMMON_EDITORS_WIN = [
@@ -46,6 +62,18 @@ const COMMON_EDITORS_WIN = [
   'atom.exe',
   'sublime_text.exe',
   'notepad++.exe',
+  'clion.exe',
+  'clion64.exe',
+  'idea.exe',
+  'idea64.exe',
+  'phpstorm.exe',
+  'phpstorm64.exe',
+  'pycharm.exe',
+  'pycharm64.exe',
+  'rubymine.exe',
+  'rubymine64.exe',
+  'webstorm.exe',
+  'webstorm64.exe',
 ];
 
 function addWorkspaceToArgumentsIfExists(args, workspace) {
@@ -65,9 +93,7 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
     case 'sublime':
     case 'sublime_text':
     case 'wstorm':
-    case 'appcode':
     case 'charm':
-    case 'idea':
       return [fileName + ':' + lineNumber];
     case 'notepad++':
       return ['-n' + lineNumber, fileName];
@@ -87,12 +113,19 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
         ['-g', fileName + ':' + lineNumber],
         workspace
       );
-    case 'webstorm':
-    case 'webstorm64':
+    case 'appcode':
+    case 'clion':
+    case 'clion64':
+    case 'idea':
+    case 'idea64':
     case 'phpstorm':
     case 'phpstorm64':
     case 'pycharm':
     case 'pycharm64':
+    case 'rubymine':
+    case 'rubymine64':
+    case 'webstorm':
+    case 'webstorm64':
       return addWorkspaceToArgumentsIfExists(
         ['--line', lineNumber, fileName],
         workspace


### PR DESCRIPTION
Autodetect PyCharm (Pro and CE), WebStorm, PhpStorm, IntelliJ IDEA, RubyMine, CLion, and AppCode

Added IntelliJ IDEA, RubyMine, CLion, and AppCode to list of IDEs. They have the same signature as WebStorm and PhpStorm `<editor> <projectPath> --line <number> <filePath>` so they can reuse the logic from those.

Removed older integrations of PyCharm, WebStorm, AppCode, IntelliJ IDEA

https://www.jetbrains.com/help/idea/opening-files-from-command-line.html
https://www.jetbrains.com/help/pycharm/opening-files-from-command-line.html
https://www.jetbrains.com/help/phpstorm/opening-files-from-command-line.html
https://www.jetbrains.com/help/ruby/opening-files-from-command-line.html
https://www.jetbrains.com/help/webstorm/opening-files-from-command-line.html

Tested with Appcode 2017.1.3, CLion 2017.1.3, Intellij Idea 2017.1.5, PhpStorm 2017.1.4, PyCharm (Pro and CE) 2017.1.4, RubyMine 2017.1.5, and WebStorm 2017.1.4 on MacOS 10.12
Tested with 64-bit CLion 2017.1.3, Intellij Idea 2017.1.5, PhpStorm 2017.1.4, PyCharm (Pro and CE) 2017.1.4, RubyMine 2017.1.5, and WebStorm 2017.1.4 on a Windows 10 VM

Relates to #2636

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
