### PR TITLE
Allow the dev server to watch for changes in src/node_modules

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -72,10 +72,12 @@ module.exports = function(proxy, allowedHost) {
     // WebpackDevServer is noisy by default so we emit custom message instead
     // by listening to the compiler events with `compiler.plugin` calls above.
     quiet: true,
-    // Reportedly, this avoids CPU overload on some systems.
+    // Reportedly, ignoring node_modules avoids CPU overload on some systems.
     // https://github.com/facebookincubator/create-react-app/issues/293
+    // src/node_modules is not ignored to support absolute imports
+    // https://github.com/facebookincubator/create-react-app/issues/1065
     watchOptions: {
-      ignored: /node_modules/,
+      ignored: /^([^\/\\]|[\/\\](?!src))*[\/\\]node_modules[\/\\]/,
     },
     // Enable HTTPS if the HTTPS environment variable is set to 'true'
     https: protocol === 'https',


### PR DESCRIPTION
This allows users to put a `node_modules` folder in `src` if they want to use absolute imports
or imitate the webpack `resolve.alias` config.

This allows users to put a `node_modules` folder in `src` if they want to use absolute imports
or imitate the webpack `resolve.alias` config.

When experimenting with the `src/node_modules` trick mentioned in https://github.com/facebookincubator/create-react-app/issues/1065 I noticed that the dev server wasn't picking up any changes that happened in the `src/node_modules` folder.  This change makes it so the dev server will correctly notice changes in `src/node_modules` and rebuild while still ignoring the `node_modules` folder in the root of the project.
