### PR TITLE
Don't prompt to install serve if already installed

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -41,7 +41,7 @@
     "detect-port-alt": "1.1.3",
     "escape-string-regexp": "1.0.5",
     "filesize": "3.3.0",
-    "global-modules": "^1.0.0",
+    "global-modules": "1.0.0",
     "gzip-size": "3.0.0",
     "html-entities": "1.2.1",
     "inquirer": "3.1.1",

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -41,6 +41,7 @@
     "detect-port-alt": "1.1.3",
     "escape-string-regexp": "1.0.5",
     "filesize": "3.3.0",
+    "global-modules": "^1.0.0",
     "gzip-size": "3.0.0",
     "html-entities": "1.2.1",
     "inquirer": "3.1.1",

--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -11,7 +11,7 @@
 
 const chalk = require('chalk');
 const url = require('url');
-const modules = require('global-modules');
+const globalModules = require('global-modules');
 const fs = require('fs');
 
 function printHostingInstructions(
@@ -123,7 +123,7 @@ function printHostingInstructions(
     );
     console.log('You may serve it with a static server:');
     console.log();
-    if (!fs.existsSync(`${modules}/serve`)) {
+    if (!fs.existsSync(`${globalModules}/serve`)) {
       if (useYarn) {
         console.log(`  ${chalk.cyan('yarn')} global add serve`);
       } else {

--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -11,6 +11,8 @@
 
 const chalk = require('chalk');
 const url = require('url');
+const modules = require('global-modules');
+const fs = require('fs');
 
 function printHostingInstructions(
   appPackage,
@@ -121,10 +123,12 @@ function printHostingInstructions(
     );
     console.log('You may serve it with a static server:');
     console.log();
-    if (useYarn) {
-      console.log(`  ${chalk.cyan('yarn')} global add serve`);
-    } else {
-      console.log(`  ${chalk.cyan('npm')} install -g serve`);
+    if (!fs.existsSync(`${modules}/serve`)) {
+      if (useYarn) {
+        console.log(`  ${chalk.cyan('yarn')} global add serve`);
+      } else {
+        console.log(`  ${chalk.cyan('npm')} install -g serve`);
+      }
     }
     console.log(`  ${chalk.cyan('serve')} -s ${buildFolder}`);
     console.log();


### PR DESCRIPTION
This PR (#2750) removes the line prompting to install `serve` if the user already has it installed globally. Tested on Mac OS with and without serve installed.
