### PR TITLE
CRA_BABEL_PRESET_FILE to handle optional dependencies.

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -8,131 +8,139 @@
  */
 'use strict';
 
-const plugins = [
-  // class { handleClick = () => { } }
-  require.resolve('babel-plugin-transform-class-properties'),
-  // The following two plugins use Object.assign directly, instead of Babel's
-  // extends helper. Note that this assumes `Object.assign` is available.
-  // { ...todo, completed: true }
-  [
-    require.resolve('babel-plugin-transform-object-rest-spread'),
-    {
-      useBuiltIns: true,
-    },
-  ],
-  // Transforms JSX
-  [
-    require.resolve('babel-plugin-transform-react-jsx'),
-    {
-      useBuiltIns: true,
-    },
-  ],
-  // Polyfills the runtime needed for async/await and generators
-  [
-    require.resolve('babel-plugin-transform-runtime'),
-    {
-      helpers: false,
-      polyfill: false,
-      regenerator: true,
-    },
-  ],
-];
+const path = require('path');
 
-// This is similar to how `env` works in Babel:
-// https://babeljs.io/docs/usage/babelrc/#env-option
-// We are not using `env` because it’s ignored in versions > babel-core@6.10.4:
-// https://github.com/babel/babel/issues/4539
-// https://github.com/facebookincubator/create-react-app/issues/720
-// It’s also nice that we can enforce `NODE_ENV` being specified.
-var env = process.env.BABEL_ENV || process.env.NODE_ENV;
-if (env !== 'development' && env !== 'test' && env !== 'production') {
-  throw new Error(
-    'Using `babel-preset-react-app` requires that you specify `NODE_ENV` or ' +
-      '`BABEL_ENV` environment variables. Valid values are "development", ' +
-      '"test", and "production". Instead, received: ' +
-      JSON.stringify(env) +
-      '.'
-  );
-}
-
-if (env === 'development' || env === 'test') {
-  // The following two plugins are currently necessary to make React warnings
-  // include more valuable information. They are included here because they are
-  // currently not enabled in babel-preset-react. See the below threads for more info:
-  // https://github.com/babel/babel/issues/4702
-  // https://github.com/babel/babel/pull/3540#issuecomment-228673661
-  // https://github.com/facebookincubator/create-react-app/issues/989
-  plugins.push.apply(plugins, [
-    // Adds component stack to warning messages
-    require.resolve('babel-plugin-transform-react-jsx-source'),
-    // Adds __self attribute to JSX which React will use for some warnings
-    require.resolve('babel-plugin-transform-react-jsx-self'),
-  ]);
-}
-
-if (env === 'test') {
-  module.exports = {
-    presets: [
-      // ES features necessary for user's Node version
-      [
-        require('babel-preset-env').default,
-        {
-          targets: {
-            node: 'current',
-          },
-        },
-      ],
-      // JSX, Flow
-      require.resolve('babel-preset-react'),
-    ],
-    plugins: plugins.concat([
-      // Compiles import() to a deferred require()
-      require.resolve('babel-plugin-dynamic-import-node'),
-    ]),
-  };
+if (process.env.CRA_BABEL_PRESET_FILE) {
+  let presetFile = path.resolve(process.cwd(),
+    process.env.CRA_BABEL_PRESET_FILE);
+  module.exports = require(presetFile);
 } else {
-  module.exports = {
-    presets: [
-      // Latest stable ECMAScript features
-      [
-        require.resolve('babel-preset-env'),
-        {
-          targets: {
-            // React parses on ie 9, so we should too
-            ie: 9,
-            // We currently minify with uglify
-            // Remove after https://github.com/mishoo/UglifyJS2/issues/448
-            uglify: true,
-          },
-          // Disable polyfill transforms
-          useBuiltIns: false,
-          // Do not transform modules to CJS
-          modules: false,
-        },
-      ],
-      // JSX, Flow
-      require.resolve('babel-preset-react'),
+  const plugins = [
+    // class { handleClick = () => { } }
+    require.resolve('babel-plugin-transform-class-properties'),
+    // The following two plugins use Object.assign directly, instead of Babel's
+    // extends helper. Note that this assumes `Object.assign` is available.
+    // { ...todo, completed: true }
+    [
+      require.resolve('babel-plugin-transform-object-rest-spread'),
+      {
+        useBuiltIns: true,
+      },
     ],
-    plugins: plugins.concat([
-      // function* () { yield 42; yield 43; }
-      [
-        require.resolve('babel-plugin-transform-regenerator'),
-        {
-          // Async functions are converted to generators by babel-preset-env
-          async: false,
-        },
-      ],
-      // Adds syntax support for import()
-      require.resolve('babel-plugin-syntax-dynamic-import'),
-    ]),
-  };
+    // Transforms JSX
+    [
+      require.resolve('babel-plugin-transform-react-jsx'),
+      {
+        useBuiltIns: true,
+      },
+    ],
+    // Polyfills the runtime needed for async/await and generators
+    [
+      require.resolve('babel-plugin-transform-runtime'),
+      {
+        helpers: false,
+        polyfill: false,
+        regenerator: true,
+      },
+    ],
+  ];
 
-  if (env === 'production') {
-    // Optimization: hoist JSX that never changes out of render()
-    // Disabled because of issues: https://github.com/facebookincubator/create-react-app/issues/553
-    // TODO: Enable again when these issues are resolved.
-    // plugins.push.apply(plugins, [
-    //   require.resolve('babel-plugin-transform-react-constant-elements')
-    // ]);
+  // This is similar to how `env` works in Babel:
+  // https://babeljs.io/docs/usage/babelrc/#env-option
+  // We are not using `env` because it’s ignored in versions > babel-core@6.10.4:
+  // https://github.com/babel/babel/issues/4539
+  // https://github.com/facebookincubator/create-react-app/issues/720
+  // It’s also nice that we can enforce `NODE_ENV` being specified.
+  var env = process.env.BABEL_ENV || process.env.NODE_ENV;
+  if (env !== 'development' && env !== 'test' && env !== 'production') {
+    throw new Error(
+      'Using `babel-preset-react-app` requires that you specify `NODE_ENV` or ' +
+        '`BABEL_ENV` environment variables. Valid values are "development", ' +
+        '"test", and "production". Instead, received: ' +
+        JSON.stringify(env) +
+        '.'
+    );
+  }
+
+  if (env === 'development' || env === 'test') {
+    // The following two plugins are currently necessary to make React warnings
+    // include more valuable information. They are included here because they are
+    // currently not enabled in babel-preset-react. See the below threads for more info:
+    // https://github.com/babel/babel/issues/4702
+    // https://github.com/babel/babel/pull/3540#issuecomment-228673661
+    // https://github.com/facebookincubator/create-react-app/issues/989
+    plugins.push.apply(plugins, [
+      // Adds component stack to warning messages
+      require.resolve('babel-plugin-transform-react-jsx-source'),
+      // Adds __self attribute to JSX which React will use for some warnings
+      require.resolve('babel-plugin-transform-react-jsx-self'),
+    ]);
+  }
+
+  if (env === 'test') {
+    module.exports = {
+      presets: [
+        // ES features necessary for user's Node version
+        [
+          require('babel-preset-env').default,
+          {
+            targets: {
+              node: 'current',
+            },
+          },
+        ],
+        // JSX, Flow
+        require.resolve('babel-preset-react'),
+      ],
+      plugins: plugins.concat([
+        // Compiles import() to a deferred require()
+        require.resolve('babel-plugin-dynamic-import-node'),
+      ]),
+    };
+  } else {
+    module.exports = {
+      presets: [
+        // Latest stable ECMAScript features
+        [
+          require.resolve('babel-preset-env'),
+          {
+            targets: {
+              // React parses on ie 9, so we should too
+              ie: 9,
+              // We currently minify with uglify
+              // Remove after https://github.com/mishoo/UglifyJS2/issues/448
+              uglify: true,
+            },
+            // Disable polyfill transforms
+            useBuiltIns: false,
+            // Do not transform modules to CJS
+            modules: false,
+          },
+        ],
+        // JSX, Flow
+        require.resolve('babel-preset-react'),
+      ],
+      plugins: plugins.concat([
+        // function* () { yield 42; yield 43; }
+        [
+          require.resolve('babel-plugin-transform-regenerator'),
+          {
+            // Async functions are converted to generators by babel-preset-env
+            async: false,
+          },
+        ],
+        // Adds syntax support for import()
+        require.resolve('babel-plugin-syntax-dynamic-import'),
+      ]),
+    };
+
+    if (env === 'production') {
+      // Optimization: hoist JSX that never changes out of render()
+      // Disabled because of issues: https://github.com/facebookincubator/create-react-app/issues/553
+      // TODO: Enable again when these issues are resolved.
+      // plugins.push.apply(plugins, [
+      //   require.resolve('babel-plugin-transform-react-constant-elements')
+      // ]);
+    }
   }
 }

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1750,7 +1750,7 @@ If you’re using [Apache HTTP Server](https://httpd.apache.org/), you need to c
     RewriteRule ^ index.html [QSA,L]
 ```
 
-It will get copied to the `build` folder when you run `npm run build`. 
+It will get copied to the `build` folder when you run `npm run build`.
 
 If you’re using [Apache Tomcat](http://tomcat.apache.org/), you need to follow [this Stack Overflow answer](https://stackoverflow.com/a/41249464/4878474).
 
@@ -2043,6 +2043,7 @@ HTTPS | :white_check_mark: | :x: | When set to `true`, Create React App will run
 PUBLIC_URL | :x: | :white_check_mark: | Create React App assumes your application is hosted at the serving web server's root or a subpath as specified in [`package.json` (`homepage`)](#building-for-relative-paths). Normally, Create React App ignores the hostname. You may use this variable to force assets to be referenced verbatim to the url you provide (hostname included). This may be particularly useful when using a CDN to host your application.
 CI | :large_orange_diamond: | :white_check_mark: | When set to `true`, Create React App treats warnings as failures in the build. It also makes the test runner non-watching. Most CIs set this flag by default.
 REACT_EDITOR | :white_check_mark: | :x: | When an app crashes in development, you will see an error overlay with clickable stack trace. When you click on it, Create React App will try to determine the editor you are using based on currently running processes, and open the relevant source file. You can [send a pull request to detect your editor of choice](https://github.com/facebookincubator/create-react-app/issues/2636). Setting this environment variable overrides the automatic detection. If you do it, make sure your systems [PATH](https://en.wikipedia.org/wiki/PATH_(variable)) environment variable points to your editor’s bin folder.
+CRA_BABEL_PRESET_FILE | :white_check_mark: | :x: | If you need to modify the babel preset file without ejecting you can set this to a project relative file path e.g. `CRA_BABEL_PRESET_FILE=.babel-preset-react-app.js`.  Doing so is needed for optional dependencies like Typescript or relay (see [facebookincubator/create-react-app#2775](https://github.com/facebookincubator/create-react-app/pull/2775)).
 
 ## Troubleshooting
 


### PR DESCRIPTION
* This will allow for optional babel dependencies to be added without ejecting cra.
* CRA_BABEL_PRESET_FILE=relative/path/to/babel/preset can be added to package.json.

I verified this locally by copying `index.js` to `node_modules/babel-preset-react-app/index.js` within one of my projects.  Here is the package.json for my project:

```
{
  "name": "my-app",
  "version": "0.1.0",
  "private": true,
  "dependencies": {
    "babel-plugin-relay": "^1.1.0",
    "react": "^15.6.1",
    "react-dom": "^15.6.1",
    "react-router-dom": "^4.1.1",
    "react-scripts": "1.0.10",
    "shared-git-hooks": "^1.2.1"
  },
  "scripts": {
    "start": "CRA_BABEL_PRESET_FILE=.babel-preset-react-app react-scripts start",
    "build": "react-scripts build",
    "test": "react-scripts test --env=jsdom",
    "eject": "react-scripts eject"
  },
  "homepage": "."
}
```

I'm doing this because I want to use relay modern in my app.  My `.babel-preset-react-app.js` file is exactly what @maletor had in PR https://github.com/facebookincubator/create-react-app/pull/2343

cc @gaearon Is this an acceptable approach per your comment https://github.com/facebookincubator/create-react-app/pull/2343#issuecomment-311409607 ?

Also relates to #2001