### PR TITLE
Fix parsing HTML/JSX tags to real elements

### DIFF
--- a/packages/react-dev-utils/ansiHTML.js
+++ b/packages/react-dev-utils/ansiHTML.js
@@ -10,6 +10,8 @@
 'use strict';
 
 var Anser = require('anser');
+var Entities = require('html-entities').AllHtmlEntities;
+var entities = new Entities();
 
 // Color scheme inspired by https://chriskempson.github.io/base16/css/base16-github.css
 // var base00 = 'ffffff'; // Default Background
@@ -61,7 +63,7 @@ var anserMap = {
 };
 
 function ansiHTML(txt) {
-  var arr = new Anser().ansiToJson(txt, {
+  var arr = new Anser().ansiToJson(entities.encode(txt), {
     use_classes: true,
   });
 
@@ -78,10 +80,7 @@ function ansiHTML(txt) {
         result += '<span data-ansi-line="true">';
         open = true;
       }
-      var part = contentParts[_index]
-        .replace('\r', '')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;');
+      var part = contentParts[_index].replace('\r', '');
       var color = colors[anserMap[fg]];
       if (color != null) {
         result += '<span style="color: #' + color + ';">' + part + '</span>';

--- a/packages/react-dev-utils/ansiHTML.js
+++ b/packages/react-dev-utils/ansiHTML.js
@@ -78,7 +78,10 @@ function ansiHTML(txt) {
         result += '<span data-ansi-line="true">';
         open = true;
       }
-      var part = contentParts[_index].replace('\r', '');
+      var part = contentParts[_index]
+        .replace('\r', '')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
       var color = colors[anserMap[fg]];
       if (color != null) {
         result += '<span style="color: #' + color + ';">' + part + '</span>';

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -22,9 +22,7 @@ var SockJS = require('sockjs-client');
 var stripAnsi = require('strip-ansi');
 var url = require('url');
 var formatWebpackMessages = require('./formatWebpackMessages');
-var Entities = require('html-entities').AllHtmlEntities;
 var ansiHTML = require('./ansiHTML');
-var entities = new Entities();
 
 function createOverlayIframe(onIframeLoad) {
   var iframe = document.createElement('iframe');
@@ -138,7 +136,7 @@ function showErrorOverlay(message) {
       'margin-bottom: 0.5em; overflow-x: auto; white-space: pre-wrap; ' +
       'border-radius: 0.25rem; background-color: rgba(206, 17, 38, 0.05)">' +
       '<code style="font-family: Consolas, Menlo, monospace;">' +
-      ansiHTML(entities.encode(message)) +
+      ansiHTML(message) +
       '</code></pre>' +
       '<div style="' +
       'font-family: sans-serif; color: rgb(135, 142, 145); margin-top: 0.5rem; ' +


### PR DESCRIPTION
This should fixed #2789.

Just replaces all the angle brackets to `&lt;` and `&gt;` to avoid parsing them as real HTML elements.

Here is the screenshot of the example that mentioned in origin issue, the checkbox is not showing and it displays its source code.
![image](https://user-images.githubusercontent.com/8115912/28237021-5f2e6f34-6968-11e7-9bdc-a4d05b33a03f.png)
