### PR TITLE
Remove note about webpackHotDevClient being webpack 1.0 only

### DIFF
--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -295,8 +295,6 @@ Returns an object with local and remote URLs for the development server. Pass th
 
 This is an alternative client for [WebpackDevServer](https://github.com/webpack/webpack-dev-server) that shows a syntax error overlay.
 
-It currently supports only Webpack 1.x.
-
 ```js
 // Webpack development config
 module.exports = {

--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -295,7 +295,7 @@ Returns an object with local and remote URLs for the development server. Pass th
 
 This is an alternative client for [WebpackDevServer](https://github.com/webpack/webpack-dev-server) that shows a syntax error overlay.
 
-It currently supports only Webpack 2.x
+It currently supports only Webpack 3.x.
 
 ```js
 // Webpack development config

--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -295,6 +295,8 @@ Returns an object with local and remote URLs for the development server. Pass th
 
 This is an alternative client for [WebpackDevServer](https://github.com/webpack/webpack-dev-server) that shows a syntax error overlay.
 
+It currently supports only Webpack 2.x
+
 ```js
 // Webpack development config
 module.exports = {


### PR DESCRIPTION
It must work in webpack 2 since create-react-app is still using it and is using webpack 2 now.

It would be great if you could add some kind of note about how it differs from the default webpack hot reloaders.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
