### PR TITLE
add WebpackUglifyParallel

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -16,12 +16,14 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
+const WebpackUglifyParallel = require('webpack-uglify-parallel');
 const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
+const os = require('os');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
@@ -285,7 +287,8 @@ module.exports = {
     // Otherwise React will be compiled in the very slow development mode.
     new webpack.DefinePlugin(env.stringified),
     // Minify the code.
-    new webpack.optimize.UglifyJsPlugin({
+    new WebpackUglifyParallel({
+      workers: os.cpus().length,
       compress: {
         warnings: false,
         // Disabled because of an issue with Uglify breaking seemingly valid code:

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -56,6 +56,7 @@
     "webpack": "2.6.1",
     "webpack-dev-server": "2.5.0",
     "webpack-manifest-plugin": "1.1.0",
+    "webpack-uglify-parallel": "^0.1.3",
     "whatwg-fetch": "2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace default UglifyJSPlugin with https://github.com/tradingview/webpack-uglify-parallel for parallelizing uglifyjs
Master:
![screen shot 2017-07-16 at 2 36 15 pm](https://user-images.githubusercontent.com/9636410/28245564-2f3cbd7c-6a34-11e7-8288-9e3a0059b9b8.png)

UglifyParallel:
![screen shot 2017-07-16 at 2 35 21 pm](https://user-images.githubusercontent.com/9636410/28245567-4e3bf4f4-6a34-11e7-9b5b-61e9dc531bac.png)
