### PR TITLE
Upgrade webpack-dev-server

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -54,7 +54,7 @@
     "sw-precache-webpack-plugin": "0.11.3",
     "url-loader": "0.5.9",
     "webpack": "2.6.1",
-    "webpack-dev-server": "2.5.0",
+    "webpack-dev-server": "2.5.1",
     "webpack-manifest-plugin": "1.1.0",
     "whatwg-fetch": "2.0.3"
   },


### PR DESCRIPTION
This resolves another iteration of #1268 which was resolved in https://github.com/webpack/webpack-dev-server/pull/975. The current error is:

> Uncaught Error: Incompatible SockJS! Main site uses: "1.1.4", the iframe: "1.1.2".