### PR TITLE
Offline-First Considerations: index.html caching

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1599,12 +1599,17 @@ instructions for using other methods. *Be sure to always use an
 incognito window to avoid complications with your browser cache.*
 
 1. If possible, configure your production environment to serve the generated
-`service-worker.js` [with HTTP caching disabled](http://stackoverflow.com/questions/38843970/service-worker-javascript-update-frequency-every-24-hours).
+`service-worker.js` and `index.html` [with HTTP caching disabled](http://stackoverflow.com/questions/38843970/service-worker-javascript-update-frequency-every-24-hours).
 If that's not possible—[GitHub Pages](#github-pages), for instance, does not
 allow you to change the default 10 minute HTTP cache lifetime—then be aware
 that if you visit your production site, and then revisit again before
 `service-worker.js` has expired from your HTTP cache, you'll continue to get
-the previously cached assets from the service worker. If you have an immediate
+the previously cached assets from the service worker. Even worse, if the
+caches for `service-worker.js` and `index.html` get out of sync, a user might
+end up having a new `service-worker.js` populate its cache with an old
+`index.html`, and this erronous state will persist until yet another
+`service-worker.js` is installed so that the SW cache is repopulated.
+If you have an immediate
 need to view your updated production deployment, performing a shift-refresh
 will temporarily disable the service worker and retrieve all assets from the
 network.


### PR DESCRIPTION
If using CloudFront you should not cache index.html.
Otherwise an old index.html might get populated in the cache
for a new service-worker.js. That does not get recovered
until a new service-worker.js is deployed.

Step-by-step:
1. create-react-app sw-cache-problems ; cd sw-cache-problems
2. npm run build
3. mv build cloud-front-simulation
4. perl -pi -e 's/To get started/BANANA/g' src/App.js
5. npm run build
6. serve -s cloud-front-simulation/  # And keep it running while continuing below
7. Go to http://localhost:5000 in e.g. Google Chrome and observe 'To get started' appearing on the page
8. Close the browser
9. mv build/service-worker.js cloud-front-simulation/service-worker.js   # We wait with index.html, pretending it is still cached in CloudFront
10. cp -r build/static cloud-front-simulation/
10. Go to http://localhost:5000 again
11. You will notice in Console "New content available; please refresh" so do that. However, you still get the old index.html of course
12. Close the browser
13. mv build/index.html cloud-front-simulation/index.html    # To simulate CloudFront cache experied and it fetched the new version
14. Go to http://localhost:5000 again
15. If you press F5 you get the old site (with 'To get started'). If you press Shift+F5 you get the new site (with 'BANANA') since you bypass SW . That's because the sw cache was populated while index.html was still old. And now we're stuck like this until a new service-worker.js is deployed
