### PR TITLE
Add display qrcode for lan url in terminal.

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -16,6 +16,7 @@ const chalk = require('chalk');
 const detect = require('detect-port-alt');
 const isRoot = require('is-root');
 const inquirer = require('inquirer');
+const qrcode = require('qrcode-terminal');
 const clearConsole = require('./clearConsole');
 const formatWebpackMessages = require('./formatWebpackMessages');
 const getProcessForPort = require('./getProcessForPort');
@@ -82,9 +83,11 @@ function prepareUrls(protocol, host, port) {
   }
   const localUrlForTerminal = prettyPrintUrl(prettyHost);
   const localUrlForBrowser = formatUrl(prettyHost);
+  const lanUrlForBrowser = formatUrl(lanUrlForConfig);
   return {
     lanUrlForConfig,
     lanUrlForTerminal,
+    lanUrlForBrowser,
     localUrlForTerminal,
     localUrlForBrowser,
   };
@@ -102,6 +105,7 @@ function printInstructions(appName, urls, useYarn) {
     console.log(
       `  ${chalk.bold('On Your Network:')}  ${urls.lanUrlForTerminal}`
     );
+    qrcode.generate(urls.lanUrlForBrowser);
   } else {
     console.log(`  ${urls.localUrlForTerminal}`);
   }

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -47,6 +47,7 @@
     "inquirer": "3.1.1",
     "is-root": "1.0.0",
     "opn": "5.1.0",
+    "qrcode-terminal": "^0.11.0",
     "recursive-readdir": "2.2.1",
     "shell-quote": "1.6.1",
     "sockjs-client": "1.1.4",


### PR DESCRIPTION
This PR helps to easy test react app on cell phones:

1. In created react app run `npm start`
2. After compiled successfully, it will display like:

```
Compiled successfully!

You can now view pap_app in the browser.

  Local:            http://localhost:3000/
  On Your Network:  http://192.168.1.100:3000/
....................................
....................................
....................................
....................................
....................................
....................................
...a qr code will displayed here....
....................................
....................................
....................................
....................................
....................................

Note that the development build is not optimized.
To create a production build, use npm run build.
```
