### PR TITLE
fix formatWebpackMessages to return all formatted messages instead of just one error.

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -164,6 +164,11 @@ function createCompiler(webpack, config, appName, urls, useYarn) {
 
     // If errors exist, only show errors.
     if (messages.errors.length) {
+      // Only keep the first error. Others are often indicative
+      // of the same problem, but confuse the reader with noise.
+      if (result.errors.length > 1) {
+        result.errors.length = 1;
+      }
       console.log(chalk.red('Failed to compile.\n'));
       console.log(messages.errors.join('\n\n'));
       return;

--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -166,8 +166,8 @@ function createCompiler(webpack, config, appName, urls, useYarn) {
     if (messages.errors.length) {
       // Only keep the first error. Others are often indicative
       // of the same problem, but confuse the reader with noise.
-      if (result.errors.length > 1) {
-        result.errors.length = 1;
+      if (messages.errors.length > 1) {
+        messages.errors.length = 1;
       }
       console.log(chalk.red('Failed to compile.\n'));
       console.log(messages.errors.join('\n\n'));

--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -121,11 +121,6 @@ function formatWebpackMessages(json) {
     // preceding a much more useful Babel syntax error.
     result.errors = result.errors.filter(isLikelyASyntaxError);
   }
-  // Only keep the first error. Others are often indicative
-  // of the same problem, but confuse the reader with noise.
-  if (result.errors.length > 1) {
-    result.errors.length = 1;
-  }
   return result;
 }
 

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -121,6 +121,11 @@ function build(previousFileSizes) {
       }
       const messages = formatWebpackMessages(stats.toJson({}, true));
       if (messages.errors.length) {
+        // Only keep the first error. Others are often indicative
+        // of the same problem, but confuse the reader with noise.
+        if (messages.errors.length > 1) {
+          messages.errors.length = 1;
+        }
         return reject(new Error(messages.errors.join('\n\n')));
       }
       if (


### PR DESCRIPTION
Hi,

I propose this change to `formatWebpackMessages` that currently removes all errors but one to the places in which it is used.

I propose this change because it's really surprising that when you call a function that is supposed to format messages that actually formats and removes messages.

I moved the removal of messages where they're displayed. That makes it clearer why you see only one single error and not all the errors that occured.