### PR TITLE
Documentation to help windows contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,23 @@ and then run `npm start` or `npm run build`.
 
 More detailed information are in the dedicated [README](/packages/react-scripts/fixtures/kitchensink/README.md).
 
+## Tips for contributors using Windows
+
+The scripts in tasks folder and other scripts in `package.json` will not work in Windows out of the box. However, using [Bash on  windows](https://msdn.microsoft.com/en-us/commandline/wsl/about) makes it easier to use those scripts without any workarounds.
+
+### Install Bash on Ubuntu on Windows
+
+A good step by step guide can be found [here](https://www.howtogeek.com/249966/how-to-install-and-use-the-linux-bash-shell-on-windows-10/)
+
+### Install Node.js and npm
+Even if you have node and npm installed on your windows, it would not be accessible from the bash shell. You would have to install it again. Installing via [`nvm`](https://github.com/creationix/nvm#install-script) is recommended.
+
+### Line endings
+
+By default git would use `CRLF` line endings which would cause the scripts to fail. You can change it for this repo only by setting `autocrlf` to false.
+`git config core.autocrlf false`
+You can also enable it for all your repos by using the `--global` flag
+
 ## Cutting a Release
 
 1. Tag all merged pull requests that go into the release with the relevant milestone. Each merged PR should also be labeled with one of the [labels](https://github.com/facebookincubator/create-react-app/labels) named `tag: ...` to indicate what kind of change it is.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ More detailed information are in the dedicated [README](/packages/react-scripts/
 
 ## Tips for contributors using Windows
 
-The scripts in tasks folder and other scripts in `package.json` will not work in Windows out of the box. However, using [Bash on  windows](https://msdn.microsoft.com/en-us/commandline/wsl/about) makes it easier to use those scripts without any workarounds.
+The scripts in tasks folder and other scripts in `package.json` will not work in Windows out of the box. However, using [Bash on  windows](https://msdn.microsoft.com/en-us/commandline/wsl/about) makes it easier to use those scripts without any workarounds. The steps to do so are detailed below: 
 
 ### Install Bash on Ubuntu on Windows
 
@@ -109,9 +109,7 @@ Even if you have node and npm installed on your windows, it would not be accessi
 
 ### Line endings
 
-By default git would use `CRLF` line endings which would cause the scripts to fail. You can change it for this repo only by setting `autocrlf` to false.
-`git config core.autocrlf false`
-You can also enable it for all your repos by using the `--global` flag
+By default git would use `CRLF` line endings which would cause the scripts to fail. You can change it for this repo only by setting `autocrlf` to false by running `git config core.autocrlf false`. You can also enable it for all your repos by using the `--global` flag if you wish to do so.
 
 ## Cutting a Release
 


### PR DESCRIPTION
This PR is in follow up to the discussion in issue #2828 

This introduces a new section in contributing.md for developers using windows machine to help them contribute to this project without relying on workarounds. 


**Tests**: 
Below are the screenshot that shows that the steps followed enable devs to use the scripts in the repo as is: 

_Running Prettier_
This shows that windows bash is able to understand unix based paths and patterns without any changes.
![image](https://user-images.githubusercontent.com/8372161/28500213-77598f32-6fc4-11e7-9d12-8c0dd757bf9b.png)

_Running .sh scripts in tasks folder_
This shows that windows bash is able to run the scripts out of the box.
![image](https://user-images.githubusercontent.com/8372161/28500268-6a8d973e-6fc5-11e7-8195-0a5b8b053f95.png)

