### PR TITLE
Allow use of scoped packages with a pinned version

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -441,7 +441,7 @@ function getPackageName(installPackage) {
     // git+https://github.com/mycompany/react-scripts.git
     // git+ssh://github.com/mycompany/react-scripts.git#v1.2.3
     return Promise.resolve(installPackage.match(/([^\/]+)\.git(#.*)?$/)[1]);
-  } else if (installPackage.indexOf('@') > 0) {
+  } else if (installPackage.match(/.+@/)) {
     // Do not match @scope/ when stripping off @version or @tag
     return Promise.resolve(
       installPackage.charAt(0) + installPackage.substr(1).split('@')[0]


### PR DESCRIPTION
When specifying a --scripts-version, the first `@` in a scoped package prevents the `packageName` from being trimmed of its version tag, if it has one. Hence, an uncaught error is thrown when the full, pinned package name is used in the path to read `package.json`:

<img width="748" alt="screen shot 2017-07-25 at 3 38 14 pm" src="https://user-images.githubusercontent.com/3528097/28596776-579a4100-714f-11e7-864c-acd03ae07281.png">

I added the .match() to yield a truthy value if the `installPackage` contains an @ symbol at char `0` and at char `1+`. To test that this works, run `create-react-app --scripts-version=@organization/my-react-scripts@0.0.1` and see that create-react-app completed successfully and that the correct package version was installed:

<img width="554" alt="screen shot 2017-07-25 at 3 44 29 pm" src="https://user-images.githubusercontent.com/3528097/28597020-8994d70a-7150-11e7-9f67-b0f56ec76274.png">
