### PR TITLE
use the template string

### DIFF
--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -21,7 +21,7 @@ switch (script) {
   case 'test': {
     const result = spawn.sync(
       'node',
-      [require.resolve('../scripts/' + script)].concat(args),
+      [require.resolve(`../scripts/${script}`)].concat(args),
       { stdio: 'inherit' }
     );
     if (result.signal) {


### PR DESCRIPTION
The create-react-app need node >= 6, and node version 6 support a lot of ES6, and let's switch using '+' to concat string with template string.


