### PR TITLE
Fix the order of arguments in spawned child proc

### DIFF
--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -27,7 +27,7 @@ switch (script) {
       'node',
       nodeArgs
         .concat(require.resolve('../scripts/' + script))
-        .concat(args.slice(scriptIndex + 1))
+        .concat(args.slice(scriptIndex + 1)),
       { stdio: 'inherit' }
     );
     if (result.signal) {

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -13,9 +13,8 @@
 const spawn = require('react-dev-utils/crossSpawn');
 const args = process.argv.slice(2);
 
-const scriptIndex = args.findIndex(
-  x => x === 'build' || x === 'eject' || x === 'start' || x === 'test',
-);
+const scriptIndex = args.findIndex(x =>
+   x === 'build' || x === 'eject' || x === 'start' || x === 'test');
 const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
 const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : [];
 

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -21,7 +21,7 @@ switch (script) {
   case 'test': {
     const result = spawn.sync(
       'node',
-      [require.resolve(`../scripts/${script}`)].concat(args),
+      args.concat(require.resolve(`../scripts/${script}`)),
       { stdio: 'inherit' }
     );
     if (result.signal) {

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -11,8 +11,13 @@
 'use strict';
 
 const spawn = require('react-dev-utils/crossSpawn');
-const script = process.argv[2];
-const args = process.argv.slice(3);
+const args = process.argv.slice(2);
+
+const scriptIndex = args.findIndex(
+  x => x === 'build' || x === 'eject' || x === 'start' || x === 'test',
+);
+const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
+const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : [];
 
 switch (script) {
   case 'build':
@@ -21,7 +26,9 @@ switch (script) {
   case 'test': {
     const result = spawn.sync(
       'node',
-      args.concat(require.resolve(`../scripts/${script}`)),
+      nodeArgs
+        .concat(require.resolve('../scripts/' + script))
+        .concat(args.slice(scriptIndex + 1))
       { stdio: 'inherit' }
     );
     if (result.signal) {


### PR DESCRIPTION
Need to be able to pass Node args into the spawned Node process:

```bash
$ npx react-scripts --inspect build
```