### PR TITLE
<!doctype html> -> <!DOCTYPE html>

### DIFF
--- a/packages/react-scripts/template/public/index.html
+++ b/packages/react-scripts/template/public/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
Changed

`<!doctype html>`

to

`<!DOCTYPE html>`

According to the spec it should be uppercase (but parsing is case insensitive).

Spec link (see then `8.1.1 The DOCTYPE` chapter): https://www.w3.org/TR/html5/syntax.html#the-doctype
