### PR TITLE
Remove deprecated rule `jsx-a11y/href-no-hash` for eslint^4.0.0

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -279,7 +279,6 @@ module.exports = {
     'jsx-a11y/aria-role': 'warn',
     'jsx-a11y/aria-unsupported-elements': 'warn',
     'jsx-a11y/heading-has-content': 'warn',
-    'jsx-a11y/href-no-hash': 'warn',
     'jsx-a11y/iframe-has-title': 'warn',
     'jsx-a11y/img-redundant-alt': 'warn',
     'jsx-a11y/no-access-key': 'warn',


### PR DESCRIPTION
Remove this rule we can avoid having a lot of warnings during build of CRA to work event with `eslint^4.0.0` and `eslint-plugin-jsx-a11y^6.0.2`

`Line 1:  Definition for rule 'jsx-a11y/href-no-hash' was not found  jsx-a11y/href-no-hash`
