### PR TITLE
Remove 'shortcut' from favicon link

### DIFF
--- a/packages/react-scripts/template/public/index.html
+++ b/packages/react-scripts/template/public/index.html
@@ -9,7 +9,7 @@
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
According to the documentation on MDN, the `shortcut` link type [should no longer be used](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types).

I've removed it from the template.

As far as I can tell, this isn't covered by a test and is just copied across to new projects.