### PR TITLE
start using npm-run-all to build scss and js

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -584,7 +584,8 @@ Then we can change `start` and `build` scripts to include the CSS preprocessor c
 -    "build": "react-scripts build",
 +    "start-js": "react-scripts start",
 +    "start": "npm-run-all -p watch-css start-js",
-+    "build": "npm run build-css && react-scripts build",
++    "build-js": "react-scripts build",
++    "build": "npm-run-all build-css build-js",
      "test": "react-scripts test --env=jsdom",
      "eject": "react-scripts eject"
    }


### PR DESCRIPTION
Instead of using `&&` to run multiple commands in `package.json`, guide users to use `npm-run-all`.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
