### PR TITLE
Uniform behaviour in linux and windows

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -84,7 +84,9 @@ choosePort(HOST, DEFAULT_PORT)
         clearConsole();
       }
       console.log(chalk.cyan('Starting the development server...\n'));
-      openBrowser(urls.localUrlForBrowser);
+      if (process.env.BROWSER !== "none") {
+        openBrowser(urls.localUrlForBrowser);
+      }
     });
 
     ['SIGINT', 'SIGTERM'].forEach(function(sig) {


### PR DESCRIPTION
In linux I can set `export BROWSER=none` to avoid opening the browser when launching `npm start`, whereas in windows I cannot.
When using react inside electron it's annoying that the browser opens automatically.
I propose to check the BROWSER environment variable before opening the browser, to avoid the issue

Below a screenshot of the updated react-script running smoothly
![capture](https://user-images.githubusercontent.com/22430306/29460633-fb55ee02-8428-11e7-9571-86a8af27a8cc.PNG)
