### PR TITLE
Docs: How to Debug Unit Tests

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1482,9 +1482,11 @@ If you use [Visual Studio Code](https://code.visualstudio.com), there is a [Jest
 
 ## Debugging Tests
 
-There are various ways to setup a debugger for your Jest tests. We cover debugging in Chrome and Visual Studio Code.
+There are various ways to setup a debugger for your Jest tests. We cover debugging in Chrome and [Visual Studio Code](https://code.visualstudio.com/).
 
-### Chrome
+>Note: debugging tests requires Node 8 or higher.
+
+### Debugging Tests in Chrome
 
 Add the following to the `scripts` section in your project's `package.json`
 ```json
@@ -1510,7 +1512,7 @@ After opening that link, the Chrome Developer Tools will be displayed. Select `i
 
 ### Debugging Tests in Visual Studio Code
 
-Debugging Jest tests for `create-react-app` is supported out of the box for [Visual Studio Code](https://code.visualstudio.com).
+Debugging Jest tests is supported out of the box for [Visual Studio Code](https://code.visualstudio.com).
 
 Use the following [`launch.json`](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) configuration file:
 ```

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1486,16 +1486,15 @@ There are various ways to setup a debugger for your Jest tests. We cover debuggi
 
 ### Chrome
 
-Place `debugger;` statements in any test and run
-
-macOS/Linux
-```bash
-node node_modules/.bin/react-scripts --inspect-brk test --runInBand --env=jsdom
+Add the following to the `scripts` section in your project's `package.json`
+```json
+"scripts": {
+    "test:debug": "react-scripts --inspect-brk test --runInBand --env=jsdom"
+  }
 ```
-
-Windows
+Place `debugger;` statements in any test and run:
 ```bash
-node node_modules/bin/react-scripts --inspect-brk test --runInBand --testPathIgnorePatterns=ui-tests/* --env=jsdom
+$ npm run test:debug
 ```
 
 This will start running your Jest tests, but pause before executing to allow a debugger to attach to the process.
@@ -1509,7 +1508,7 @@ After opening that link, the Chrome Developer Tools will be displayed. Select `i
 
 >Note: the --runInBand cli option makes sure Jest runs test in the same process rather than spawning processes for individual tests. Normally Jest parallelizes test runs across processes but it is hard to debug many processes at the same time.
 
-### Visual Studio Code
+### Debugging Tests in Visual Studio Code
 
 Debugging Jest tests for `create-react-app` is supported out of the box for [Visual Studio Code](https://code.visualstudio.com).
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1484,13 +1484,7 @@ If you use [Visual Studio Code](https://code.visualstudio.com), there is a [Jest
 
 There are various ways to setup a debugger for your Jest tests. We cover debugging in Chrome and Visual Studio Code.
 
-### Chrome & Node Inspector
-
-Download [Node Inspector](https://github.com/node-inspector/node-inspector) or similar debugger
-
-```bash
-npm install -g node-inspector
-```
+### Chrome
 
 Place `debugger;` statements in any test and run
 
@@ -1506,12 +1500,12 @@ node node_modules/bin/react-scripts --inspect-brk test --runInBand --testPathIgn
 
 This will start running your Jest tests, but pause before executing to allow a debugger to attach to the process.
 
-To attach the `node-inspector` debugger, run:
+Open the following in Chrome
 ```
-node-inspector
+about:inspect
 ```
 
-This will output a link that you can open in Chrome. After opening that link, the Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done simply to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the debugger statement, execution will pause and you can examine the current scope and call stack.
+After opening that link, the Chrome Developer Tools will be displayed. Select `inspect` on your process and a breakpoint will be set at the first line of the react script (this is done simply to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the debugger statement, execution will pause and you can examine the current scope and call stack.
 
 >Note: the --runInBand cli option makes sure Jest runs test in the same process rather than spawning processes for individual tests. Normally Jest parallelizes test runs across processes but it is hard to debug many processes at the same time.
 
@@ -1528,7 +1522,7 @@ Use the following [`launch.json`](https://code.visualstudio.com/docs/editor/debu
       "name": "Debug CRA Tests",
       "type": "node",
       "request": "launch",
-      "runtimeExecutable": "${workspaceRoot/node_modules/.bin/react-scripts",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
       "runtimeArgs": [
         "--inspect-brk",
         "test"

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -64,6 +64,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
   - [Disabling jsdom](#disabling-jsdom)
   - [Snapshot Testing](#snapshot-testing)
   - [Editor Integration](#editor-integration)
+- [Debugging Tests](#debugging-tests)
 - [Developing Components in Isolation](#developing-components-in-isolation)
   - [Getting Started with Storybook](#getting-started-with-storybook)
   - [Getting Started with Styleguidist](#getting-started-with-styleguidist)
@@ -1478,6 +1479,73 @@ Snapshot testing is a feature of Jest that automatically generates text snapshot
 If you use [Visual Studio Code](https://code.visualstudio.com), there is a [Jest extension](https://github.com/orta/vscode-jest) which works with Create React App out of the box. This provides a lot of IDE-like features while using a text editor: showing the status of a test run with potential fail messages inline, starting and stopping the watcher automatically, and offering one-click snapshot updates.
 
 ![VS Code Jest Preview](https://cloud.githubusercontent.com/assets/49038/20795349/a032308a-b7c8-11e6-9b34-7eeac781003f.png)
+
+## Debugging Tests
+
+There are various ways to setup a debugger for your Jest tests. We cover debugging in Chrome and Visual Studio Code.
+
+### Chrome & Node Inspector
+
+Download [Node Inspector](https://github.com/node-inspector/node-inspector) or similar debugger
+
+```bash
+npm install -g node-inspector
+```
+
+Place `debugger;` statements in any test and run
+
+macOS/Linux
+```bash
+node node_modules/.bin/react-scripts --inspect-brk test --runInBand --env=jsdom
+```
+
+Windows
+```bash
+node node_modules/bin/react-scripts --inspect-brk test --runInBand --testPathIgnorePatterns=ui-tests/* --env=jsdom
+```
+
+This will start running your Jest tests, but pause before executing to allow a debugger to attach to the process.
+
+To attach the `node-inspector` debugger, run:
+```
+node-inspector
+```
+
+This will output a link that you can open in Chrome. After opening that link, the Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done simply to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the debugger statement, execution will pause and you can examine the current scope and call stack.
+
+>Note: the --runInBand cli option makes sure Jest runs test in the same process rather than spawning processes for individual tests. Normally Jest parallelizes test runs across processes but it is hard to debug many processes at the same time.
+
+### Visual Studio Code
+
+Debugging Jest tests for `create-react-app` is supported out of the box for [Visual Studio Code](https://code.visualstudio.com).
+
+Use the following [`launch.json`](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) configuration file:
+```
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug CRA Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceRoot/node_modules/.bin/react-scripts",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "test"
+      ],
+      "args": [
+        "--runInBand",
+        "--no-cache",
+        "--env=jsdom"
+      ],
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}
+```
 
 ## Developing Components in Isolation
 


### PR DESCRIPTION
This updates the docs to include a “Debugging Tests” section. 

I included how to use debug Jest tests with Chrome/Node Inspector and the new `—inspect` flag.  

I also included the configuration file for debugging tests directly in VS Code.

I _think_ this mostly closes #594. I know @prigara wanted to additionally add a section about debugging Webstorm too, which would really finish this off! 