### PR TITLE
Fix module function name in error overlay

### DIFF
--- a/packages/react-error-overlay/src/components/frame.js
+++ b/packages/react-error-overlay/src/components/frame.js
@@ -101,13 +101,13 @@ function frameDiv(
   const frame = document.createElement('div');
   const frameFunctionName = document.createElement('div');
 
-  let cleanedFunctionName;
-  if (!functionName || functionName === 'Object.<anonymous>') {
-    cleanedFunctionName = '(anonymous function)';
-  } else {
-    cleanedFunctionName = functionName;
+  if (functionName && functionName.indexOf('Object.') === 0) {
+    functionName = functionName.slice('Object.'.length);
   }
-
+  if (functionName === '<anonymous>') {
+    functionName = null;
+  }
+  const cleanedFunctionName = functionName || '(anonymous function)';
   const cleanedUrl = url.replace('webpack://', '.');
 
   if (internalUrl) {


### PR DESCRIPTION
Since https://github.com/facebookincubator/create-react-app/pull/2458, we've been showing a weird name in the error overlay for top-level module errors: `Object.<module path>`. 

<img width="670" alt="screen shot 2017-08-26 at 5 30 11 pm" src="https://user-images.githubusercontent.com/810438/29745894-c83445e8-8a84-11e7-91f2-02748eb8711f.png">

This fixes it to just omit `Object.` because it's always useless.

<img width="682" alt="screen shot 2017-08-26 at 5 29 45 pm" src="https://user-images.githubusercontent.com/810438/29745893-c4333698-8a84-11e7-9a0b-07e536010895.png">
