### PR TITLE
Make error overlay filename configurable

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -33,6 +33,7 @@ ErrorOverlay.startReportingRuntimeErrors({
       module.hot.decline();
     }
   },
+  filename: 'static/js/bundle.js',
 });
 
 if (module.hot && typeof module.hot.dispose === 'function') {

--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -21,7 +21,7 @@ import type { ErrorRecord } from './listenToRuntimeErrors';
 type RuntimeReportingOptions = {|
   onError: () => void,
   launchEditorEndpoint: string,
-  filename: string,
+  filename?: string,
 |};
 
 let iframe: null | HTMLIFrameElement = null;

--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -21,6 +21,7 @@ import type { ErrorRecord } from './listenToRuntimeErrors';
 type RuntimeReportingOptions = {|
   onError: () => void,
   launchEditorEndpoint: string,
+  filename: string,
 |};
 
 let iframe: null | HTMLIFrameElement = null;
@@ -55,7 +56,7 @@ export function startReportingRuntimeErrors(options: RuntimeReportingOptions) {
     } finally {
       handleRuntimeError(errorRecord);
     }
-  });
+  }, options.filename);
 }
 
 function handleRuntimeError(errorRecord) {

--- a/packages/react-error-overlay/src/listenToRuntimeErrors.js
+++ b/packages/react-error-overlay/src/listenToRuntimeErrors.js
@@ -39,7 +39,10 @@ export type ErrorRecord = {|
   stackFrames: StackFrame[],
 |};
 
-export function listenToRuntimeErrors(crash: ErrorRecord => void) {
+export function listenToRuntimeErrors(
+  crash: ErrorRecord => void,
+  filename: string
+) {
   function crashWithFrames(error: Error, unhandledRejection = false) {
     getStackFrames(error, unhandledRejection, CONTEXT_SIZE)
       .then(stackFrames => {
@@ -68,7 +71,7 @@ export function listenToRuntimeErrors(crash: ErrorRecord => void) {
       {
         message: data.message,
         stack: data.stack,
-        __unmap_source: '/static/js/bundle.js',
+        __unmap_source: filename,
       },
       false
     );

--- a/packages/react-error-overlay/src/listenToRuntimeErrors.js
+++ b/packages/react-error-overlay/src/listenToRuntimeErrors.js
@@ -41,7 +41,7 @@ export type ErrorRecord = {|
 
 export function listenToRuntimeErrors(
   crash: ErrorRecord => void,
-  filename: string
+  filename: string = '/static/js/bundle.js'
 ) {
   function crashWithFrames(error: Error, unhandledRejection = false) {
     getStackFrames(error, unhandledRejection, CONTEXT_SIZE)


### PR DESCRIPTION
Related to #2515 .

This makes the filename that `react-error-overlay` listens to configurable making it more modular and easy to integrate outside of CRA.
