### PR TITLE
Cleaning up printHostingInstructions a bit

### DIFF
--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -38,7 +38,7 @@ function printHostingInstructions(
     //   or no homepage
     printBaseMessage(buildFolder, publicUrl);
 
-    printStaticServerInstructions(useYarn);
+    printStaticServerInstructions(buildFolder, useYarn);
   }
   console.log();
 }
@@ -108,7 +108,7 @@ function printDeployInstructions(publicUrl, hasDeployScript, useYarn) {
   console.log(`  ${chalk.cyan(useYarn ? 'yarn' : 'npm')} run deploy`);
 }
 
-function printStaticServerInstructions(useYarn) {
+function printStaticServerInstructions(buildFolder, useYarn) {
   console.log('You may serve it with a static server:');
   console.log();
 

--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -21,62 +21,32 @@ function printHostingInstructions(
   buildFolder,
   useYarn
 ) {
-  const publicPathname = url.parse(publicPath).pathname;
-  if (publicUrl && publicUrl.indexOf('.github.io/') !== -1) {
+  if (publicUrl && publicUrl.includes('.github.io/')) {
     // "homepage": "http://user.github.io/project"
-    console.log(
-      `The project was built assuming it is hosted at ${chalk.green(
-        publicPathname
-      )}.`
-    );
-    console.log(
-      `You can control this with the ${chalk.green(
-        'homepage'
-      )} field in your ${chalk.cyan('package.json')}.`
-    );
-    console.log();
-    console.log(
-      `The ${chalk.cyan(buildFolder)} folder is ready to be deployed.`
-    );
-    console.log(`To publish it at ${chalk.green(publicUrl)}, run:`);
-    // If script deploy has been added to package.json, skip the instructions
-    if (typeof appPackage.scripts.deploy === 'undefined') {
-      console.log();
-      if (useYarn) {
-        console.log(`  ${chalk.cyan('yarn')} add --dev gh-pages`);
-      } else {
-        console.log(`  ${chalk.cyan('npm')} install --save-dev gh-pages`);
-      }
-      console.log();
-      console.log(
-        `Add the following script in your ${chalk.cyan('package.json')}.`
-      );
-      console.log();
-      console.log(`    ${chalk.dim('// ...')}`);
-      console.log(`    ${chalk.yellow('"scripts"')}: {`);
-      console.log(`      ${chalk.dim('// ...')}`);
-      console.log(
-        `      ${chalk.yellow('"predeploy"')}: ${chalk.yellow(
-          '"npm run build",'
-        )}`
-      );
-      console.log(
-        `      ${chalk.yellow('"deploy"')}: ${chalk.yellow(
-          '"gh-pages -d build"'
-        )}`
-      );
-      console.log('    }');
-      console.log();
-      console.log('Then run:');
-    }
-    console.log();
-    console.log(`  ${chalk.cyan(useYarn ? 'yarn' : 'npm')} run deploy`);
-    console.log();
+    const publicPathname = url.parse(publicPath).pathname;
+    const hasDeployScript = typeof appPackage.scripts.deploy !== 'undefined';
+    printBaseMessage(buildFolder, publicPathname);
+
+    printDeployInstructions(publicUrl, hasDeployScript, useYarn);
+
   } else if (publicPath !== '/') {
     // "homepage": "http://mywebsite.com/project"
+    printBaseMessage(buildFolder, publicPath);
+
+  } else {
+    // "homepage": "http://mywebsite.com"
+    //   or no homepage
+    printBaseMessage(buildFolder, publicUrl);
+
+    printStaticServerInstructions(useYarn);
+  }
+  console.log();
+}
+
+function printBaseMessage(buildFolder, hostingLocation) {
     console.log(
       `The project was built assuming it is hosted at ${chalk.green(
-        publicPath
+        hostingLocation || 'the server root'
       )}.`
     );
     console.log(
@@ -84,59 +54,72 @@ function printHostingInstructions(
         'homepage'
       )} field in your ${chalk.cyan('package.json')}.`
     );
-    console.log();
-    console.log(
-      `The ${chalk.cyan(buildFolder)} folder is ready to be deployed.`
-    );
-    console.log();
-  } else {
-    if (publicUrl) {
-      // "homepage": "http://mywebsite.com"
-      console.log(
-        `The project was built assuming it is hosted at ${chalk.green(
-          publicUrl
-        )}.`
-      );
-      console.log(
-        `You can control this with the ${chalk.green(
-          'homepage'
-        )} field in your ${chalk.cyan('package.json')}.`
-      );
-      console.log();
-    } else {
-      // no homepage
-      console.log(
-        'The project was built assuming it is hosted at the server root.'
-      );
-      console.log(
-        `To override this, specify the ${chalk.green(
-          'homepage'
-        )} in your ${chalk.cyan('package.json')}.`
-      );
+
+    if (!hostingLocation) {
       console.log('For example, add this to build it for GitHub Pages:');
       console.log();
+
       console.log(
         `  ${chalk.green('"homepage"')} ${chalk.cyan(':')} ${chalk.green(
           '"http://myname.github.io/myapp"'
         )}${chalk.cyan(',')}`
       );
-      console.log();
     }
+    console.log();
+
     console.log(
       `The ${chalk.cyan(buildFolder)} folder is ready to be deployed.`
     );
-    console.log('You may serve it with a static server:');
-    console.log();
-    if (!fs.existsSync(`${globalModules}/serve`)) {
-      if (useYarn) {
-        console.log(`  ${chalk.cyan('yarn')} global add serve`);
-      } else {
-        console.log(`  ${chalk.cyan('npm')} install -g serve`);
-      }
+}
+
+function printDeployInstructions(publicUrl, hasDeployScript, useYarn) {
+  console.log(`To publish it at ${chalk.green(publicUrl)}, run:`);
+  console.log();
+
+  // If script deploy has been added to package.json, skip the instructions
+  if (!hasDeployScript) {
+    if (useYarn) {
+      console.log(`  ${chalk.cyan('yarn')} add --dev gh-pages`);
+    } else {
+      console.log(`  ${chalk.cyan('npm')} install --save-dev gh-pages`);
     }
-    console.log(`  ${chalk.cyan('serve')} -s ${buildFolder}`);
+    console.log();
+
+    console.log(`Add the following script in your ${chalk.cyan(
+      'package.json'
+    )}.`);
+    console.log();
+
+    console.log(`    ${chalk.dim('// ...')}`);
+    console.log(`    ${chalk.yellow('"scripts"')}: {`);
+    console.log(`      ${chalk.dim('// ...')}`);
+    console.log(`      ${chalk.yellow('"predeploy"')}: ${chalk.yellow(
+      '"npm run build",'
+    )}`);
+    console.log(`      ${chalk.yellow('"deploy"')}: ${chalk.yellow(
+      '"gh-pages -d build"'
+    )}`);
+    console.log('    }');
+    console.log();
+
+    console.log('Then run:');
     console.log();
   }
+  console.log(`  ${chalk.cyan(useYarn ? 'yarn' : 'npm')} run deploy`);
+}
+
+function printStaticServerInstructions(useYarn) {
+  console.log('You may serve it with a static server:');
+  console.log();
+
+  if (!fs.existsSync(`${globalModules}/serve`)) {
+    if (useYarn) {
+      console.log(`  ${chalk.cyan('yarn')} global add serve`);
+    } else {
+      console.log(`  ${chalk.cyan('npm')} install -g serve`);
+    }
+  }
+  console.log(`  ${chalk.cyan('serve')} -s ${buildFolder}`);
 }
 
 module.exports = printHostingInstructions;

--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -35,7 +35,9 @@ function printHostingInstructions(
       )} field in your ${chalk.cyan('package.json')}.`
     );
     console.log();
-    console.log(`The ${chalk.cyan('build')} folder is ready to be deployed.`);
+    console.log(
+      `The ${chalk.cyan(buildFolder)} folder is ready to be deployed.`
+    );
     console.log(`To publish it at ${chalk.green(publicUrl)}, run:`);
     // If script deploy has been added to package.json, skip the instructions
     if (typeof appPackage.scripts.deploy === 'undefined') {
@@ -83,7 +85,9 @@ function printHostingInstructions(
       )} field in your ${chalk.cyan('package.json')}.`
     );
     console.log();
-    console.log(`The ${chalk.cyan('build')} folder is ready to be deployed.`);
+    console.log(
+      `The ${chalk.cyan(buildFolder)} folder is ready to be deployed.`
+    );
     console.log();
   } else {
     if (publicUrl) {


### PR DESCRIPTION
There are no functional or text changes with this PR. I'm just cleaning up the logic for printHostingInstructions to make it more readable and remove some duplication. The only minor logic change is that I replaced a couple hard-coded literals (`'build'`) with variables (`buildFolder`).

The main `printHostingInstructions` method is now purely logic. It calls three other functions `printBaseMessage`, `printDeployInstructions`, and `printStaticServerInstructions`; which contain the console statements with minimal logic.