### PR TITLE
Strip hash from chunk file name

### DIFF
--- a/packages/react-dev-utils/FileSizeReporter.js
+++ b/packages/react-dev-utils/FileSizeReporter.js
@@ -92,7 +92,10 @@ function printFileSizesAfterBuild(
 function removeFileNameHash(buildFolder, fileName) {
   return fileName
     .replace(buildFolder, '')
-    .replace(/\/?(.*)(\.\w+)(\.js|\.css)/, (match, p1, p2, p3) => p1 + p3);
+    .replace(
+      /\/?(.*)(\.[0-9a-f]+)(\.chunk)?(\.js|\.css)/,
+      (match, p1, p2, p3, p4) => p1 + p4
+    );
 }
 
 // Input: 1024, 2048


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

### Fix

This fixes bug #3048 and strips hashes from chunks correctly.

### Testing

1. `npm run create-react-app test-fix`
2. `cd test-fix`
3. Copied `src/App.js` and `src/content.js` from [cra-chunk-bundle-diff-bug repo](https://github.com/esturcke/cra-chunk-bundle-diff-bug)
4. `yarn build`

```
...
File sizes after gzip:

  48.61 KB  build/static/js/main.b6cc0832.js
  288 B     build/static/css/main.cacbacc7.css
  177 B     build/static/js/content.4f2061bf.chunk.js
...
```

5. Edit `src/content.js`
6. `yarn build`

```
...
File sizes after gzip:

  48.61 KB (-1 B)  build/static/js/main.b3f3c0af.js
  288 B            build/static/css/main.cacbacc7.css
  180 B (+3 B)     build/static/js/content.c58cbe0c.chunk.js
...
```

