### PR TITLE
Auto-detect running editor on Linux for error overlay

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -60,11 +60,13 @@ const COMMON_EDITORS_LINUX = {
   atom: 'atom',
   Brackets: 'brackets',
   code: 'code',
+  emacs: 'emacs',
   'idea.sh': 'idea',
   'phpstorm.sh': 'phpstorm',
   'pycharm.sh': 'pycharm',
   'rubymine.sh': 'rubymine',
   sublime_text: 'sublime_text',
+  vim: 'vim',
   'webstorm.sh': 'webstorm',
 };
 
@@ -156,7 +158,10 @@ function guessEditor() {
     return shellQuote.parse(process.env.REACT_EDITOR);
   }
 
-  // Using `ps x` on OSX or `Get-Process` on Windows we can find out which editor is currently running.
+  // We can find out which editor is currently running by:
+  // `ps x` on OSX
+  // `Get-Process` on Windows
+  // `ps -e` on Linux
   try {
     if (process.platform === 'darwin') {
       const output = child_process.execSync('ps x').toString();
@@ -188,6 +193,9 @@ function guessEditor() {
         }
       }
     } else if (process.platform === 'linux') {
+      // --no-heading No header line
+      // -e Select all processes
+      // -o comm Need only names column
       const output = child_process
         .execSync('ps --no-heading -e -o comm --sort=comm')
         .toString();

--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -159,9 +159,8 @@ function guessEditor() {
   }
 
   // We can find out which editor is currently running by:
-  // `ps x` on OSX
+  // `ps x` on macOS and Linux
   // `Get-Process` on Windows
-  // `ps -e` on Linux
   try {
     if (process.platform === 'darwin') {
       const output = child_process.execSync('ps x').toString();

--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -194,10 +194,10 @@ function guessEditor() {
       }
     } else if (process.platform === 'linux') {
       // --no-heading No header line
-      // -e Select all processes
+      // x List all processes owned by you
       // -o comm Need only names column
       const output = child_process
-        .execSync('ps --no-heading -e -o comm --sort=comm')
+        .execSync('ps x --no-heading -o comm --sort=comm')
         .toString();
       const processNames = Object.keys(COMMON_EDITORS_LINUX);
       for (let i = 0; i < processNames.length; i++) {

--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -43,7 +43,7 @@ const COMMON_EDITORS_OSX = {
   '/Applications/CLion.app/Contents/MacOS/clion':
     '/Applications/CLion.app/Contents/MacOS/clion',
   '/Applications/IntelliJ IDEA.app/Contents/MacOS/idea':
-      '/Applications/IntelliJ IDEA.app/Contents/MacOS/idea',
+    '/Applications/IntelliJ IDEA.app/Contents/MacOS/idea',
   '/Applications/PhpStorm.app/Contents/MacOS/phpstorm':
     '/Applications/PhpStorm.app/Contents/MacOS/phpstorm',
   '/Applications/PyCharm.app/Contents/MacOS/pycharm':
@@ -53,7 +53,19 @@ const COMMON_EDITORS_OSX = {
   '/Applications/RubyMine.app/Contents/MacOS/rubymine':
     '/Applications/RubyMine.app/Contents/MacOS/rubymine',
   '/Applications/WebStorm.app/Contents/MacOS/webstorm':
-      '/Applications/WebStorm.app/Contents/MacOS/webstorm',
+    '/Applications/WebStorm.app/Contents/MacOS/webstorm',
+};
+
+const COMMON_EDITORS_LINUX = {
+  atom: 'atom',
+  Brackets: 'brackets',
+  code: 'code',
+  'idea.sh': 'idea',
+  'phpstorm.sh': 'phpstorm',
+  'pycharm.sh': 'pycharm',
+  'rubymine.sh': 'rubymine',
+  sublime_text: 'sublime_text',
+  'webstorm.sh': 'webstorm',
 };
 
 const COMMON_EDITORS_WIN = [
@@ -145,7 +157,6 @@ function guessEditor() {
   }
 
   // Using `ps x` on OSX or `Get-Process` on Windows we can find out which editor is currently running.
-  // Potentially we could use similar technique for Linux
   try {
     if (process.platform === 'darwin') {
       const output = child_process.execSync('ps x').toString();
@@ -174,6 +185,17 @@ function guessEditor() {
 
         if (COMMON_EDITORS_WIN.indexOf(shortProcessName) !== -1) {
           return [fullProcessPath];
+        }
+      }
+    } else if (process.platform === 'linux') {
+      const output = child_process
+        .execSync('ps --no-heading -e -o comm --sort=comm')
+        .toString();
+      const processNames = Object.keys(COMMON_EDITORS_LINUX);
+      for (let i = 0; i < processNames.length; i++) {
+        const processName = processNames[i];
+        if (output.indexOf(processName) !== -1) {
+          return [COMMON_EDITORS_LINUX[processName]];
         }
       }
     }


### PR DESCRIPTION
Basic support of auto detecting running editor for #2636.
Tested on Ubuntu 16.04.
It detects few editors. JetBrains products should start by wrapper like /usr/local/bin/webstorm. Otherwise it takes a lot of time to open editor.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
