### PR TITLE
Switch to unix path separators before normalizing path for Windows compatibility

### DIFF
--- a/packages/react-error-overlay/src/utils/unmapper.js
+++ b/packages/react-error-overlay/src/utils/unmapper.js
@@ -56,6 +56,10 @@ async function unmap(
     }
     let { fileName } = frame;
     if (fileName) {
+      // The web version of this module only provides POSIX support, so Windows
+      // paths like C:\foo\\baz\..\\bar\ cannot be normalized.
+      // A simple solution to this is to replace all `\` with `/`, then
+      // normalize afterwards.
       fileName = path.normalize(fileName.replace(/[\\]+/g, '/'));
     }
     if (fileName == null) {
@@ -64,6 +68,7 @@ async function unmap(
     const fN: string = fileName;
     const source = map
       .getSources()
+      // Prepare path for normalization; see comment above for reasoning.
       .map(s => s.replace(/[\\]+/g, '/'))
       .filter(p => {
         p = path.normalize(p);

--- a/packages/react-error-overlay/src/utils/unmapper.js
+++ b/packages/react-error-overlay/src/utils/unmapper.js
@@ -27,25 +27,6 @@ function count(search: string, string: string): number {
   return count;
 }
 
-function normalizePath(_path: string): string {
-  // `path.normalize` cleans a file path, (e.g. /foo//baz/..//bar/ becomes
-  // /foo/bar/).
-  // The web version of this module only provides POSIX support, so Windows
-  // paths like C:\foo\\baz\..\\bar\ cannot be normalized.
-  // A simple solution to this is to replace all `\` with `/`, then normalize
-  // afterwards.
-  //
-  // Note:
-  // `path.normalize` supports POSIX forward slashes on Windows, but not the
-  // other way around. Converting all backslashes to forward slashes before
-  // normalizing makes this cross platform if it were isomorphic (used server
-  // side).
-  return path.normalize(
-    // Match contiguous backslashes
-    _path.replace(/[\\]+/g, '/')
-  );
-}
-
 /**
  * Turns a set of mapped <code>StackFrame</code>s back into their generated code position and enhances them with code.
  * @param {string} fileUri The URI of the <code>bundle.js</code> file.
@@ -75,7 +56,7 @@ async function unmap(
     }
     let { fileName } = frame;
     if (fileName) {
-      fileName = normalizePath(fileName);
+      fileName = path.normalize(fileName.replace(/[\\]+/g, '/'));
     }
     if (fileName == null) {
       return frame;
@@ -83,7 +64,7 @@ async function unmap(
     const fN: string = fileName;
     const source = map
       .getSources()
-      .map(normalizePath)
+      .map(s => s.replace(/[\\]+/g, '/'))
       .filter(p => {
         p = path.normalize(p);
         const i = p.lastIndexOf(fN);

--- a/packages/react-error-overlay/src/utils/unmapper.js
+++ b/packages/react-error-overlay/src/utils/unmapper.js
@@ -27,6 +27,25 @@ function count(search: string, string: string): number {
   return count;
 }
 
+function normalizePath(_path: string): string {
+  // `path.normalize` cleans a file path, (e.g. /foo//baz/..//bar/ becomes
+  // /foo/bar/).
+  // The web version of this module only provides POSIX support, so Windows
+  // paths like C:\foo\\baz\..\\bar\ cannot be normalized.
+  // A simple solution to this is to replace all `\` with `/`, then normalize
+  // afterwards.
+  //
+  // Note:
+  // `path.normalize` supports POSIX forward slashes on Windows, but not the
+  // other way around. Converting all backslashes to forward slashes before
+  // normalizing makes this cross platform if it were isomorphic (used server
+  // side).
+  return path.normalize(
+    // Match contiguous backslashes
+    _path.replace(/[\\]+/g, '/')
+  );
+}
+
 /**
  * Turns a set of mapped <code>StackFrame</code>s back into their generated code position and enhances them with code.
  * @param {string} fileUri The URI of the <code>bundle.js</code> file.
@@ -56,7 +75,7 @@ async function unmap(
     }
     let { fileName } = frame;
     if (fileName) {
-      fileName = path.normalize(fileName.replace(/[\\]+/g, '/'));
+      fileName = normalizePath(fileName);
     }
     if (fileName == null) {
       return frame;
@@ -64,7 +83,7 @@ async function unmap(
     const fN: string = fileName;
     const source = map
       .getSources()
-      .map(s => s.replace(/[\\]+/g, '/'))
+      .map(normalizePath)
       .filter(p => {
         p = path.normalize(p);
         const i = p.lastIndexOf(fN);

--- a/packages/react-error-overlay/src/utils/unmapper.js
+++ b/packages/react-error-overlay/src/utils/unmapper.js
@@ -56,7 +56,7 @@ async function unmap(
     }
     let { fileName } = frame;
     if (fileName) {
-      fileName = path.normalize(fileName);
+      fileName = path.normalize(fileName.replace(/[\\]+/g, '/'));
     }
     if (fileName == null) {
       return frame;


### PR DESCRIPTION
Turns out that the `path` module stubbed into a web environment does not support Windows, nor contains the `posix` / `win32` variants of path (it's fixed `posix`, so `path.sep` returns `/` in a win32 environment).

Effectively, what happened here is that the `fileName` was `C:\foo\bar` and upon normalizing, remained `C:\foo\bar` (it should've switched to `/`, or more specifically, `path.sep`).

This aligns the behavior with the other path normalization process as seen here: https://github.com/facebookincubator/create-react-app/blob/b17fa4123e2d098d943f4b33ae9c5c2ac311fab6/packages/react-error-overlay/src/utils/unmapper.js#L67

Fixes #3078.

![](https://i.imgur.com/lwLZLcv.png)