### PR TITLE
normalize the e2e behavior for npm link in npm 5 and below

### DIFF
--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -164,10 +164,10 @@ npm install test-integrity@^2.0.1
 cd "$temp_app_path/test-kitchensink"
 
 # Link to our preset
-npm link "$root_path"/packages/babel-preset-react-app
+cp -r "$root_path"/packages/babel-preset-react-app node_modules
 
 # Link to test module
-npm link "$temp_module_path/node_modules/test-integrity"
+cp -r "$temp_module_path/node_modules/test-integrity" node_modules
 
 # Test the build
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
@@ -225,13 +225,13 @@ npm unlink "$root_path"/packages/babel-preset-react-app
 echo yes | npm run eject
 
 # ...but still link to the local packages
-npm link "$root_path"/packages/babel-preset-react-app
-npm link "$root_path"/packages/eslint-config-react-app
-npm link "$root_path"/packages/react-dev-utils
-npm link "$root_path"/packages/react-scripts
+cp -r "$root_path"/packages/babel-preset-react-app node_modules
+cp -r "$root_path"/packages/eslint-config-react-app node_modules
+cp -r "$root_path"/packages/react-dev-utils node_modules
+cp -r "$root_path"/packages/react-scripts node_modules
 
 # Link to test module
-npm link "$temp_module_path/node_modules/test-integrity"
+cp -r "$temp_module_path/node_modules/test-integrity" node_modules
 
 # Test the build
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -167,7 +167,7 @@ cd "$temp_app_path/test-kitchensink"
 cp -r "$root_path"/packages/babel-preset-react-app node_modules
 
 # Link to test module
-cp -r "$temp_module_path/node_modules/test-integrity" node_modules
+npm link "$temp_module_path/node_modules/test-integrity"
 
 # Test the build
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
@@ -231,7 +231,7 @@ cp -r "$root_path"/packages/react-dev-utils node_modules
 cp -r "$root_path"/packages/react-scripts node_modules
 
 # Link to test module
-cp -r "$temp_module_path/node_modules/test-integrity" node_modules
+npm link "$temp_module_path/node_modules/test-integrity"
 
 # Test the build
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -219,7 +219,7 @@ E2E_FILE=./build/index.html \
 # ******************************************************************************
 
 # Unlink our preset
-npm unlink "$root_path"/packages/babel-preset-react-app
+rm -rf node_modules/packages/babel-preset-react-app
 
 # Eject...
 echo yes | npm run eject

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -309,10 +309,10 @@ verify_module_scope
 echo yes | npm run eject
 
 # ...but still link to the local packages
-npm link "$root_path"/packages/babel-preset-react-app
-npm link "$root_path"/packages/eslint-config-react-app
-npm link "$root_path"/packages/react-dev-utils
-npm link "$root_path"/packages/react-scripts
+cp -r "$root_path"/packages/babel-preset-react-app node_modules
+cp -r "$root_path"/packages/eslint-config-react-app node_modules
+cp -r "$root_path"/packages/react-dev-utils node_modules
+cp -r "$root_path"/packages/react-scripts node_modules
 
 # Test the build
 npm run build


### PR DESCRIPTION
changes in https://github.com/facebookincubator/create-react-app/pull/3026 made some build fails in node 8 (success in https://github.com/facebookincubator/create-react-app/pull/3104 and https://github.com/facebookincubator/create-react-app/pull/3026 , failed in https://github.com/facebookincubator/create-react-app/pull/2755 because of misssing dependencies). probably because npm link behavior is changed in npm 5 http://codetunnel.io/npm-5-changes-to-npm-link/

this PR tries to investigate how to normalize the npm link behavior for e2e in npm 5 and below