### PR TITLE
Revert "run npm 5.4.0 in CI (#3026)"

### DIFF
--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -95,11 +95,11 @@ fi
 
 if hash npm 2>/dev/null
 then
-  # npm 5.0-5.4.0 is too buggy
+  # npm 5 is too buggy right now
   if [ $(npm -v | head -c 1) -eq 5 ]; then
-    npm i -g npm@^5.4.1
+    npm i -g npm@^4.x
   fi;
-  npm cache clean --force || npm cache verify
+  npm cache clean || npm cache verify
 fi
 
 # Prevent bootstrap, we only want top-level dependencies

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -87,11 +87,11 @@ fi
 
 if hash npm 2>/dev/null
 then
-  # npm 5.0-5.4.0 is too buggy
+  # npm 5 is too buggy right now
   if [ $(npm -v | head -c 1) -eq 5 ]; then
-    npm i -g npm@^5.4.1
+    npm i -g npm@^4.x
   fi;
-  npm cache clean --force || npm cache verify
+  npm cache clean || npm cache verify
 fi
 
 # Prevent bootstrap, we only want top-level dependencies

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -86,11 +86,11 @@ fi
 
 if hash npm 2>/dev/null
 then
-  # npm 5.0-5.4.0 is too buggy
+  # npm 5 is too buggy right now
   if [ $(npm -v | head -c 1) -eq 5 ]; then
-    npm i -g npm@^5.4.1
+    npm i -g npm@^4.x
   fi;
-  npm cache clean --force || npm cache verify
+  npm cache clean || npm cache verify
 fi
 
 # Prevent bootstrap, we only want top-level dependencies


### PR DESCRIPTION
This reverts commit fcb6dc55578e089e9f62f6e6c12cb9b60a57fee5.
https://github.com/npm/npm/issues/16970 made the e2e in CI failed for changes containing the top level packages like https://github.com/facebookincubator/create-react-app/pull/3105 and https://github.com/facebookincubator/create-react-app/pull/3100.

I think we need to wait a little more to run npm 5++ in CI

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
