### PR TITLE
Update dependencies (To fix Babel bug)

### DIFF
--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -11,17 +11,17 @@
     "index.js"
   ],
   "dependencies": {
-    "babel-plugin-dynamic-import-node": "1.0.2",
+    "babel-plugin-dynamic-import-node": "1.1.0",
     "babel-plugin-syntax-dynamic-import": "6.18.0",
     "babel-plugin-transform-class-properties": "6.24.1",
-    "babel-plugin-transform-object-rest-spread": "6.23.0",
+    "babel-plugin-transform-object-rest-spread": "6.26.0",
     "babel-plugin-transform-react-constant-elements": "6.23.0",
     "babel-plugin-transform-react-jsx": "6.24.1",
     "babel-plugin-transform-react-jsx-self": "6.22.0",
     "babel-plugin-transform-react-jsx-source": "6.22.0",
-    "babel-plugin-transform-regenerator": "6.24.1",
+    "babel-plugin-transform-regenerator": "6.26.0",
     "babel-plugin-transform-runtime": "6.23.0",
-    "babel-preset-env": "1.5.2",
+    "babel-preset-env": "1.6.0",
     "babel-preset-react": "6.24.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
`babel-plugin-transform-es2015-modules-commonjs` has a serious bug about the following snippet and it is fixed in `v6.26.0` release.

```js
export const { variable } = otherVariable
```

- [export const {variable} = otherVariable · Issue #193 · babel/babel-preset-env](https://github.com/babel/babel-preset-env/issues/193)
- [Fix commonjs exports with destructuring. by yavorsky · Pull Request #5469 · babel/babel](https://github.com/babel/babel/pull/5469)

The problem is that current `create-react-app` installs Babel `v6.24.1`. It should be updated.

I'm not familiar with Babel and npm version resolution algorithm, however, I guess the reason; `babel-preset-react-app` doesn't use caret `^` versioning and select old versions. So we may use caret or update the versions. (This PR simply update versions)