### PR TITLE
Fix for add .gitattributes file #3080

### DIFF
--- a/packages/react-error-overlay/.gitattributes
+++ b/packages/react-error-overlay/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
Added .gitattributes file react-error-overlay which forces all *.js files to be checked out with LF line feeds.