### PR TITLE
Add mobile devices into autoprefix target.

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -209,6 +209,8 @@ module.exports = {
                         'last 4 versions',
                         'Firefox ESR',
                         'not ie < 9', // React doesn't support IE8 anyway
+                        'iOS >= 8',
+                        'android >= 4.0'
                       ],
                       flexbox: 'no-2009',
                     }),

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -223,6 +223,8 @@ module.exports = {
                               'last 4 versions',
                               'Firefox ESR',
                               'not ie < 9', // React doesn't support IE8 anyway
+                              'iOS >= 8',
+                              'android >= 4.0'
                             ],
                             flexbox: 'no-2009',
                           }),


### PR DESCRIPTION
###  Problem
I realized autoprefix is not working on iOS 8 Safari from some commit between 0.9.5 and 1.0.10 release.

This is because current target browser setting in webpack configuration in react-scripts is not including mobile devices which still used by amount of users.

`./packages/react-scripts/config/webpack.config.dev.js`
`./packages/react-scripts/config/webpack.config.prod.js`
```javascript
browsers: [
  '>1%',
  'last 4 versions',
  'Firefox ESR',
  'not ie < 9', // React doesn't support IE8 anyway
]
```

#### Below explains visual impact from issue.

- Works autoprefix on react-script `0.9.5`.
<img src="https://user-images.githubusercontent.com/2619560/30407417-18fcbc6e-9933-11e7-809f-a45a4468c4dc.png"  width="200" />

- Not works autoprefix on react-script `1.0.10`.
<img src="https://user-images.githubusercontent.com/2619560/30407418-1900a450-9933-11e7-9604-5dce98cf8b25.png"  width="200" />

###  Solution
Include iOS and Android setting into the configuration.

```javascript
'iOS >= 8',
'android >= 4.0'
```
Support above android 4.0 and iOS 8 is statistically reasonable from my point of view.
Still there is room for discussion about from which version we will support though.