### PR TITLE
Display pid in already running message (#3106)

### DIFF
--- a/packages/react-dev-utils/getProcessForPort.js
+++ b/packages/react-dev-utils/getProcessForPort.js
@@ -48,9 +48,11 @@ function getProcessCommand(processId, processDirectory) {
     execOptions
   );
 
+  command = command.replace(/\n$/, '')
+
   if (isProcessAReactApp(command)) {
     const packageName = getPackageNameInDirectory(processDirectory);
-    return packageName ? packageName + '\n' : command;
+    return packageName ? packageName : command;
   } else {
     return command;
   }
@@ -68,7 +70,8 @@ function getProcessForPort(port) {
     var processId = getProcessIdOnPort(port);
     var directory = getDirectoryOfProcessById(processId);
     var command = getProcessCommand(processId, directory);
-    return chalk.cyan(command) + chalk.blue('  in ') + chalk.cyan(directory);
+    return chalk.cyan(command) + chalk.grey(' (pid ' + processId + ')\n') + 
+      chalk.blue('  in ') + chalk.cyan(directory);
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
A few days late but here it is. Simply added the pid to the output allowing the process to be easily killed if that's your fancy.

![screenshot](https://user-images.githubusercontent.com/817422/30450207-5db5b1c2-9991-11e7-9fe0-a0b5d7218bdd.png)
