### PR TITLE
Link local react-error-overlay package in kitchensink test

### DIFF
--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -165,6 +165,9 @@ cd "$temp_app_path/test-kitchensink"
 
 # Link to our preset
 npm link "$root_path"/packages/babel-preset-react-app
+# Link to error overlay package because now it's a dependency
+# of react-dev-utils and not react-scripts
+npm link "$root_path"/packages/react-error-overlay
 
 # Link to test module
 npm link "$temp_module_path/node_modules/test-integrity"
@@ -220,6 +223,8 @@ E2E_FILE=./build/index.html \
 
 # Unlink our preset
 npm unlink "$root_path"/packages/babel-preset-react-app
+# Unlink error overlay
+npm unlink "$root_path"/packages/react-error-overlay
 
 # Eject...
 echo yes | npm run eject
@@ -227,6 +232,7 @@ echo yes | npm run eject
 # ...but still link to the local packages
 npm link "$root_path"/packages/babel-preset-react-app
 npm link "$root_path"/packages/eslint-config-react-app
+npm link "$root_path"/packages/react-error-overlay
 npm link "$root_path"/packages/react-dev-utils
 npm link "$root_path"/packages/react-scripts
 


### PR DESCRIPTION
In #2515, we removed react-error-overlay from the dependency list of react-scripts, and now it's only included via react-dev-utils. This causes kitchensink test to download and use published react-error-overlay package from NPM instead of using the local package since [`replace-own-deps.js`](https://github.com/facebookincubator/create-react-app/blob/v1.0.13/tasks/e2e-kitchensink.sh#L133) can't handle it anymore. As a result, the test fails when there are changes that need sync in the local react-error-overlay and react-dev-utils packages (#3100).

This PR fixes the issue by linking the local package with `npm link`.