### PR TITLE
Make error overlay to run in the context of the iframe

### DIFF
--- a/packages/react-error-overlay/build.js
+++ b/packages/react-error-overlay/build.js
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 const webpack = require('webpack');
 const chalk = require('chalk');

--- a/packages/react-error-overlay/build.js
+++ b/packages/react-error-overlay/build.js
@@ -1,0 +1,50 @@
+const webpack = require('webpack');
+const chalk = require('chalk');
+const webpackConfig = require('./webpack.config.js');
+const iframeWebpackConfig = require('./webpack.config.iframe.js');
+const rimraf = require('rimraf');
+
+function build(config, name, callback) {
+  console.log(chalk.cyan('Compiling ' + name));
+  webpack(config).run((error, stats) => {
+    if (error) {
+      console.log(chalk.red('Failed to compile.'));
+      console.log(error.message || error);
+      console.log();
+      return;
+    }
+
+    if (stats.compilation.errors.length) {
+      console.log(chalk.red('Failed to compile.'));
+      console.log(stats.toString({ all: false, errors: true }));
+      return;
+    }
+
+    if (stats.compilation.warnings.length) {
+      console.log(chalk.yellow('Compiled with warnings.'));
+      console.log(stats.toString({ all: false, warnings: true }));
+    }
+
+    console.log(
+      stats.toString({ colors: true, modules: false, version: false })
+    );
+    console.log();
+
+    callback(stats);
+  });
+}
+
+function runBuildSteps() {
+  build(iframeWebpackConfig, 'iframeScript.js', () => {
+    build(webpackConfig, 'index.js', () => {
+      console.log(chalk.bold.green('Compiled successfully!'));
+    });
+  });
+}
+
+// Clean up lib folder
+rimraf('lib/', () => {
+  console.log('Cleaned up the lib folder.');
+  console.log();
+  runBuildSteps();
+});

--- a/packages/react-error-overlay/build.js
+++ b/packages/react-error-overlay/build.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
 const webpack = require('webpack');
 const chalk = require('chalk');
 const webpackConfig = require('./webpack.config.js');

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublishOnly": "npm run build:prod && npm test",
-    "start": "cross-env NODE_ENV=development node build.js",
+    "start": "cross-env NODE_ENV=development node build.js --watch",
     "test": "flow && cross-env NODE_ENV=test jest",
     "build": "cross-env NODE_ENV=development node build.js",
     "build:prod": "cross-env NODE_ENV=production node build.js"
@@ -46,6 +46,7 @@
     "babel-eslint": "7.2.3",
     "babel-preset-react-app": "^3.0.3",
     "chalk": "^2.1.0",
+    "chokidar": "^1.7.0",
     "cross-env": "5.0.5",
     "eslint": "4.4.1",
     "eslint-config-react-app": "^2.0.1",

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -36,6 +36,8 @@
     "babel-loader": "^7.1.2",
     "babel-runtime": "6.26.0",
     "html-entities": "1.2.1",
+    "object-assign": "^4.1.1",
+    "promise": "^8.0.1",
     "react": "^15 || ^16",
     "react-dom": "^15 || ^16",
     "settle-promise": "1.0.0",

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -5,10 +5,10 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublishOnly": "npm run build:prod && npm test",
-    "start": "rimraf lib/ && cross-env NODE_ENV=development npm run build -- --watch",
-    "test": "flow && jest",
-    "build": "rimraf lib/ && babel src/ -d lib/",
-    "build:prod": "rimraf lib/ && cross-env NODE_ENV=production babel src/ -d lib/"
+    "start": "rimraf lib/ && cross-env NODE_ENV=development webpack --config webpack.config.js -w & NODE_ENV=development babel src/ -d lib/ -w",
+    "test": "flow && cross-env NODE_ENV=test jest",
+    "build": "rimraf lib/ && cross-env NODE_ENV=development babel src/ -d lib/ && cross-env NODE_ENV=production webpack --config webpack.config.js",
+    "build:prod": "rimraf lib/ && cross-env NODE_ENV=production babel src/ -d lib/ && cross-env NODE_ENV=production webpack --config webpack.config.js"
   },
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",
@@ -33,12 +33,14 @@
   "dependencies": {
     "anser": "1.4.1",
     "babel-code-frame": "6.22.0",
+    "babel-loader": "^7.1.2",
     "babel-runtime": "6.26.0",
     "html-entities": "1.2.1",
     "react": "^15 || ^16",
     "react-dom": "^15 || ^16",
     "settle-promise": "1.0.0",
-    "source-map": "0.5.6"
+    "source-map": "0.5.6",
+    "webpack": "^3.6.0"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",
@@ -54,6 +56,7 @@
     "flow-bin": "^0.54.0",
     "jest": "20.0.4",
     "jest-fetch-mock": "1.2.1",
+    "raw-loader": "^0.5.1",
     "rimraf": "^2.6.1"
   },
   "jest": {

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "anser": "1.4.1",
     "babel-code-frame": "6.22.0",
-    "babel-loader": "^7.1.2",
     "babel-runtime": "6.26.0",
     "html-entities": "1.2.1",
     "object-assign": "^4.1.1",
@@ -47,6 +46,7 @@
   "devDependencies": {
     "babel-eslint": "7.2.3",
     "babel-preset-react-app": "^3.0.3",
+    "babel-loader": "^7.1.2",
     "chalk": "^2.1.0",
     "chokidar": "^1.7.0",
     "cross-env": "5.0.5",

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -35,13 +35,12 @@
     "babel-code-frame": "6.22.0",
     "babel-runtime": "6.26.0",
     "html-entities": "1.2.1",
-    "object-assign": "^4.1.1",
-    "promise": "^8.0.1",
+    "object-assign": "4.1.1",
+    "promise": "8.0.1",
     "react": "^15 || ^16",
     "react-dom": "^15 || ^16",
     "settle-promise": "1.0.0",
-    "source-map": "0.5.6",
-    "webpack": "^3.6.0"
+    "source-map": "0.5.6"
   },
   "devDependencies": {
     "babel-eslint": "7.2.3",
@@ -60,7 +59,8 @@
     "jest": "20.0.4",
     "jest-fetch-mock": "1.2.1",
     "raw-loader": "^0.5.1",
-    "rimraf": "^2.6.1"
+    "rimraf": "^2.6.1",
+    "webpack": "^3.6.0"
   },
   "jest": {
     "setupFiles": [

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -5,10 +5,10 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublishOnly": "npm run build:prod && npm test",
-    "start": "rimraf lib/ && cross-env NODE_ENV=development webpack --config webpack.config.js -w & NODE_ENV=development babel src/ -d lib/ -w",
+    "start": "cross-env NODE_ENV=development node build.js",
     "test": "flow && cross-env NODE_ENV=test jest",
-    "build": "rimraf lib/ && cross-env NODE_ENV=development babel src/ -d lib/ && cross-env NODE_ENV=production webpack --config webpack.config.js",
-    "build:prod": "rimraf lib/ && cross-env NODE_ENV=production babel src/ -d lib/ && cross-env NODE_ENV=production webpack --config webpack.config.js"
+    "build": "cross-env NODE_ENV=development node build.js",
+    "build:prod": "cross-env NODE_ENV=production node build.js"
   },
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",
@@ -43,9 +43,9 @@
     "webpack": "^3.6.0"
   },
   "devDependencies": {
-    "babel-cli": "6.24.1",
     "babel-eslint": "7.2.3",
     "babel-preset-react-app": "^3.0.3",
+    "chalk": "^2.1.0",
     "cross-env": "5.0.5",
     "eslint": "4.4.1",
     "eslint-config-react-app": "^2.0.1",

--- a/packages/react-error-overlay/src/iframeScript.js
+++ b/packages/react-error-overlay/src/iframeScript.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+
 import './utils/pollyfills.js';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/packages/react-error-overlay/src/iframeScript.js
+++ b/packages/react-error-overlay/src/iframeScript.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import CompileErrorContainer from './containers/CompileErrorContainer';
+import RuntimeErrorContainer from './containers/RuntimeErrorContainer';
+import { overlayStyle } from './styles';
+import { applyStyles } from './utils/dom/css';
+
+let iframeRoot = null;
+
+function render({
+  currentBuildError,
+  currentRuntimeErrorRecords,
+  dismissRuntimeErrors,
+  launchEditorEndpoint,
+}) {
+  if (currentBuildError) {
+    return <CompileErrorContainer error={currentBuildError} />;
+  }
+  if (currentRuntimeErrorRecords.length > 0) {
+    return (
+      <RuntimeErrorContainer
+        errorRecords={currentRuntimeErrorRecords}
+        close={dismissRuntimeErrors}
+        launchEditorEndpoint={launchEditorEndpoint}
+      />
+    );
+  }
+  return null;
+}
+
+window.updateContent = function updateContent(errorOverlayProps) {
+  let renderedElement = render(errorOverlayProps);
+
+  if (renderedElement === null) {
+    ReactDOM.unmountComponentAtNode(iframeRoot);
+    return false;
+  }
+  // Update the overlay
+  ReactDOM.render(renderedElement, iframeRoot);
+  return true;
+};
+
+document.body.style.margin = '0';
+// Keep popup within body boundaries for iOS Safari
+document.body.style['max-width'] = '100vw';
+iframeRoot = document.createElement('div');
+applyStyles(iframeRoot, overlayStyle);
+document.body.appendChild(iframeRoot);
+window.parent.__REACT_ERROR_OVERLAY_GLOBAL_HOOK__.iframeReady();

--- a/packages/react-error-overlay/src/iframeScript.js
+++ b/packages/react-error-overlay/src/iframeScript.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+import './utils/pollyfills.js';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import CompileErrorContainer from './containers/CompileErrorContainer';

--- a/packages/react-error-overlay/src/iframeScript.js
+++ b/packages/react-error-overlay/src/iframeScript.js
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import './utils/pollyfills.js';

--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -12,6 +12,7 @@ import { applyStyles } from './utils/dom/css';
 
 // Importing iframe-bundle generated in the pre build step as
 // a text using webpack raw-loader. See webpack.config.js file.
+// $FlowFixMe
 import iframeScript from 'iframeScript';
 
 import type { ErrorRecord } from './listenToRuntimeErrors';

--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -12,7 +12,7 @@ import { applyStyles } from './utils/dom/css';
 
 /* eslint-disable import/no-webpack-loader-syntax */
 //$FlowFixMe
-import iframeScript from 'raw-loader!./bundle.js';
+import iframeScript from 'raw-loader!iframeScript';
 /* eslint-enable import/no-webpack-loader-syntax */
 
 import type { ErrorRecord } from './listenToRuntimeErrors';

--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -10,10 +10,9 @@ import { listenToRuntimeErrors } from './listenToRuntimeErrors';
 import { iframeStyle } from './styles';
 import { applyStyles } from './utils/dom/css';
 
-/* eslint-disable import/no-webpack-loader-syntax */
-//$FlowFixMe
-import iframeScript from 'raw-loader!iframeScript';
-/* eslint-enable import/no-webpack-loader-syntax */
+// Importing iframe-bundle generated in the pre build step as
+// a text using webpack raw-loader. See webpack.config.js file.
+import iframeScript from 'iframeScript';
 
 import type { ErrorRecord } from './listenToRuntimeErrors';
 

--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -6,14 +6,14 @@
  */
 
 /* @flow */
-import React from 'react';
-import type { Element } from 'react';
-import ReactDOM from 'react-dom';
-import CompileErrorContainer from './containers/CompileErrorContainer';
-import RuntimeErrorContainer from './containers/RuntimeErrorContainer';
 import { listenToRuntimeErrors } from './listenToRuntimeErrors';
-import { iframeStyle, overlayStyle } from './styles';
+import { iframeStyle } from './styles';
 import { applyStyles } from './utils/dom/css';
+
+/* eslint-disable import/no-webpack-loader-syntax */
+//$FlowFixMe
+import iframeScript from 'raw-loader!./bundle.js';
+/* eslint-enable import/no-webpack-loader-syntax */
 
 import type { ErrorRecord } from './listenToRuntimeErrors';
 
@@ -25,8 +25,8 @@ type RuntimeReportingOptions = {|
 
 let iframe: null | HTMLIFrameElement = null;
 let isLoadingIframe: boolean = false;
+var isIframeReady: boolean = false;
 
-let renderedElement: null | Element<any> = null;
 let currentBuildError: null | string = null;
 let currentRuntimeErrorRecords: Array<ErrorRecord> = [];
 let currentRuntimeErrorOptions: null | RuntimeReportingOptions = null;
@@ -88,15 +88,14 @@ export function stopReportingRuntimeErrors() {
 }
 
 function update() {
-  renderedElement = render();
   // Loading iframe can be either sync or async depending on the browser.
   if (isLoadingIframe) {
     // Iframe is loading.
     // First render will happen soon--don't need to do anything.
     return;
   }
-  if (iframe) {
-    // Iframe has already loaded.
+  if (isIframeReady) {
+    // Iframe is ready.
     // Just update it.
     updateIframeContent();
     return;
@@ -108,58 +107,46 @@ function update() {
   loadingIframe.onload = function() {
     const iframeDocument = loadingIframe.contentDocument;
     if (iframeDocument != null && iframeDocument.body != null) {
-      iframeDocument.body.style.margin = '0';
-      // Keep popup within body boundaries for iOS Safari
-      iframeDocument.body.style['max-width'] = '100vw';
-      const iframeRoot = iframeDocument.createElement('div');
-      applyStyles(iframeRoot, overlayStyle);
-      iframeDocument.body.appendChild(iframeRoot);
-
-      // Ready! Now we can update the UI.
       iframe = loadingIframe;
-      isLoadingIframe = false;
-      updateIframeContent();
+      const script = loadingIframe.contentWindow.document.createElement(
+        'script'
+      );
+      script.type = 'text/javascript';
+      script.innerHTML = iframeScript;
+      iframeDocument.body.appendChild(script);
     }
   };
   const appDocument = window.document;
   appDocument.body.appendChild(loadingIframe);
 }
 
-function render() {
-  if (currentBuildError) {
-    return <CompileErrorContainer error={currentBuildError} />;
-  }
-  if (currentRuntimeErrorRecords.length > 0) {
-    if (!currentRuntimeErrorOptions) {
-      throw new Error('Expected options to be injected.');
-    }
-    return (
-      <RuntimeErrorContainer
-        errorRecords={currentRuntimeErrorRecords}
-        close={dismissRuntimeErrors}
-        launchEditorEndpoint={currentRuntimeErrorOptions.launchEditorEndpoint}
-      />
-    );
-  }
-  return null;
-}
-
 function updateIframeContent() {
-  if (iframe === null) {
+  if (!currentRuntimeErrorOptions) {
+    throw new Error('Expected options to be injected.');
+  }
+
+  if (!iframe) {
     throw new Error('Iframe has not been created yet.');
   }
-  const iframeBody = iframe.contentDocument.body;
-  if (!iframeBody) {
-    throw new Error('Expected iframe to have a body.');
-  }
-  const iframeRoot = iframeBody.firstChild;
-  if (renderedElement === null) {
-    // Destroy iframe and force it to be recreated on next error
+
+  const isRendered = iframe.contentWindow.updateContent({
+    currentBuildError,
+    currentRuntimeErrorRecords,
+    dismissRuntimeErrors,
+    launchEditorEndpoint: currentRuntimeErrorOptions.launchEditorEndpoint,
+  });
+
+  if (!isRendered) {
     window.document.body.removeChild(iframe);
-    ReactDOM.unmountComponentAtNode(iframeRoot);
     iframe = null;
-    return;
+    isIframeReady = false;
   }
-  // Update the overlay
-  ReactDOM.render(renderedElement, iframeRoot);
 }
+
+window.__REACT_ERROR_OVERLAY_GLOBAL_HOOK__ =
+  window.__REACT_ERROR_OVERLAY_GLOBAL_HOOK__ || {};
+window.__REACT_ERROR_OVERLAY_GLOBAL_HOOK__.iframeReady = function iframeReady() {
+  isIframeReady = true;
+  isLoadingIframe = false;
+  updateIframeContent();
+};

--- a/packages/react-error-overlay/src/utils/pollyfills.js
+++ b/packages/react-error-overlay/src/utils/pollyfills.js
@@ -1,11 +1,10 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
+
 if (typeof Promise === 'undefined') {
   // Rejection tracking prevents a common issue where React gets into an
   // inconsistent state due to an error, but it gets swallowed by a Promise,

--- a/packages/react-error-overlay/src/utils/pollyfills.js
+++ b/packages/react-error-overlay/src/utils/pollyfills.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+if (typeof Promise === 'undefined') {
+  // Rejection tracking prevents a common issue where React gets into an
+  // inconsistent state due to an error, but it gets swallowed by a Promise,
+  // and the user has no idea what causes React's erratic future behavior.
+  require('promise/lib/rejection-tracking').enable();
+  window.Promise = require('promise/lib/es6-extensions.js');
+}
+
+// Object.assign() is commonly used with React.
+// It will use the native implementation if it's present and isn't buggy.
+Object.assign = require('object-assign');

--- a/packages/react-error-overlay/src/utils/pollyfills.js
+++ b/packages/react-error-overlay/src/utils/pollyfills.js
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-'use strict';
-
 if (typeof Promise === 'undefined') {
   // Rejection tracking prevents a common issue where React gets into an
   // inconsistent state due to an error, but it gets swallowed by a Promise,

--- a/packages/react-error-overlay/webpack.config.iframe.js
+++ b/packages/react-error-overlay/webpack.config.iframe.js
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 'use strict';
 

--- a/packages/react-error-overlay/webpack.config.iframe.js
+++ b/packages/react-error-overlay/webpack.config.iframe.js
@@ -22,14 +22,7 @@ module.exports = {
       {
         test: /\.js$/,
         include: path.resolve(__dirname, './src'),
-        use: [
-          {
-            loader: 'babel-loader',
-            options: {
-              cacheDirectory: true,
-            },
-          },
-        ],
+        use: 'babel-loader',
       },
     ],
   },

--- a/packages/react-error-overlay/webpack.config.iframe.js
+++ b/packages/react-error-overlay/webpack.config.iframe.js
@@ -1,5 +1,14 @@
-var path = require('path');
-var webpack = require('webpack');
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const path = require('path');
 
 module.exports = {
   devtool: 'cheap-module-source-map',

--- a/packages/react-error-overlay/webpack.config.iframe.js
+++ b/packages/react-error-overlay/webpack.config.iframe.js
@@ -3,12 +3,10 @@ var webpack = require('webpack');
 
 module.exports = {
   devtool: 'cheap-module-source-map',
-  entry: './src/index.js',
+  entry: './src/iframeScript.js',
   output: {
     path: path.join(__dirname, './lib'),
-    filename: 'index.js',
-    library: 'ReactErrorOverlay',
-    libraryTarget: 'umd',
+    filename: 'iframe-bundle.js',
   },
   module: {
     rules: [
@@ -25,10 +23,5 @@ module.exports = {
         ],
       },
     ],
-  },
-  resolve: {
-    alias: {
-      iframeScript$: path.resolve(__dirname, './lib/iframe-bundle.js'),
-    },
   },
 };

--- a/packages/react-error-overlay/webpack.config.js
+++ b/packages/react-error-overlay/webpack.config.js
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 'use strict';
 

--- a/packages/react-error-overlay/webpack.config.js
+++ b/packages/react-error-overlay/webpack.config.js
@@ -1,0 +1,27 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  devtool: 'cheap-module-source-map',
+  entry: './src/iframeScript.js',
+  output: {
+    path: path.join(__dirname, './lib'),
+    filename: 'bundle.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        include: path.resolve(__dirname, './src'),
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              cacheDirectory: true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/packages/react-error-overlay/webpack.config.js
+++ b/packages/react-error-overlay/webpack.config.js
@@ -1,5 +1,14 @@
-var path = require('path');
-var webpack = require('webpack');
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const path = require('path');
 
 module.exports = {
   devtool: 'cheap-module-source-map',

--- a/packages/react-error-overlay/webpack.config.js
+++ b/packages/react-error-overlay/webpack.config.js
@@ -28,14 +28,7 @@ module.exports = {
       {
         test: /\.js$/,
         include: path.resolve(__dirname, './src'),
-        use: [
-          {
-            loader: 'babel-loader',
-            options: {
-              cacheDirectory: true,
-            },
-          },
-        ],
+        use: 'babel-loader',
       },
     ],
   },

--- a/packages/react-error-overlay/webpack.config.js
+++ b/packages/react-error-overlay/webpack.config.js
@@ -13,6 +13,10 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /iframe-bundle\.js$/,
+        use: 'raw-loader',
+      },
+      {
         test: /\.js$/,
         include: path.resolve(__dirname, './src'),
         use: [


### PR DESCRIPTION
This attempts to implement the idea proposed in #3120.

In this implementation, the script(`iframeScript.js`) that needs to be executed in the context of the iframe is bundled in a separate webpack build step. Then this script is imported as a text using webpack raw-loader in the main overlay script(`index.js`) and inject to the iframe with a script tag. After the injected script is executed, it starts to communicate with the main script via some global hooks and continue to update overlay until there are no errors to show. 

Based on #2961, #1944, [using inline webpack raw-loader](https://github.com/facebookincubator/create-react-app/pull/3142/files#diff-66b69a1c0b15ace46390921b87d6621dR17) might not be a good idea. Any suggestions on that?