### PR TITLE
Support reason-react

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-flowtype": "2.35.0",
     "eslint-plugin-import": "2.7.0",
     "eslint-plugin-jsx-a11y": "5.1.1",
-    "eslint-plugin-react": "7.3.0",
+    "eslint-plugin-react": "7.4.0",
     "extract-text-webpack-plugin": "3.0.0",
     "file-loader": "0.11.2",
     "fs-extra": "3.0.1",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-flowtype": "2.35.0",
     "eslint-plugin-import": "2.7.0",
     "eslint-plugin-jsx-a11y": "5.1.1",
-    "eslint-plugin-react": "7.1.0",
+    "eslint-plugin-react": "7.3.0",
     "extract-text-webpack-plugin": "3.0.0",
     "file-loader": "0.11.2",
     "fs-extra": "3.0.1",


### PR DESCRIPTION
After trying out to interop reasonml bindings for react, [reason-react](https://github.com/reasonml/reason-react) @chenglou found out that eslint was causing this practicular [problem](https://github.com/yannickcr/eslint-plugin-react/issues/921).

It is fixed in the newer version of eslint-plugin-react@7.3.0, this will allow to interop components in reason and plain js.

I have this [repo](https://github.com/lpalmes/reason-react-test) that displays the error found out when running it (in one session `yarn start`,  in another `yarn bsb-watch`), and a [branch](https://github.com/lpalmes/reason-react-test/tree/eject) fixing the problem by upgrading the dependency.

I'm sure this will be helpful for a lot of people looking to chime into the future of react.

Thanks!