### PR TITLE
Change template manifest start_url to dot to make it react-router fri…

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1784,6 +1784,12 @@ service worker navigation routing can be configured or disabled by
 and [`navigateFallbackWhitelist`](https://github.com/GoogleChrome/sw-precache#navigatefallbackwhitelist-arrayregexp)
 options of the `SWPreachePlugin` [configuration](../config/webpack.config.prod.js).
 
+When users install your app to the homescreen of their device the default configuration will make a shortcut to `/index.html`. This may not work for client-side routers which expect the app to be served from `/`. Edit the web app manifest at [`public/manifest.json`](public/manifest.json) and change `start_url` to match the required URL scheme, for example:
+
+```js
+  "start_url": ".",
+```
+
 ### Building for Relative Paths
 
 By default, Create React App produces a build assuming your app is hosted at the server root.<br>

--- a/packages/react-scripts/template/public/manifest.json
+++ b/packages/react-scripts/template/public/manifest.json
@@ -8,7 +8,7 @@
       "type": "image/png"
     }
   ],
-  "start_url": "./index.html",
+  "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"

--- a/packages/react-scripts/template/public/manifest.json
+++ b/packages/react-scripts/template/public/manifest.json
@@ -8,7 +8,7 @@
       "type": "image/png"
     }
   ],
-  "start_url": ".",
+  "start_url": "./index.html",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"


### PR DESCRIPTION
The current template has public/manifest.json start_url set to "./index.html". This causes a problem with folks using client side routing since the home screen shortcut points to "https://myapp/index.html" and index.html does not match anything. I'd suggest we change start_url to "." for consistency with the dev server etc. This makes the shortcut point to "https://myapp" instead which is the "standard" form most people use to access these apps. I hope this helps.