### PR TITLE
Update webpack-dev-server to 2.8.2

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -53,7 +53,7 @@
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.5.9",
     "webpack": "3.5.1",
-    "webpack-dev-server": "2.7.1",
+    "webpack-dev-server": "2.8.2",
     "webpack-manifest-plugin": "1.2.1",
     "whatwg-fetch": "2.0.3"
   },


### PR DESCRIPTION
It doesn't look like there is any backwards incompatibility:

https://github.com/webpack/webpack-dev-server/releases