### PR TITLE
Remove output.path from dev webpack config

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -63,8 +63,6 @@ module.exports = {
     // changing JS code would still trigger a refresh.
   ],
   output: {
-    // Next line is not used in dev but WebpackDevServer crashes without it:
-    path: paths.appBuild,
     // Add /* filename */ comments to generated require()s in the output.
     pathinfo: true,
     // This does not produce a real file. It's just the virtual path that is


### PR DESCRIPTION
According to this parameter's comment, it's unused but webpack-dev-server crashes without it. However, webpack-dev-server is running fine for me without this parameter.