### PR TITLE
change absolute path to relative so their compatible with yarn worksp…

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -285,9 +285,8 @@ function run(
       checkNodeVersion(packageName);
       setCaretRangeForRuntimeDeps(packageName);
 
-      const scriptsPath = path.resolve(
-        process.cwd(),
-        'node_modules',
+      const scriptsPath = path.join(
+        '..',
         packageName,
         'scripts',
         'init.js'
@@ -469,9 +468,8 @@ function checkNpmVersion() {
 }
 
 function checkNodeVersion(packageName) {
-  const packageJsonPath = path.resolve(
-    process.cwd(),
-    'node_modules',
+  const packageJsonPath = path.join(
+    '..',
     packageName,
     'package.json'
   );


### PR DESCRIPTION
The previous absolute path was not compatible with yarn workspaces. 
I have tested this on windows.
So now it works inside yarn workspaces. I also tested it standalone.

from:
https://github.com/facebookincubator/create-react-app/issues/3031

![image](https://user-images.githubusercontent.com/6407476/30755504-3e07a614-9fc7-11e7-9920-f66d3633c51b.png)
![image](https://user-images.githubusercontent.com/6407476/30755594-a0b2c564-9fc7-11e7-8f34-2a74769c936e.png)
