### PR TITLE
Support specific env configs.

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -24,8 +24,12 @@ if (!NODE_ENV) {
   );
 }
 
+const DOTENV = process.env.DOTENV;
+
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 var dotenvFiles = [
+  DOTENV && `${paths.dotenv}.${DOTENV}.local`,
+  DOTENV && `${paths.dotenv}.${DOTENV}`,
   `${paths.dotenv}.${NODE_ENV}.local`,
   `${paths.dotenv}.${NODE_ENV}`,
   // Don't include `.env.local` for `test` environment


### PR DESCRIPTION
I found many people like me need to build and deploy to not only production server but also staging server. Since create-react-app is hard coded `NODE_ENV` to `production` during build time, I thought we can add another env variable to achieve this goal.

Here's the code examples:

In `.env.staging`
```
REACT_APP_SECRET=xxxx
```

In `.env.production`
```
REACT_APP_SECRET=yyyy
```

We can use `DOTENV=staging npm run build` to build our static files using `.env.staging`.

We also can add `"build:staging": "DOTENV=staging npm run build"` into `scripts` in our `package.json` and just run `npm run build:staging` to do the same thing. This way we can still get an optimized production build but for different deploy targets.

Reference to #2880 #790