### PR TITLE
Correct manual proxy documentation

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1049,7 +1049,7 @@ You may also specify any configuration value [`http-proxy-middleware`](https://g
 All requests matching this path will be proxies, no exceptions. This includes requests for `text/html`, which the standard `proxy` option does not proxy.
 
 If you need to specify multiple proxies, you may do so by specifying additional entries.
-You may also narrow down matches using `*` and/or `**`, to match the path exactly or any subpath.
+Matches are regular expressions, so that you can use a regexp to match multiple paths.
 ```js
 {
   // ...
@@ -1070,12 +1070,12 @@ You may also narrow down matches using `*` and/or `**`, to match the path exactl
       // ...
     },
     // Matches /bar/abc.html but not /bar/sub/def.html
-    "/bar/*.html": {
+    "/bar/[^/]*[.]html": {
       "target": "<url_3>",
       // ...
     },
     // Matches /baz/abc.html and /baz/sub/def.html
-    "/baz/**/*.html": {
+    "/baz/.*/.*[.]html": {
       "target": "<url_4>"
       // ...
     }


### PR DESCRIPTION
Fixes #3184. 
My observation was that the configuration uses regexps for the proxy paths instead of globs.