### PR TITLE
Allow the dev server to watch for changes in src/node_modules

### DIFF
--- a/packages/react-dev-utils/getProcessForPort.js
+++ b/packages/react-dev-utils/getProcessForPort.js
@@ -46,7 +46,7 @@ function getProcessCommand(processId, processDirectory) {
     execOptions
   );
 
-  command = command.replace(/\n$/, '')
+  command = command.replace(/\n$/, '');
 
   if (isProcessAReactApp(command)) {
     const packageName = getPackageNameInDirectory(processDirectory);
@@ -68,8 +68,12 @@ function getProcessForPort(port) {
     var processId = getProcessIdOnPort(port);
     var directory = getDirectoryOfProcessById(processId);
     var command = getProcessCommand(processId, directory);
-    return chalk.cyan(command) + chalk.grey(' (pid ' + processId + ')\n') + 
-      chalk.blue('  in ') + chalk.cyan(directory);
+    return (
+      chalk.cyan(command) +
+      chalk.grey(' (pid ' + processId + ')\n') +
+      chalk.blue('  in ') +
+      chalk.cyan(directory)
+    );
   } catch (e) {
     return null;
   }

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -75,7 +75,7 @@ module.exports = function(proxy, allowedHost) {
     // src/node_modules is not ignored to support absolute imports
     // https://github.com/facebookincubator/create-react-app/issues/1065
     watchOptions: {
-      ignored: new RegExp(`^(?!${paths.appSrc})*[\\\/]node_modules[\\\/]`, 'g'),
+      ignored: new RegExp(`^(?!${paths.appSrc})*[\\/]node_modules[\\/]`, 'g'),
     },
     // Enable HTTPS if the HTTPS environment variable is set to 'true'
     https: protocol === 'https',

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -75,7 +75,7 @@ module.exports = function(proxy, allowedHost) {
     // src/node_modules is not ignored to support absolute imports
     // https://github.com/facebookincubator/create-react-app/issues/1065
     watchOptions: {
-      ignored: new RegExp(`^(?!${paths.appSrc})*[\\/]node_modules[\\/]`, 'g'),
+      ignored: new RegExp(`^(?!${paths.appSrc}).+[\\/]node_modules[\\/]`, 'g'),
     },
     // Enable HTTPS if the HTTPS environment variable is set to 'true'
     https: protocol === 'https',

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -72,8 +72,10 @@ module.exports = function(proxy, allowedHost) {
     quiet: true,
     // Reportedly, this avoids CPU overload on some systems.
     // https://github.com/facebookincubator/create-react-app/issues/293
+    // src/node_modules is not ignored to support absolute imports
+    // https://github.com/facebookincubator/create-react-app/issues/1065
     watchOptions: {
-      ignored: /node_modules/,
+      ignored: new RegExp(`^(?!${paths.appSrc})*[\\\/]node_modules[\\\/]`, 'g'),
     },
     // Enable HTTPS if the HTTPS environment variable is set to 'true'
     https: protocol === 'https',

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -10,6 +10,7 @@
 
 const errorOverlayMiddleware = require('react-dev-utils/errorOverlayMiddleware');
 const noopServiceWorkerMiddleware = require('react-dev-utils/noopServiceWorkerMiddleware');
+const path = require('path');
 const config = require('./webpack.config.dev');
 const paths = require('./paths');
 
@@ -75,7 +76,10 @@ module.exports = function(proxy, allowedHost) {
     // src/node_modules is not ignored to support absolute imports
     // https://github.com/facebookincubator/create-react-app/issues/1065
     watchOptions: {
-      ignored: new RegExp(`^(?!${paths.appSrc}).+[\\/]node_modules[\\/]`, 'g'),
+      ignored: new RegExp(
+        `^(?!${path.normalize(paths.appSrc + '/')}).+[\\/]node_modules[\\/]`,
+        'g'
+      ),
     },
     // Enable HTTPS if the HTTPS environment variable is set to 'true'
     https: protocol === 'https',


### PR DESCRIPTION
Building off #2760, this will allow dev server to watch for changes in the `src/node_modules` directory.

Fix #3223
