### PR TITLE
Update style-loader and disable inclusion of its HMR code in builds

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -197,7 +197,12 @@ module.exports = {
             loader: ExtractTextPlugin.extract(
               Object.assign(
                 {
-                  fallback: require.resolve('style-loader'),
+                  fallback: {
+                    loader: require.resolve('style-loader'),
+                    options: {
+                      hmr: false,
+                    },
+                  },
                   use: [
                     {
                       loader: require.resolve('css-loader'),

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -49,7 +49,7 @@
     "postcss-loader": "2.0.6",
     "promise": "8.0.1",
     "react-dev-utils": "^4.1.0",
-    "style-loader": "0.18.2",
+    "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.5.9",
     "webpack": "3.5.1",


### PR DESCRIPTION
[`style-loader` v0.19.0](https://github.com/webpack-contrib/style-loader/blob/master/CHANGELOG.md#0190-2017-10-03) adds an [`hmr` option](https://github.com/webpack-contrib/style-loader#hmr) which can be used to disable inclusion of its HMR code block in production builds.