### PR TITLE
`react-error-overlay` has no dependencies now (it's bundled)

### DIFF
--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "anser": "1.4.1",
     "babel-code-frame": "6.22.0",
-    "babel-core": "^7.0.0-beta.2",
+    "babel-core": "^6.26.0",
     "babel-eslint": "7.2.3",
     "babel-loader": "^7.1.2",
     "babel-preset-react-app": "^3.0.3",

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -30,22 +30,14 @@
     "lib/",
     "middleware.js"
   ],
-  "dependencies": {
+  "devDependencies": {
     "anser": "1.4.1",
     "babel-code-frame": "6.22.0",
-    "babel-runtime": "6.26.0",
-    "html-entities": "1.2.1",
-    "object-assign": "4.1.1",
-    "promise": "8.0.1",
-    "react": "^15 || ^16",
-    "react-dom": "^15 || ^16",
-    "settle-promise": "1.0.0",
-    "source-map": "0.5.6"
-  },
-  "devDependencies": {
+    "babel-core": "^7.0.0-beta.2",
     "babel-eslint": "7.2.3",
-    "babel-preset-react-app": "^3.0.3",
     "babel-loader": "^7.1.2",
+    "babel-preset-react-app": "^3.0.3",
+    "babel-runtime": "6.26.0",
     "chalk": "^2.1.0",
     "chokidar": "^1.7.0",
     "cross-env": "5.0.5",
@@ -56,10 +48,17 @@
     "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-react": "7.1.0",
     "flow-bin": "^0.54.0",
+    "html-entities": "1.2.1",
     "jest": "20.0.4",
     "jest-fetch-mock": "1.2.1",
+    "object-assign": "4.1.1",
+    "promise": "8.0.1",
     "raw-loader": "^0.5.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "rimraf": "^2.6.1",
+    "settle-promise": "1.0.0",
+    "source-map": "0.5.6",
     "webpack": "^3.6.0"
   },
   "jest": {


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
