### PR TITLE
Add warning when using `react-error-overlay` in production

### DIFF
--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -167,3 +167,15 @@ window.__REACT_ERROR_OVERLAY_GLOBAL_HOOK__.iframeReady = function iframeReady() 
   isLoadingIframe = false;
   updateIframeContent();
 };
+
+var testFunc = function testFn() {};
+if ((testFunc.name || testFunc.toString()).indexOf('testFn') !== -1) {
+  console.warn(
+    'It looks like you are using `react-error-overlay` in production. When ' +
+      'deploying an application, `react-error-overlay` should be excluded ' +
+      'as it is a heavy dependency meant for development.\n\n' +
+      'Consider adding an error boundary to your tree to customize error ' +
+      'handling behavior. See https://fb.me/react-error-boundaries for more ' +
+      'information.'
+  );
+}

--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -168,23 +168,9 @@ window.__REACT_ERROR_OVERLAY_GLOBAL_HOOK__.iframeReady = function iframeReady() 
   updateIframeContent();
 };
 
-const warningText =
-  'When deploying an application, `react-error-overlay` should be excluded ' +
-  'as it is a heavy dependency meant for development.\n\n' +
-  'Consider adding an error boundary to your tree to customize error ' +
-  'handling behavior. See https://fb.me/react-error-boundaries for more ' +
-  'information.';
-
-if (process.env.NODE_ENV !== 'production') {
-  var testFunc = function testFn() {};
-  if ((testFunc.name || testFunc.toString()).indexOf('testFn') === -1) {
-    console.warn(
-      'It looks like you are using `react-error-overlay` in production. ' +
-        warningText
-    );
-  }
-} else {
+if (process.env.NODE_ENV === 'production') {
   console.warn(
-    'You are using `react-error-overlay` in production. ' + warningText
+    'react-error-overlay is not meant for use in production. You should ' +
+      'ensure it is not included in your build to reduce bundle size.'
   );
 }

--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -168,14 +168,23 @@ window.__REACT_ERROR_OVERLAY_GLOBAL_HOOK__.iframeReady = function iframeReady() 
   updateIframeContent();
 };
 
-var testFunc = function testFn() {};
-if ((testFunc.name || testFunc.toString()).indexOf('testFn') !== -1) {
+const warningText =
+  'When deploying an application, `react-error-overlay` should be excluded ' +
+  'as it is a heavy dependency meant for development.\n\n' +
+  'Consider adding an error boundary to your tree to customize error ' +
+  'handling behavior. See https://fb.me/react-error-boundaries for more ' +
+  'information.';
+
+if (process.env.NODE_ENV !== 'production') {
+  var testFunc = function testFn() {};
+  if ((testFunc.name || testFunc.toString()).indexOf('testFn') === -1) {
+    console.warn(
+      'It looks like you are using `react-error-overlay` in production. ' +
+        warningText
+    );
+  }
+} else {
   console.warn(
-    'It looks like you are using `react-error-overlay` in production. When ' +
-      'deploying an application, `react-error-overlay` should be excluded ' +
-      'as it is a heavy dependency meant for development.\n\n' +
-      'Consider adding an error boundary to your tree to customize error ' +
-      'handling behavior. See https://fb.me/react-error-boundaries for more ' +
-      'information.'
+    'You are using `react-error-overlay` in production. ' + warningText
   );
 }


### PR DESCRIPTION
This logs a warning when the overlay is included in an envified production build or strictly minified build.