### PR TITLE
Make uglify work in Safari 10.0 - fixes #3280

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -299,6 +299,9 @@ module.exports = {
         // https://github.com/mishoo/UglifyJS2/issues/2011
         comparisons: false,
       },
+      mangle: {
+        safari10: true,
+      },        
       output: {
         comments: false,
         // Turned on because emoji and regex is not minified properly using default


### PR DESCRIPTION
Implement settings as suggested here:
https://github.com/mishoo/UglifyJS2/tree/harmony#mangle-options

To solve this Safari bug:
https://bugs.webkit.org/show_bug.cgi?id=171041

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
