### PR TITLE
Support --coverage for `npm start` and `npm run build` (#3257)

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -68,6 +68,21 @@ if (env === 'development' || env === 'test') {
   ]);
 }
 
+var thisEnv = process.env.BABEL_PRESET_REACT_APP_ENV;
+if (thisEnv !== undefined) {
+  if (thisEnv === 'coverage') {
+    plugins.push.call(plugins, require.resolve('babel-plugin-istanbul'));
+  } else {
+    throw new Error(
+      'Using `babel-preset-react-app` requires that if you specify ' +
+        '`BABEL_PRESET_REACT_APP_ENV` it must be "coverage". No ' +
+        'other values are allowed. Received: ' +
+        JSON.stringify(thisEnv) +
+        '.'
+    );
+  }
+}
+
 if (env === 'test') {
   module.exports = {
     presets: [

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -12,6 +12,7 @@
   ],
   "dependencies": {
     "babel-plugin-dynamic-import-node": "1.0.2",
+    "babel-plugin-istanbul": "4.1.5",
     "babel-plugin-syntax-dynamic-import": "6.18.0",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-object-rest-spread": "6.23.0",

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -21,6 +21,7 @@ process.on('unhandledRejection', err => {
 
 // Ensure environment variables are read.
 require('../config/env');
+require('./utils/setBabelPresetReactAppEnv')();
 
 const path = require('path');
 const chalk = require('chalk');

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -21,6 +21,7 @@ process.on('unhandledRejection', err => {
 
 // Ensure environment variables are read.
 require('../config/env');
+require('./utils/setBabelPresetReactAppEnv')();
 
 const fs = require('fs');
 const chalk = require('chalk');

--- a/packages/react-scripts/scripts/utils/setBabelPresetReactAppEnv.js
+++ b/packages/react-scripts/scripts/utils/setBabelPresetReactAppEnv.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = () => {
+  const argv = process.argv.slice(2);
+  if (argv.indexOf('--coverage') >= 0) {
+    process.env.BABEL_PRESET_REACT_APP_ENV = 'coverage';
+  }
+};


### PR DESCRIPTION
UNVERIFIED PROOF OF CONCEPT PATCH

Passing --coverage makes babel-preset-react-app add
babel-plugin-istanbul to support code coverage reports for end-to-end
tests.

I got no feedback in the ticket I filed if this feature was interesting to create-react-app maintainers so I'm providing a sketch of how the code could look in hope of getting some feedback.