### PR TITLE
Respect process.env.GENERATE_SOURCEMAP in dev mode too

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -23,6 +23,8 @@ const paths = require('./paths');
 // Webpack uses `publicPath` to determine where the app is being served from.
 // In development, we always serve from the root. This makes config easier.
 const publicPath = '/';
+// Source maps might not be desired in dev mode by some people for various reasons.
+const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 // `publicUrl` is just like `publicPath`, but we will provide it to our app
 // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
 // Omit trailing slash as %PUBLIC_PATH%/xyz looks better than %PUBLIC_PATH%xyz.
@@ -36,7 +38,7 @@ const env = getClientEnvironment(publicUrl);
 module.exports = {
   // You may want 'eval' instead if you prefer to see the compiled output in DevTools.
   // See the discussion in https://github.com/facebookincubator/create-react-app/issues/343.
-  devtool: 'cheap-module-source-map',
+  devtool: shouldUseSourceMap ? 'cheap-module-source-map' : false,
   // These are the "entry points" to our application.
   // This means they will be the "root" imports that are included in JS bundle.
   // The first two entry points enable "hot" CSS and auto-refreshes for JS.


### PR DESCRIPTION
Personally I hate source maps - because I use dev tools heavily and they just bring too much of a disconnect between what's in them and what actual code gets shipped to the browser. I often evaluate expressions in the console and I just easily look up REAL identifiers, cause all I see are mapped identifiers. This provides a terrible debugging experience for me and I always chose not to use source maps.

You already respect (for other reasons) this env variable in production config and I literally dont see any con against respecting it in dev mode too.

**How did I verify my change?**
I've ejected in the project created with latest create-react-app, done the same changes locally and verified that it works.
