### PR TITLE
adds documentation for specific config  in react-scripts

### DIFF
--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -3,5 +3,39 @@
 This package includes scripts and configuration used by [Create React App](https://github.com/facebookincubator/create-react-app).<br>
 Please refer to its documentation:
 
+
+The following are also configurable:
+
+collectCoverageFrom
+coverageReporters
+coverageThreshold
+snapshotSerializers
+
+Add any of the above to a Jest config in package.json
+
+for instnace:
+
+``json
+ {
+   "name": "your-package",
+   "jest": {
+     "collectCoverageFrom" : [
+       "src/**/*.{js,jsx}",
+       "!<rootDir>/node_modules/",
+       "!<rootDir>/path/to/dir/"
+     ],
+     "coverageThreshold": {
+       "global": {
+         "branches": 90,
+         "functions": 90,
+         "lines": 90,
+        "statements": 90
+       }
+     },
+     "coverageReporters": ["text"],
+    "snapshotSerializers": ["my-serializer-module"]
+   }
+ }
+
 * [Getting Started](https://github.com/facebookincubator/create-react-app/blob/master/README.md#getting-started) – How to create a new app.
 * [User Guide](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md) – How to develop apps bootstrapped with Create React App.


### PR DESCRIPTION
adds documentation for Exclude Storybook Stories from code coverage #3278
makes clear how to alter collectiveCoverage and make snapshot and jest options overridable


<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
