### PR TITLE
Stop using `npm link` in tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ image: Visual Studio 2017
 
 environment:
   matrix:
-    - nodejs_version: 7
+    - nodejs_version: 8
       test_suite: "simple"
-    - nodejs_version: 7
+    - nodejs_version: 8
       test_suite: "installs"
-    - nodejs_version: 7
+    - nodejs_version: 8
       test_suite: "kitchensink"
     - nodejs_version: 6
       test_suite: "simple"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
   # TODO: Remove after https://github.com/appveyor/ci/issues/1426 is fixed
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - choco uninstall yarn
+  - choco uninstall yarn --force
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ install:
   # TODO: Remove after https://github.com/appveyor/ci/issues/1426 is fixed
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version $env:platform
+  - choco install -y rsync
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,6 @@ install:
   # TODO: Remove after https://github.com/appveyor/ci/issues/1426 is fixed
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - choco install -y rsync
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
   # TODO: Remove after https://github.com/appveyor/ci/issues/1426 is fixed
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - choco install -y rsync
+  - choco install -y cygwin
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ install:
   # TODO: Remove after https://github.com/appveyor/ci/issues/1426 is fixed
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version $env:platform
+  - choco uninstall yarn
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
   # TODO: Remove after https://github.com/appveyor/ci/issues/1426 is fixed
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - choco install -y cygwin
+  - choco install -y rsync
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,6 @@ install:
   # TODO: Remove after https://github.com/appveyor/ci/issues/1426 is fixed
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - choco uninstall yarn --force
 
 build: off
 

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -230,21 +230,8 @@ inquirer
     }
 
     if (fs.existsSync(paths.yarnLockFile)) {
-      // TODO: this is disabled for three reasons.
-      //
-      // 1. It produces garbage warnings on Windows on some systems:
-      //    https://github.com/facebookincubator/create-react-app/issues/2030
-      //
-      // 2. For the above reason, it breaks Windows CI:
-      //    https://github.com/facebookincubator/create-react-app/issues/2624
-      //
-      // 3. It is wrong anyway: re-running yarn will respect the lockfile
-      //    rather than package.json we just updated. Instead we should have
-      //    updated the lockfile. So we might as well not do it while it's broken.
-      //    https://github.com/facebookincubator/create-react-app/issues/2627
-      //
-      // console.log(cyan('Running yarn...'));
-      // spawnSync('yarnpkg', [], { stdio: 'inherit' });
+      console.log(cyan('Running yarn...'));
+      spawnSync('yarnpkg', [], { stdio: 'inherit' });
     } else {
       console.log(cyan('Running npm install...'));
       spawnSync('npm', ['install', '--loglevel', 'error'], {

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -230,8 +230,21 @@ inquirer
     }
 
     if (fs.existsSync(paths.yarnLockFile)) {
-      console.log(cyan('Running yarn...'));
-      spawnSync('yarnpkg', [], { stdio: 'inherit' });
+      // TODO: this is disabled for three reasons.
+      //
+      // 1. It produces garbage warnings on Windows on some systems:
+      //    https://github.com/facebookincubator/create-react-app/issues/2030
+      //
+      // 2. For the above reason, it breaks Windows CI:
+      //    https://github.com/facebookincubator/create-react-app/issues/2624
+      //
+      // 3. It is wrong anyway: re-running yarn will respect the lockfile
+      //    rather than package.json we just updated. Instead we should have
+      //    updated the lockfile. So we might as well not do it while it's broken.
+      //    https://github.com/facebookincubator/create-react-app/issues/2627
+      //
+      // console.log(cyan('Running yarn...'));
+      // spawnSync('yarnpkg', [], { stdio: 'inherit' });
     } else {
       console.log(cyan('Running npm install...'));
       spawnSync('npm', ['install', '--loglevel', 'error'], {

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -50,8 +50,7 @@ function install_package {
   rm -rf node_modules/**/$(basename $1)/
 
   # Copy package into node_modules/
-  copyfrom=${1%/}
-  rsync -a ${copyfrom/\/c\//c:\/} node_modules/ --exclude node_modules
+  rsync -a ${1%/} node_modules/ --exclude node_modules
 
   # Install `dependencies`
   cd node_modules/$(basename $1)/

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -44,6 +44,22 @@ function create_react_app {
   node "$temp_cli_path"/node_modules/create-react-app/index.js "$@"
 }
 
+function install_package {
+  rsync -a ${1%/} node_modules/ --exclude node_modules
+
+  $restore_location = $(pwd)
+
+  cd node_modules/$(basename $1)/
+  if [ "$USE_YARN" = "yes" ]
+  then
+    yarn install --production
+  else
+    npm install --only=production
+  fi
+
+  cd $restore_location
+}
+
 # Check for the existence of one or more files.
 function exists {
   for f in $*; do
@@ -162,13 +178,13 @@ npm install test-integrity@^2.0.1
 cd "$temp_app_path/test-kitchensink"
 
 # Link to our preset
-npm link "$root_path"/packages/babel-preset-react-app
+install_package "$root_path"/packages/babel-preset-react-app
 # Link to error overlay package because now it's a dependency
 # of react-dev-utils and not react-scripts
-npm link "$root_path"/packages/react-error-overlay
+install_package "$root_path"/packages/react-error-overlay
 
 # Link to test module
-npm link "$temp_module_path/node_modules/test-integrity"
+install_package "$temp_module_path/node_modules/test-integrity"
 
 # Test the build
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
@@ -219,23 +235,18 @@ E2E_FILE=./build/index.html \
 # Finally, let's check that everything still works after ejecting.
 # ******************************************************************************
 
-# Unlink our preset
-npm unlink "$root_path"/packages/babel-preset-react-app
-# Unlink error overlay
-npm unlink "$root_path"/packages/react-error-overlay
-
 # Eject...
 echo yes | npm run eject
 
 # ...but still link to the local packages
-npm link "$root_path"/packages/babel-preset-react-app
-npm link "$root_path"/packages/eslint-config-react-app
-npm link "$root_path"/packages/react-error-overlay
-npm link "$root_path"/packages/react-dev-utils
-npm link "$root_path"/packages/react-scripts
+install_package "$root_path"/packages/babel-preset-react-app
+install_package "$root_path"/packages/eslint-config-react-app
+install_package "$root_path"/packages/react-error-overlay
+install_package "$root_path"/packages/react-dev-utils
+install_package "$root_path"/packages/react-scripts
 
 # Link to test module
-npm link "$temp_module_path/node_modules/test-integrity"
+install_package "$temp_module_path/node_modules/test-integrity"
 
 # Test the build
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -23,7 +23,7 @@ function cleanup {
   ps -ef | grep 'react-scripts' | grep -v grep | awk '{print $2}' | xargs kill -9
   cd "$root_path"
   # TODO: fix "Device or resource busy" and remove ``|| $CI`
-  # rm -rf "$temp_cli_path" "$temp_app_path" "$temp_module_path" || $CI
+  rm -rf "$temp_cli_path" "$temp_app_path" "$temp_module_path" || $CI
 }
 
 # Error messages are redirected to stderr

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -50,7 +50,7 @@ function install_package {
   rm -rf node_modules/**/$(basename $1)/
 
   # Copy package into node_modules/
-  rsync -a /cygdrive${1%/} node_modules/ --exclude node_modules
+  rsync -a ${1%/} node_modules/ --exclude node_modules
 
   # Install `dependencies`
   cd node_modules/$(basename $1)/

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -47,8 +47,6 @@ function create_react_app {
 function install_package {
   rsync -a ${1%/} node_modules/ --exclude node_modules
 
-  $restore_location = $(pwd)
-
   cd node_modules/$(basename $1)/
   if [ "$USE_YARN" = "yes" ]
   then
@@ -56,8 +54,7 @@ function install_package {
   else
     npm install --only=production
   fi
-
-  cd $restore_location
+  cd ../..
 }
 
 # Check for the existence of one or more files.

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -53,7 +53,7 @@ function install_package {
 
   # Copy package into node_modules/ ignoring installed deps
   # rsync -a ${1%/} node_modules/ --exclude node_modules
-  cp -r ${1%/} node_modules/
+  cp -R ${1%/} node_modules/
   rm -rf node_modules/$pkg/node_modules/
 
   # Install `dependencies`

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -50,7 +50,8 @@ function install_package {
   rm -rf node_modules/**/$(basename $1)/
 
   # Copy package into node_modules/
-  rsync -a ${1%/} node_modules/ --exclude node_modules
+  copyfrom=${1%/}
+  rsync -a ${copyfrom/\/c\//c:\/} node_modules/ --exclude node_modules
 
   # Install `dependencies`
   cd node_modules/$(basename $1)/

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -50,7 +50,7 @@ function install_package {
   rm -rf node_modules/**/$(basename $1)/
 
   # Copy package into node_modules/
-  rsync -a ${1%/} node_modules/ --exclude node_modules
+  rsync -a /cygdrive${1%/} node_modules/ --exclude node_modules
 
   # Install `dependencies`
   cd node_modules/$(basename $1)/

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -247,6 +247,11 @@ E2E_FILE=./build/index.html \
 # Eject...
 echo yes | npm run eject
 
+if hash yarnpkg 2>/dev/null
+then
+  yarn install --check-files
+fi
+
 # ...but still link to the local packages
 install_package "$root_path"/packages/babel-preset-react-app
 install_package "$root_path"/packages/eslint-config-react-app

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -60,6 +60,8 @@ function install_package {
   else
     npm install --only=production
   fi
+  # Remove our packages
+  rm -rf node_modules/{babel-preset-react-app,eslint-config-react-app,react-dev-utils,react-error-overlay,react-scripts}
   cd ../..
 }
 

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -45,7 +45,7 @@ function create_react_app {
 }
 
 function install_package {
-  pkg = $(basename $1)
+  local pkg=$(basename $1)
 
   # Clean target (for safety)
   rm -rf node_modules/$pkg/

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -45,22 +45,26 @@ function create_react_app {
 }
 
 function install_package {
-  # Clean target
-  rm -rf node_modules/$(basename $1)/
-  rm -rf node_modules/**/$(basename $1)/
+  pkg = $(basename $1)
 
-  # Copy package into node_modules/
-  rsync -a ${1%/} node_modules/ --exclude node_modules
+  # Clean target (for safety)
+  rm -rf node_modules/$pkg/
+  rm -rf node_modules/**/$pkg/
+
+  # Copy package into node_modules/ ignoring installed deps
+  # rsync -a ${1%/} node_modules/ --exclude node_modules
+  cp -r ${1%/} node_modules/
+  rm -rf node_modules/$pkg/node_modules/
 
   # Install `dependencies`
-  cd node_modules/$(basename $1)/
+  cd node_modules/$pkg/
   if [ "$USE_YARN" = "yes" ]
   then
     yarn install --production
   else
     npm install --only=production
   fi
-  # Remove our packages
+  # Remove our packages to ensure side-by-side versions are used (which we link)
   rm -rf node_modules/{babel-preset-react-app,eslint-config-react-app,react-dev-utils,react-error-overlay,react-scripts}
   cd ../..
 }

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -45,8 +45,14 @@ function create_react_app {
 }
 
 function install_package {
+  # Clean target
+  rm -rf node_modules/$(basename $1)/
+  rm -rf node_modules/**/$(basename $1)/
+
+  # Copy package into node_modules/
   rsync -a ${1%/} node_modules/ --exclude node_modules
 
+  # Install `dependencies`
   cd node_modules/$(basename $1)/
   if [ "$USE_YARN" = "yes" ]
   then

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -23,7 +23,7 @@ function cleanup {
   ps -ef | grep 'react-scripts' | grep -v grep | awk '{print $2}' | xargs kill -9
   cd "$root_path"
   # TODO: fix "Device or resource busy" and remove ``|| $CI`
-  rm -rf "$temp_cli_path" "$temp_app_path" "$temp_module_path" || $CI
+  # rm -rf "$temp_cli_path" "$temp_app_path" "$temp_module_path" || $CI
 }
 
 # Error messages are redirected to stderr
@@ -252,7 +252,6 @@ install_package "$root_path"/packages/babel-preset-react-app
 install_package "$root_path"/packages/eslint-config-react-app
 install_package "$root_path"/packages/react-error-overlay
 install_package "$root_path"/packages/react-dev-utils
-install_package "$root_path"/packages/react-scripts
 
 # Link to test module
 install_package "$temp_module_path/node_modules/test-integrity"

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -247,6 +247,9 @@ E2E_FILE=./build/index.html \
 # Eject...
 echo yes | npm run eject
 
+# Ensure Yarn is ran after eject; at the time of this commit, we don't run Yarn
+# after ejecting. Soon, we may only skip Yarn on Windows. Let's try to remove
+# this in the near future.
 if hash yarnpkg 2>/dev/null
 then
   yarn install --check-files

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -44,22 +44,26 @@ function create_react_app {
 }
 
 function install_package {
-  # Clean target
-  rm -rf node_modules/$(basename $1)/
-  rm -rf node_modules/**/$(basename $1)/
+  pkg = $(basename $1)
 
-  # Copy package into node_modules/
-  rsync -a ${1%/} node_modules/ --exclude node_modules
+  # Clean target (for safety)
+  rm -rf node_modules/$pkg/
+  rm -rf node_modules/**/$pkg/
+
+  # Copy package into node_modules/ ignoring installed deps
+  # rsync -a ${1%/} node_modules/ --exclude node_modules
+  cp -r ${1%/} node_modules/
+  rm -rf node_modules/$pkg/node_modules/
 
   # Install `dependencies`
-  cd node_modules/$(basename $1)/
+  cd node_modules/$pkg/
   if [ "$USE_YARN" = "yes" ]
   then
     yarn install --production
   else
     npm install --only=production
   fi
-  # Remove our packages
+  # Remove our packages to ensure side-by-side versions are used (which we link)
   rm -rf node_modules/{babel-preset-react-app,eslint-config-react-app,react-dev-utils,react-error-overlay,react-scripts}
   cd ../..
 }

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -49,7 +49,7 @@ function install_package {
   rm -rf node_modules/**/$(basename $1)/
 
   # Copy package into node_modules/
-  rsync -a /cygdrive${1%/} node_modules/ --exclude node_modules
+  rsync -a ${1%/} node_modules/ --exclude node_modules
 
   # Install `dependencies`
   cd node_modules/$(basename $1)/

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -49,7 +49,8 @@ function install_package {
   rm -rf node_modules/**/$(basename $1)/
 
   # Copy package into node_modules/
-  rsync -a ${1%/} node_modules/ --exclude node_modules
+  copyfrom=${1%/}
+  rsync -a ${copyfrom/\/c\//c:\/} node_modules/ --exclude node_modules
 
   # Install `dependencies`
   cd node_modules/$(basename $1)/

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -52,7 +52,7 @@ function install_package {
 
   # Copy package into node_modules/ ignoring installed deps
   # rsync -a ${1%/} node_modules/ --exclude node_modules
-  cp -r ${1%/} node_modules/
+  cp -R ${1%/} node_modules/
   rm -rf node_modules/$pkg/node_modules/
 
   # Install `dependencies`

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -49,7 +49,7 @@ function install_package {
   rm -rf node_modules/**/$(basename $1)/
 
   # Copy package into node_modules/
-  rsync -a ${1%/} node_modules/ --exclude node_modules
+  rsync -a /cygdrive${1%/} node_modules/ --exclude node_modules
 
   # Install `dependencies`
   cd node_modules/$(basename $1)/

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -53,6 +53,8 @@ function install_package {
   else
     npm install --only=production
   fi
+  # Remove our packages
+  rm -rf node_modules/{babel-preset-react-app,eslint-config-react-app,react-dev-utils,react-error-overlay,react-scripts}
   cd ../..
 }
 

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -331,6 +331,11 @@ verify_module_scope
 # Eject...
 echo yes | npm run eject
 
+if hash yarnpkg 2>/dev/null
+then
+  yarn install --check-files
+fi
+
 # ...but still link to the local packages
 install_package "$root_path"/packages/babel-preset-react-app
 install_package "$root_path"/packages/eslint-config-react-app

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -44,7 +44,7 @@ function create_react_app {
 }
 
 function install_package {
-  pkg = $(basename $1)
+  local pkg=$(basename $1)
 
   # Clean target (for safety)
   rm -rf node_modules/$pkg/

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -331,9 +331,12 @@ verify_module_scope
 # Eject...
 echo yes | npm run eject
 
+# Ensure Yarn is ran after eject; at the time of this commit, we don't run Yarn
+# after ejecting. Soon, we may only skip Yarn on Windows. Let's try to remove
+# this in the near future.
 if hash yarnpkg 2>/dev/null
 then
-  yarn install --check-files
+  yarnpkg install --check-files
 fi
 
 # ...but still link to the local packages

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -46,8 +46,6 @@ function create_react_app {
 function install_package {
   rsync -a ${1%/} node_modules/ --exclude node_modules
 
-  $restore_location = $(pwd)
-
   cd node_modules/$(basename $1)/
   if [ "$USE_YARN" = "yes" ]
   then
@@ -55,8 +53,7 @@ function install_package {
   else
     npm install --only=production
   fi
-
-  cd $restore_location
+  cd ../..
 }
 
 # Check for the existence of one or more files.

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -329,7 +329,7 @@ verify_module_scope
 # ******************************************************************************
 
 # Eject...
-echo yes | npm run eject
+echo yes | npm run eject || echo
 
 # ...but still link to the local packages
 install_package "$root_path"/packages/babel-preset-react-app

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -43,6 +43,22 @@ function create_react_app {
   node "$temp_cli_path"/node_modules/create-react-app/index.js "$@"
 }
 
+function install_package {
+  rsync -a ${1%/} node_modules/ --exclude node_modules
+
+  $restore_location = $(pwd)
+
+  cd node_modules/$(basename $1)/
+  if [ "$USE_YARN" = "yes" ]
+  then
+    yarn install --production
+  else
+    npm install --only=production
+  fi
+
+  cd $restore_location
+}
+
 # Check for the existence of one or more files.
 function exists {
   for f in $*; do
@@ -307,10 +323,10 @@ verify_module_scope
 echo yes | npm run eject
 
 # ...but still link to the local packages
-npm link "$root_path"/packages/babel-preset-react-app
-npm link "$root_path"/packages/eslint-config-react-app
-npm link "$root_path"/packages/react-dev-utils
-npm link "$root_path"/packages/react-scripts
+install_package "$root_path"/packages/babel-preset-react-app
+install_package "$root_path"/packages/eslint-config-react-app
+install_package "$root_path"/packages/react-dev-utils
+install_package "$root_path"/packages/react-scripts
 
 # Test the build
 npm run build

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -49,8 +49,7 @@ function install_package {
   rm -rf node_modules/**/$(basename $1)/
 
   # Copy package into node_modules/
-  copyfrom=${1%/}
-  rsync -a ${copyfrom/\/c\//c:\/} node_modules/ --exclude node_modules
+  rsync -a ${1%/} node_modules/ --exclude node_modules
 
   # Install `dependencies`
   cd node_modules/$(basename $1)/

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -329,7 +329,7 @@ verify_module_scope
 # ******************************************************************************
 
 # Eject...
-echo yes | npm run eject || echo
+echo yes | npm run eject
 
 # ...but still link to the local packages
 install_package "$root_path"/packages/babel-preset-react-app

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -22,7 +22,7 @@ function cleanup {
   cd "$root_path"
   # Uncomment when snapshot testing is enabled by default:
   # rm ./packages/react-scripts/template/src/__snapshots__/App.test.js.snap
-  # rm -rf "$temp_cli_path" $temp_app_path
+  rm -rf "$temp_cli_path" $temp_app_path
 }
 
 # Error messages are redirected to stderr

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -44,8 +44,14 @@ function create_react_app {
 }
 
 function install_package {
+  # Clean target
+  rm -rf node_modules/$(basename $1)/
+  rm -rf node_modules/**/$(basename $1)/
+
+  # Copy package into node_modules/
   rsync -a ${1%/} node_modules/ --exclude node_modules
 
+  # Install `dependencies`
   cd node_modules/$(basename $1)/
   if [ "$USE_YARN" = "yes" ]
   then

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -22,7 +22,7 @@ function cleanup {
   cd "$root_path"
   # Uncomment when snapshot testing is enabled by default:
   # rm ./packages/react-scripts/template/src/__snapshots__/App.test.js.snap
-  rm -rf "$temp_cli_path" $temp_app_path
+  # rm -rf "$temp_cli_path" $temp_app_path
 }
 
 # Error messages are redirected to stderr
@@ -335,7 +335,6 @@ echo yes | npm run eject
 install_package "$root_path"/packages/babel-preset-react-app
 install_package "$root_path"/packages/eslint-config-react-app
 install_package "$root_path"/packages/react-dev-utils
-install_package "$root_path"/packages/react-scripts
 
 # Test the build
 npm run build


### PR DESCRIPTION
`npm link` is super unreliable and causes our tests to fail; this replaces `npm link` with a much more predictable behavior.

This doesn't work on AppVeyor yet because the version of `rsync` is complaining about a local copy; any ideas?