### PR TITLE
Lint against files with old license

### DIFF
--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -84,6 +84,19 @@ trap 'set +x; handle_exit' SIGQUIT SIGTERM SIGINT SIGKILL SIGHUP
 # Echo every command being executed
 set -x
 
+# Make sure we don't introduce accidental references to PATENTS.
+EXPECTED='packages/react-error-overlay/fixtures/bundle.mjs
+packages/react-error-overlay/fixtures/bundle.mjs.map
+packages/react-error-overlay/fixtures/bundle_u.mjs
+packages/react-error-overlay/fixtures/bundle_u.mjs.map
+tasks/e2e-simple.sh'
+ACTUAL=$(git grep -l PATENTS)
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo "PATENTS crept into some new files?"
+  diff -u <(echo "$EXPECTED") <(echo "$ACTUAL") || true
+  exit 1
+fi
+
 # Go to root
 cd ..
 root_path=$PWD

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -84,6 +84,10 @@ trap 'set +x; handle_exit' SIGQUIT SIGTERM SIGINT SIGKILL SIGHUP
 # Echo every command being executed
 set -x
 
+# Go to root
+cd ..
+root_path=$PWD
+
 # Make sure we don't introduce accidental references to PATENTS.
 EXPECTED='tasks/e2e-simple.sh'
 ACTUAL=$(git grep -l PATENTS)
@@ -92,10 +96,6 @@ if [ "$EXPECTED" != "$ACTUAL" ]; then
   diff -u <(echo "$EXPECTED") <(echo "$ACTUAL") || true
   exit 1
 fi
-
-# Go to root
-cd ..
-root_path=$PWD
 
 # Clear cache to avoid issues with incorrect packages being used
 if hash yarnpkg 2>/dev/null

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -85,11 +85,7 @@ trap 'set +x; handle_exit' SIGQUIT SIGTERM SIGINT SIGKILL SIGHUP
 set -x
 
 # Make sure we don't introduce accidental references to PATENTS.
-EXPECTED='packages/react-error-overlay/fixtures/bundle.mjs
-packages/react-error-overlay/fixtures/bundle.mjs.map
-packages/react-error-overlay/fixtures/bundle_u.mjs
-packages/react-error-overlay/fixtures/bundle_u.mjs.map
-tasks/e2e-simple.sh'
+EXPECTED='tasks/e2e-simple.sh'
 ACTUAL=$(git grep -l PATENTS)
 if [ "$EXPECTED" != "$ACTUAL" ]; then
   echo "PATENTS crept into some new files?"

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -89,7 +89,11 @@ cd ..
 root_path=$PWD
 
 # Make sure we don't introduce accidental references to PATENTS.
-EXPECTED='tasks/e2e-simple.sh'
+EXPECTED='packages/react-error-overlay/fixtures/bundle.mjs
+packages/react-error-overlay/fixtures/bundle.mjs.map
+packages/react-error-overlay/fixtures/bundle_u.mjs
+packages/react-error-overlay/fixtures/bundle_u.mjs.map
+tasks/e2e-simple.sh'
 ACTUAL=$(git grep -l PATENTS)
 if [ "$EXPECTED" != "$ACTUAL" ]; then
   echo "PATENTS crept into some new files?"


### PR DESCRIPTION
Just so we don't accidentally introduce them again with an old PR.
Based on a similar check in React repo.