### PR TITLE
Replace template literal; fixes #3367

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -26,7 +26,8 @@ var ErrorOverlay = require('react-error-overlay');
 ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
   // Keep this sync with errorOverlayMiddleware.js
   fetch(
-    `${launchEditorEndpoint}?fileName=` +
+    launchEditorEndpoint +
+      '?fileName=' +
       window.encodeURIComponent(errorLocation.fileName) +
       '&lineNumber=' +
       window.encodeURIComponent(errorLocation.lineNumber || 1)


### PR DESCRIPTION
To test, I ran the following:

    yarn run create-react-app ie11test
    cd ie11test/
    yarn start

Then I opened localhost:3000 in IE11 and verified that the sample app runs without errors.