### PR TITLE
Update favicon props in manifest.json

### DIFF
--- a/packages/react-scripts/template/public/manifest.json
+++ b/packages/react-scripts/template/public/manifest.json
@@ -4,8 +4,8 @@
   "icons": [
     {
       "src": "favicon.ico",
-      "sizes": "64x64",
-      "type": "image/png"
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
     }
   ],
   "start_url": "./index.html",


### PR DESCRIPTION
- changed favicon sizes description to an array `64x64 32x32 24x24 16x16` as file contains multiple sizes. See [w3c](https://w3c.github.io/manifest/#sizes-member), [mdc](https://developer.mozilla.org/en-US/docs/Web/Manifest#icons)
- changed favicon mime type from `image/png` to `image/x-icon`, as per [this](https://stackoverflow.com/a/28300054/1012616) SO answer