### PR TITLE
prefer NODE_ENV over BABEL_ENV

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -42,7 +42,7 @@ const plugins = [
 // https://github.com/babel/babel/issues/4539
 // https://github.com/facebookincubator/create-react-app/issues/720
 // It’s also nice that we can enforce `NODE_ENV` being specified.
-var env = process.env.BABEL_ENV || process.env.NODE_ENV;
+var env = process.env.NODE_ENV || process.env.BABEL_ENV;
 if (env !== 'development' && env !== 'test' && env !== 'production') {
   throw new Error(
     'Using `babel-preset-react-app` requires that you specify `NODE_ENV` or ' +


### PR DESCRIPTION
`BABEL_ENV` is used by .babelrc to allow conditional plugins and presets which may be used in env other than dev/prod/test but still use `babel-preset-react-app`

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
