### PR TITLE
Update README.md

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -535,7 +535,7 @@ Following this rule often makes CSS preprocessors less useful, as features like 
 First, let’s install the command-line interface for Sass:
 
 ```sh
-npm install --save node-sass-chokidar
+npm install --save-dev node-sass-chokidar
 ```
 
 Alternatively you may use `yarn`:


### PR DESCRIPTION
Since `node-sass-chokidar` is used to build _SCSS_ files and result in _CSS_ files, it's a development requirement, not a production one. So the proper way to install it is using `--save-dev`.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
