### PR TITLE
add envinfo package, —info flag

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -105,6 +105,7 @@ if (typeof projectName === 'undefined') {
     envinfo.print({
       packages: ['react', 'react-dom', 'react-scripts'],
       noNativeIDE: true,
+      duplicates: true,
     });
     process.exit(0);
   }

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -47,6 +47,7 @@ const tmp = require('tmp');
 const unpack = require('tar-pack').unpack;
 const url = require('url');
 const hyperquest = require('hyperquest');
+const envinfo = require('envinfo');
 
 const packageJson = require('./package.json');
 
@@ -60,6 +61,7 @@ const program = new commander.Command(packageJson.name)
     projectName = name;
   })
   .option('--verbose', 'print additional logs')
+  .option('--info', 'print environment debug info')
   .option(
     '--scripts-version <alternative-package>',
     'use a non-standard version of react-scripts'
@@ -99,6 +101,13 @@ const program = new commander.Command(packageJson.name)
   .parse(process.argv);
 
 if (typeof projectName === 'undefined') {
+  if (program.info) {
+    envinfo.print({
+      packages: ['react', 'react-dom', 'react-scripts'],
+      noNativeIDE: true,
+    });
+    process.exit(0);
+  }
   console.error('Please specify the project directory:');
   console.log(
     `  ${chalk.cyan(program.name())} ${chalk.green('<project-directory>')}`

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -24,7 +24,7 @@
     "chalk": "^1.1.1",
     "commander": "^2.9.0",
     "cross-spawn": "^4.0.0",
-    "envinfo": "^3.6.0",
+    "envinfo": "^3.8.0",
     "fs-extra": "^1.0.0",
     "hyperquest": "^2.1.2",
     "semver": "^5.0.3",

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -24,6 +24,7 @@
     "chalk": "^1.1.1",
     "commander": "^2.9.0",
     "cross-spawn": "^4.0.0",
+    "envinfo": "^3.6.0",
     "fs-extra": "^1.0.0",
     "hyperquest": "^2.1.2",
     "semver": "^5.0.3",


### PR DESCRIPTION
I realize the file says not to modify the createReactApp.js, but a better way to do this did not occur to me. If there is a better way, I am certainly open to it. 

To help the issue process and better narrow down environment and version issues, I have added `create-react-app --info` which should print the following:

```
Environment:
  OS: macOS High Sierra 10.13
  Node: 8.6.0
  Yarn: 1.2.1
  npm: 5.5.1
  Watchman: 4.9.0

Packages: (wanted => installed)
  react: ^16.0.0 => 16.0.0
  react-dom: ^16.0.0 => 16.0.0
  react-scripts: 1.0.17 => 1.0.17
```
