### PR TITLE
add —use-npm flag to bypass yarn

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -64,6 +64,7 @@ const program = new commander.Command(packageJson.name)
     '--scripts-version <alternative-package>',
     'use a non-standard version of react-scripts'
   )
+  .option('--use-npm')
   .allowUnknownOption()
   .on('--help', () => {
     console.log(`    Only ${chalk.green('<project-directory>')} is required.`);
@@ -133,10 +134,11 @@ createApp(
   projectName,
   program.verbose,
   program.scriptsVersion,
+  program.useNpm,
   hiddenProgram.internalTestingTemplate
 );
 
-function createApp(name, verbose, version, template) {
+function createApp(name, verbose, version, useNpm, template) {
   const root = path.resolve(name);
   const appName = path.basename(root);
 
@@ -159,7 +161,7 @@ function createApp(name, verbose, version, template) {
     JSON.stringify(packageJson, null, 2)
   );
 
-  const useYarn = shouldUseYarn();
+  const useYarn = useNpm ? false : shouldUseYarn();
   const originalDirectory = process.cwd();
   process.chdir(root);
   if (!useYarn && !checkThatNpmCanReadCwd()) {

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -146,6 +146,20 @@ grep '"version": "0.4.0"' node_modules/react-scripts/package.json
 checkDependencies
 
 # ******************************************************************************
+# Test --use-npm flag
+# ******************************************************************************
+
+cd "$temp_app_path"
+create_react_app --use-npm --scripts-version=0.4.0 test-use-npm-flag
+cd test-use-npm-flag
+
+# Check corresponding scripts version is installed.
+exists node_modules/react-scripts
+[ ! -e "yarn.lock" ] && echo "yarn.lock correctly does not exist"
+grep '"version": "0.4.0"' node_modules/react-scripts/package.json
+checkDependencies
+
+# ******************************************************************************
 # Test --scripts-version with a tarball url
 # ******************************************************************************
 


### PR DESCRIPTION
Allow user to choose npm over yarn. This should close #3385. 