### PR TITLE
Export dismissRuntimeErrors function

### DIFF
--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -87,7 +87,7 @@ function handleRuntimeError(errorRecord) {
   update();
 }
 
-function dismissRuntimeErrors() {
+export function dismissRuntimeErrors() {
   currentRuntimeErrorRecords = [];
   update();
 }


### PR DESCRIPTION
Context from https://github.com/react-cosmos/react-cosmos/pull/484#issuecomment-341589413

> @skidding thinking of programmatically closing runtime error overlay in some cases. I noticed there's a `dismissRuntimeErrors` function but [it isn't exported](https://github.com/facebookincubator/create-react-app/blob/9ce144ed90c37f116b8457821d36dba2ceb0490a/packages/react-error-overlay/src/index.js#L90). Do you see any reasons why it shouldn't be called? Otherwise I'd like to submit a PR for exporting it.

> @Timer Mainly because in our use case it doesn't make sense to dismiss. Happy to accept a pull request exporting it.