### PR TITLE
Print full directory name from lsof

### DIFF
--- a/packages/react-dev-utils/getProcessForPort.js
+++ b/packages/react-dev-utils/getProcessForPort.js
@@ -58,7 +58,7 @@ function getProcessCommand(processId, processDirectory) {
 
 function getDirectoryOfProcessById(processId) {
   return execSync(
-    'lsof -p ' + processId + ' | awk \'$4=="cwd" {print $9}\'',
+    'lsof -p ' + processId + ' | awk \'$4=="cwd" {for (i=9; i<=NF; i++) printf "%s ", $i}\'',
     execOptions
   ).trim();
 }


### PR DESCRIPTION
awk splits lines based on spaces, which causes directory names with spaces to end up in other fields. Using a for loop allows us to print from the 9th field onwards instead of just the 9th field.

Fixes #3439.
