### PR TITLE
Add a localhost-only log message pointing folks to the PWA docs

### DIFF
--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -35,6 +35,15 @@ export default function register() {
       if (isLocalhost) {
         // This is running on localhost. Lets check if a service worker still exists or not.
         checkValidServiceWorker(swUrl);
+
+        // Add some additional logging to localhost, pointing developers to the
+        // service worker/PWA documentation.
+        navigator.serviceWorker.ready.then(() => {
+          console.log(
+            'This web app is being served cache-first by a service ' +
+              'worker. To learn more, visit https://goo.gl/SC7cgQ'
+          );
+        });
       } else {
         // Is not local host. Just register service worker
         registerValidSW(swUrl);


### PR DESCRIPTION
R: @gaearon @Timer 

This adds in an additional log message pointing folks to https://goo.gl/SC7cgQ (I could use a different URL shortener or just include the full URL if you'd prefer.)

It's displayed every time `registerServiceWorker()` is called and there's a service worker active on `localhost`. Displaying it on each load should give it higher visibility vs. the other logging messages which are only displayed when content is initially cached or content is updated.

I hope it will help with the type of questions that come up at, e.g., https://github.com/facebookincubator/create-react-app/issues/2398#issuecomment-344510011