### PR TITLE
Open editor to exact column from build error overlay

### DIFF
--- a/packages/react-dev-utils/errorOverlayMiddleware.js
+++ b/packages/react-dev-utils/errorOverlayMiddleware.js
@@ -12,11 +12,9 @@ const launchEditorEndpoint = require('./launchEditorEndpoint');
 module.exports = function createLaunchEditorMiddleware() {
   return function launchEditorMiddleware(req, res, next) {
     if (req.url.startsWith(launchEditorEndpoint)) {
-      launchEditor(
-        req.query.fileName,
-        req.query.lineNumber,
-        req.query.colNumber
-      );
+      const lineNumber = parseInt(req.query.lineNumber, 10) || 1;
+      const colNumber = parseInt(req.query.colNumber, 10) || 1;
+      launchEditor(req.query.fileName, lineNumber, colNumber);
       res.end();
     } else {
       next();

--- a/packages/react-dev-utils/errorOverlayMiddleware.js
+++ b/packages/react-dev-utils/errorOverlayMiddleware.js
@@ -12,7 +12,11 @@ const launchEditorEndpoint = require('./launchEditorEndpoint');
 module.exports = function createLaunchEditorMiddleware() {
   return function launchEditorMiddleware(req, res, next) {
     if (req.url.startsWith(launchEditorEndpoint)) {
-      launchEditor(req.query.fileName, req.query.lineNumber);
+      launchEditor(
+        req.query.fileName,
+        req.query.lineNumber,
+        req.query.colNumber
+      );
       res.end();
     } else {
       next();

--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -260,13 +260,16 @@ function launchEditor(fileName, lineNumber, colNumber) {
 
   // Sanitize lineNumber to prevent malicious use on win32
   // via: https://github.com/nodejs/node/blob/c3bb4b1aa5e907d489619fb43d233c3336bfc03d/lib/child_process.js#L333
-  if (lineNumber && isNaN(lineNumber)) {
+  // and it should be a positive integer
+  if (!(Number.isInteger(lineNumber) && lineNumber > 0)) {
     return;
   }
 
-  // colNumber is optional, but should be a number
+  // colNumber is optional, but should be a positive integer too
   // default is 1
-  colNumber = parseInt(colNumber, 10) || 1;
+  if (!(Number.isInteger(colNumber) && colNumber > 0)) {
+    colNumber = 1;
+  }
 
   let [editor, ...args] = guessEditor();
   if (!editor) {

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -30,7 +30,9 @@ ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
       '?fileName=' +
       window.encodeURIComponent(errorLocation.fileName) +
       '&lineNumber=' +
-      window.encodeURIComponent(errorLocation.lineNumber || 1)
+      window.encodeURIComponent(errorLocation.lineNumber || 1) +
+      '&colNumber=' +
+      window.encodeURIComponent(errorLocation.colNumber || 1)
   );
 });
 

--- a/packages/react-error-overlay/src/utils/parseCompileError.js
+++ b/packages/react-error-overlay/src/utils/parseCompileError.js
@@ -4,6 +4,7 @@ import Anser from 'anser';
 export type ErrorLocation = {|
   fileName: string,
   lineNumber: number,
+  colNumber?: number,
 |};
 
 const filePathRegex = /^\.(\/[^/\n ]+)+\.[^/\n ]+$/;
@@ -25,6 +26,7 @@ function parseCompileError(message: string): ?ErrorLocation {
   const lines: Array<string> = message.split('\n');
   let fileName: string = '';
   let lineNumber: number = 0;
+  let colNumber: number = 0;
 
   for (let i = 0; i < lines.length; i++) {
     const line: string = Anser.ansiToText(lines[i]).trim();
@@ -41,6 +43,8 @@ function parseCompileError(message: string): ?ErrorLocation {
       const match: ?Array<string> = line.match(lineNumberRegexes[k]);
       if (match) {
         lineNumber = parseInt(match[1], 10);
+        // colNumber starts with 0 and hence add 1
+        colNumber = parseInt(match[2], 10) + 1 || 1;
         break;
       }
       k++;
@@ -51,7 +55,7 @@ function parseCompileError(message: string): ?ErrorLocation {
     }
   }
 
-  return fileName && lineNumber ? { fileName, lineNumber } : null;
+  return fileName && lineNumber ? { fileName, lineNumber, colNumber } : null;
 }
 
 export default parseCompileError;


### PR DESCRIPTION
Fixes #3358 

Only support babel syntax errors with Atom, Sublime, Notepad++, Emacs, and VSCode. Welcome support for other editors.

@gaearon Any particular reason to [ignore the column number from eslint errors](https://github.com/facebookincubator/create-react-app/commit/5e35645b95af92b8b45cbb5e703e0bd8f38fd605)? If not we can change the message format and support eslint errors as well. 
