### PR TITLE
Allow error overlay to be unregistered

### DIFF
--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -64,7 +64,7 @@ export function startReportingRuntimeErrors(options: RuntimeReportingOptions) {
     );
   }
   currentRuntimeErrorOptions = options;
-  listenToRuntimeErrors(errorRecord => {
+  stopListeningToRuntimeErrors = listenToRuntimeErrors(errorRecord => {
     try {
       if (typeof options.onError === 'function') {
         options.onError.call(null);


### PR DESCRIPTION
Seems we forgot to set the unregister function.