### PR TITLE
Allow Babel experimental plugins using package.json create-react-app.…

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -4,7 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+// Node.js 6 ECMAScript
 'use strict';
+
+const path = require('path');
 
 const plugins = [
   // class { handleClick = () => { } }
@@ -35,6 +38,24 @@ const plugins = [
     },
   ],
 ];
+
+const filename = path.resolve('package.json');
+try {
+  const object = require(filename);
+  const craBabelPlugins = Object(
+    Object(Object(object)['create-react-app']).babel
+  ).plugins;
+  if (Array.isArray(craBabelPlugins))
+    plugins.push.apply(plugins, craBabelPlugins);
+} catch (e) {
+  console.error(
+    'babel-preset-react-app: error:',
+    String(e),
+    'reading filename:',
+    filename
+  );
+  throw e;
+}
 
 // This is similar to how `env` works in Babel:
 // https://babeljs.io/docs/usage/babelrc/#env-option

--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -45,8 +45,9 @@ try {
   const craBabelPlugins = Object(
     Object(Object(object)['create-react-app']).babel
   ).plugins;
-  if (Array.isArray(craBabelPlugins))
+  if (Array.isArray(craBabelPlugins)) {
     plugins.push.apply(plugins, craBabelPlugins);
+  }
 } catch (e) {
   console.error(
     'babel-preset-react-app: error:',


### PR DESCRIPTION
fix for #3481 

test by adding Babel Function bind transform:
* run create-react-app
* ```npm i --save-dev babel-plugin-transform-function-bind```
* add to package.json:
```json
  "create-react-app": {
    "babel": {
      "plugins": [
        "transform-function-bind"
      ]
    }
  },
```
* modify src/App.js to use the experimental bind operator:
```js
class App extends Component {
  constructor(o) {
    super(o)

    const thisf = ::this.f // this.f.bind(this) in ancient ECMAScript 2017
    const actualThis = thisf() // if bind no work: undefined

    const isCorrect = this.isCorrect = this === actualThis
    console.log(`this correct: ${isCorrect}`)
  }

  f() {
    return this
  }

  render() {
    return (
      <div className="App">bind operator working: {String(this.isCorrect)}
```
verify that **npm t** and **npm start** still works…

Awesome!