### PR TITLE
Update User Guide with deploying to GitHub User pages

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -2012,10 +2012,16 @@ For more information see [Add Firebase to your JavaScript Project](https://fireb
 **The step below is important!**<br>
 **If you skip it, your app will not deploy correctly.**
 
-Open your `package.json` and add a `homepage` field:
+Open your `package.json` and add a `homepage` field for your project:
 
-```js
+```json
   "homepage": "https://myusername.github.io/my-app",
+```
+
+or for a GitHub user page:
+
+```json
+  "homepage": "https://myusername.github.io",
 ```
 
 Create React App uses the `homepage` field to determine the root URL in the built HTML file.
@@ -2047,6 +2053,18 @@ Add the following scripts in your `package.json`:
 ```
 
 The `predeploy` script will run automatically before `deploy` is run.
+
+If you are deploying to a GitHub user page instead of a project page you'll need to make two
+additional modifications:
+
+1. First, change your repository's source branch to be any branch other than **master**.
+1. Additionally, tweak your `package.json` scripts to push deployments to **master**:
+```diff
+  "scripts": {
+    "predeploy": "npm run build",
+-   "deploy": "gh-pages -d build",
++   "deploy": "gh-pages -b master -d build",
+```
 
 #### Step 3: Deploy the site by running `npm run deploy`
 


### PR DESCRIPTION
Added details to the User Guide specifying how to deploy to a GitHub user page, instead of a project page.

Tested here: https://github.com/aaronlna/aaronlna.github.io
Issue: https://github.com/facebookincubator/create-react-app/issues/3456