### PR TITLE
Enhance Jest config error for `setupTestFrameworkScriptFile`

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -76,14 +76,16 @@ module.exports = (resolve, rootDir, isEjecting) => {
         unsupportedKeys.indexOf('setupTestFrameworkScriptFile') >= -1;
 
       const setupFileError = isOverridingSetupFile
-        ? '\nTo add a setupTestFrameworkScriptFile, create the file in ' +
+        ? 'We detected `setupTestFrameworkScriptFile` in your package.json.\n' +
+          'To add a setupTestFrameworkScriptFile, create the file in ' +
           chalk.bold('src/setupTests.js') +
           ' and create-react-app will automatically load it for you.\n'
         : '';
 
       console.error(
         chalk.red(
-          'Out of the box, Create React App only supports overriding ' +
+          setupFileError +
+            '\nOut of the box, Create React App only supports overriding ' +
             'these Jest options:\n\n' +
             supportedKeys.map(key => chalk.bold('  \u2022 ' + key)).join('\n') +
             '.\n\n' +
@@ -97,8 +99,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
             chalk.bold('npm run eject') +
             ' but remember that this is a one-way operation. ' +
             'You may also file an issue with Create React App to discuss ' +
-            'supporting more options out of the box.\n' +
-            setupFileError
+            'supporting more options out of the box.\n'
         )
       );
       process.exit(1);

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -81,9 +81,9 @@ module.exports = (resolve, rootDir, isEjecting) => {
             'We detected ' +
               chalk.bold('setupTestFrameworkScriptFile') +
               ' in your package.json.\n\n' +
-              'To add a setupTestFrameworkScriptFile, create the file ' +
+              'Remove it from Jest configuration, and put the initialization code in ' +
               chalk.bold('src/setupTests.js') +
-              ' and create-react-app will automatically load it for you.\n'
+              '.\nThis file will be loaded automatically.\n'
           )
         );
       } else {

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -72,6 +72,15 @@ module.exports = (resolve, rootDir, isEjecting) => {
     });
     const unsupportedKeys = Object.keys(overrides);
     if (unsupportedKeys.length) {
+      const isOverridingSetupFile =
+        unsupportedKeys.indexOf('setupTestFrameworkScriptFile') >= -1;
+
+      const setupFileError = isOverridingSetupFile
+        ? '\nTo add a setupTestFrameworkScriptFile, create the file in ' +
+          chalk.bold('src/setupTests.js') +
+          ' and create-react-app will automatically load it for you.\n'
+        : '';
+
       console.error(
         chalk.red(
           'Out of the box, Create React App only supports overriding ' +
@@ -88,7 +97,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
             chalk.bold('npm run eject') +
             ' but remember that this is a one-way operation. ' +
             'You may also file an issue with Create React App to discuss ' +
-            'supporting more options out of the box.\n'
+            'supporting more options out of the box.\n' +
+            setupFileError
         )
       );
       process.exit(1);

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -73,35 +73,43 @@ module.exports = (resolve, rootDir, isEjecting) => {
     const unsupportedKeys = Object.keys(overrides);
     if (unsupportedKeys.length) {
       const isOverridingSetupFile =
-        unsupportedKeys.indexOf('setupTestFrameworkScriptFile') >= -1;
+        unsupportedKeys.indexOf('setupTestFrameworkScriptFile') > -1;
 
-      const setupFileError = isOverridingSetupFile
-        ? 'We detected `setupTestFrameworkScriptFile` in your package.json.\n' +
-          'To add a setupTestFrameworkScriptFile, create the file in ' +
-          chalk.bold('src/setupTests.js') +
-          ' and create-react-app will automatically load it for you.\n'
-        : '';
-
-      console.error(
-        chalk.red(
-          setupFileError +
+      if (isOverridingSetupFile) {
+        console.error(
+          chalk.red(
+            'We detected ' +
+              chalk.bold('setupTestFrameworkScriptFile') +
+              ' in your package.json.\n\n' +
+              'To add a setupTestFrameworkScriptFile, create the file ' +
+              chalk.bold('src/setupTests.js') +
+              ' and create-react-app will automatically load it for you.\n'
+          )
+        );
+      } else {
+        console.error(
+          chalk.red(
             '\nOut of the box, Create React App only supports overriding ' +
-            'these Jest options:\n\n' +
-            supportedKeys.map(key => chalk.bold('  \u2022 ' + key)).join('\n') +
-            '.\n\n' +
-            'These options in your package.json Jest configuration ' +
-            'are not currently supported by Create React App:\n\n' +
-            unsupportedKeys
-              .map(key => chalk.bold('  \u2022 ' + key))
-              .join('\n') +
-            '\n\nIf you wish to override other Jest options, you need to ' +
-            'eject from the default setup. You can do so by running ' +
-            chalk.bold('npm run eject') +
-            ' but remember that this is a one-way operation. ' +
-            'You may also file an issue with Create React App to discuss ' +
-            'supporting more options out of the box.\n'
-        )
-      );
+              'these Jest options:\n\n' +
+              supportedKeys
+                .map(key => chalk.bold('  \u2022 ' + key))
+                .join('\n') +
+              '.\n\n' +
+              'These options in your package.json Jest configuration ' +
+              'are not currently supported by Create React App:\n\n' +
+              unsupportedKeys
+                .map(key => chalk.bold('  \u2022 ' + key))
+                .join('\n') +
+              '\n\nIf you wish to override other Jest options, you need to ' +
+              'eject from the default setup. You can do so by running ' +
+              chalk.bold('npm run eject') +
+              ' but remember that this is a one-way operation. ' +
+              'You may also file an issue with Create React App to discuss ' +
+              'supporting more options out of the box.\n'
+          )
+        );
+      }
+
       process.exit(1);
     }
   }


### PR DESCRIPTION
I wasn't aware of the fact that users of c-r-a could just define
`src/setupTests.js` and it would be configured with Jest - I nearly
ejected before I found a GitHub issue that confirmed this functionality.

I thought it might be a nice idea to add it to the error about Jest
config overrides to stop others ejecting when they don't need to.

<img width="1194" alt="screen shot 2017-11-28 at 07 15 00" src="https://user-images.githubusercontent.com/193238/33306824-fe800ad0-d40b-11e7-8e8c-f8a38d2e03ef.png">

