### PR TITLE
Fix FileSizeReporter for multi build Webpack setups

### DIFF
--- a/packages/react-dev-utils/FileSizeReporter.js
+++ b/packages/react-dev-utils/FileSizeReporter.js
@@ -25,21 +25,29 @@ function printFileSizesAfterBuild(
 ) {
   var root = previousSizeMap.root;
   var sizes = previousSizeMap.sizes;
-  var assets = webpackStats
-    .toJson()
-    .assets.filter(asset => /\.(js|css)$/.test(asset.name))
-    .map(asset => {
-      var fileContents = fs.readFileSync(path.join(root, asset.name));
-      var size = gzipSize(fileContents);
-      var previousSize = sizes[removeFileNameHash(root, asset.name)];
-      var difference = getDifferenceLabel(size, previousSize);
-      return {
-        folder: path.join(path.basename(buildFolder), path.dirname(asset.name)),
-        name: path.basename(asset.name),
-        size: size,
-        sizeLabel: filesize(size) + (difference ? ' (' + difference + ')' : ''),
-      };
-    });
+  var assets = (webpackStats.stats || [webpackStats])
+    .map(stats =>
+      stats
+        .toJson()
+        .assets.filter(asset => /\.(js|css)$/.test(asset.name))
+        .map(asset => {
+          var fileContents = fs.readFileSync(path.join(root, asset.name));
+          var size = gzipSize(fileContents);
+          var previousSize = sizes[removeFileNameHash(root, asset.name)];
+          var difference = getDifferenceLabel(size, previousSize);
+          return {
+            folder: path.join(
+              path.basename(buildFolder),
+              path.dirname(asset.name)
+            ),
+            name: path.basename(asset.name),
+            size: size,
+            sizeLabel:
+              filesize(size) + (difference ? ' (' + difference + ')' : '')
+          };
+        })
+    )
+    .reduce((single, all) => all.concat(single), []);
   assets.sort((a, b) => b.size - a.size);
   var longestSizeLabelLength = Math.max.apply(
     null,


### PR DESCRIPTION
FileSizeReporter would fail if create-react-app project is ejected and webpack configuration is
modified to multi build setup. This could be reproduced with webpack configuration which returns array of configuration objects.

Real world use case for that kind of setup could be implementing localization with separate builds for each language.

In those situations `webpackStats` parameter would contain stats array
for each build. This fix will try to access stats and then fallback to using plaing webpackStats object.

If stats array is found it is mapped through and flattened. Assets are handled like before. 