### PR TITLE
Fixed Readme in Adding a CSS Preprocessor (Sass, Less etc.) section

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -535,13 +535,13 @@ Following this rule often makes CSS preprocessors less useful, as features like 
 First, let’s install the command-line interface for Sass:
 
 ```sh
-npm install --save node-sass-chokidar
+npm install --save-dev node-sass-chokidar
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add node-sass-chokidar
+yarn add --dev node-sass-chokidar
 ```
 
 Then in `package.json`, add the following lines to `scripts`:
@@ -580,13 +580,13 @@ At this point you might want to remove all CSS files from the source control, an
 As a final step, you may find it convenient to run `watch-css` automatically with `npm start`, and run `build-css` as a part of `npm run build`. You can use the `&&` operator to execute two scripts sequentially. However, there is no cross-platform way to run two scripts in parallel, so we will install a package for this:
 
 ```sh
-npm install --save npm-run-all
+npm install --save-dev npm-run-all
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add npm-run-all
+yarn add --dev npm-run-all
 ```
 
 Then we can change `start` and `build` scripts to include the CSS preprocessor commands:


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Hello,

[In Adding a CSS Preprocessor (Sass, Less etc.) section ](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-a-css-preprocessor-sass-less-etc) currently the user is instructed to install node-sass-chokidar and npm-run-all as normal dependencies, but they should ideally be installed as dev dependencies. 

I've added the dev flags in the docs to get the desired installation as shown below.

![screen shot 2017-11-30 at 4 17 37 am](https://user-images.githubusercontent.com/4268932/33403331-fab1d016-d585-11e7-928d-f80da873ef20.png)
![screen shot 2017-11-30 at 4 17 48 am](https://user-images.githubusercontent.com/4268932/33403332-fb07b922-d585-11e7-9d2f-dd265f32a8ba.png)


