### PR TITLE
Depend on latest babel-runtime

### DIFF
--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -25,6 +25,6 @@
     "babel-preset-react": "6.24.1"
   },
   "peerDependencies": {
-    "babel-runtime": "^6.23.0"
+    "babel-runtime": "^6.26.0"
   }
 }


### PR DESCRIPTION
This avoids a warning we were getting in our project:

```
warning "@storybook/react > babel-preset-react-app@3.1.0" has unmet peer dependency "babel-runtime@^6.23.0".
```

We were getting this warning even though our app has a dependency on `"babel-runtime": "^6.26.0"`.