### PR TITLE
use safer/more aesthetic syntax for setting environment variables on Windows

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -890,10 +890,10 @@ life of the shell session.
 #### Windows (cmd.exe)
 
 ```cmd
-set REACT_APP_SECRET_CODE=abcdef&&npm start
+set "REACT_APP_SECRET_CODE=abcdef" && npm start
 ```
 
-(Note: the lack of whitespace is intentional.)
+(Note: Quotes around the variable assignment are required to avoid a trailing whitepsace.)
 
 #### Linux, macOS (Bash)
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -893,7 +893,7 @@ life of the shell session.
 set "REACT_APP_SECRET_CODE=abcdef" && npm start
 ```
 
-(Note: Quotes around the variable assignment are required to avoid a trailing whitepsace.)
+(Note: Quotes around the variable assignment are required to avoid a trailing whitespace.)
 
 #### Linux, macOS (Bash)
 


### PR DESCRIPTION
(Cleaned up version of https://github.com/facebookincubator/create-react-app/pull/3530)

Documentation update to fix a [maddeningly easy oversite](https://stackoverflow.com/questions/9249830/how-can-i-set-node-env-production-on-windows#comment48615249_9250168) for Windows users.  The `SET` command allows for [wrapping the variable assignment expression with double quotes](https://ss64.com/nt/set.html). Using this method negates the need to smash two commands together with the `&&` operator as currently documented.