### PR TITLE
keep node_env if provided from upstream

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -10,7 +10,7 @@
 
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'development';
-process.env.NODE_ENV = 'development';
+process.env.NODE_ENV = process.env.NODE_ENV ||'development';
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will


### PR DESCRIPTION

Hello, this is tiny configuration that would allow the  use of `react-script start` for browser e2e tests.

```
  "scripts": {
    "start": "react-scripts start",
    "start:test": "NODE_ENV=test react-scripts start",
...
```

So then inside index.js I could decide wether it is a dev build or integration test build.

```

if (process.env.NODE_ENV === 'test') {
  Enzyme.configure({ adapter: new Adapter() });

  const wrap = (<Provider store={store}><App />< /Provider>);

  const el = Enzyme.mount(wrap,
    { attachTo: document.getElementById('root') }
  );
  iTest(el);
} else {
  ReactDOM.render(
    <Provider store={store}>
      <App />
    </Provider>,
    document.getElementById('root')
  );
}
```

More details here:
https://github.com/DianaSuvorova/Demo-project/blob/master/frontend/package.json
https://github.com/DianaSuvorova/Demo-project/blob/master/frontend/src/index.js

Thanks,
Diana

