### PR TITLE
reading environment variables from .env file in babel-preset-react-app

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -42,6 +42,10 @@ const plugins = [
 // https://github.com/babel/babel/issues/4539
 // https://github.com/facebookincubator/create-react-app/issues/720
 // It’s also nice that we can enforce `NODE_ENV` being specified.
+// [PROPOSED_FEATURE] Read `.env` file if present and assign environment variables 
+// in `.env` file to process.env
+const dotenv = require('dotenv');
+dotenv.config();
 var env = process.env.BABEL_ENV || process.env.NODE_ENV;
 if (env !== 'development' && env !== 'test' && env !== 'production') {
   throw new Error(

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -22,7 +22,8 @@
     "babel-plugin-transform-regenerator": "6.26.0",
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "1.6.1",
-    "babel-preset-react": "6.24.1"
+    "babel-preset-react": "6.24.1",
+    "dotenv": "4.0.0"
   },
   "peerDependencies": {
     "babel-runtime": "^6.23.0"


### PR DESCRIPTION
In reference to Issue #2377 [closed].

babel-preset-react-app requires that `NODE_ENV` or `BABEL_ENV` be set to `"development" | "test" | "production"`. Prefer loading contents of `.env` file, if present, to `process.env` before the check is done.  


<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
