### PR TITLE
Autodetect MacVim editor

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -52,6 +52,8 @@ const COMMON_EDITORS_OSX = {
     '/Applications/RubyMine.app/Contents/MacOS/rubymine',
   '/Applications/WebStorm.app/Contents/MacOS/webstorm':
     '/Applications/WebStorm.app/Contents/MacOS/webstorm',
+  '/Applications/MacVim.app/Contents/MacOS/MacVim':
+    'mvim',
 };
 
 const COMMON_EDITORS_LINUX = {


### PR DESCRIPTION
Adds support for the error overlay to detect and open the file with the error in MacVim.

Relates to #2636.