### PR TITLE
CSS Modules local class names for Create React App

### DIFF
--- a/packages/react-scripts/template/src/App.css
+++ b/packages/react-scripts/template/src/App.css
@@ -1,24 +1,24 @@
-:local .root {
+:local .component {
   text-align: center;
 }
 
-:local .logo {
-  animation: logo-spin infinite 20s linear;
-  height: 80px;
-}
-
-:local .header {
+:local .component > header {
   background-color: #222;
   height: 150px;
   padding: 20px;
   color: white;
 }
 
-:local .title {
+:local .component > header > img {
+  animation: logo-spin infinite 20s linear;
+  height: 80px;
+}
+
+:local .component h1 {
   font-size: 1.5em;
 }
 
-:local .intro {
+:local .component p {
   font-size: large;
 }
 

--- a/packages/react-scripts/template/src/App.css
+++ b/packages/react-scripts/template/src/App.css
@@ -1,28 +1,28 @@
-.App {
+:local .root {
   text-align: center;
 }
 
-.App-logo {
-  animation: App-logo-spin infinite 20s linear;
+:local .logo {
+  animation: logo-spin infinite 20s linear;
   height: 80px;
 }
 
-.App-header {
+:local .header {
   background-color: #222;
   height: 150px;
   padding: 20px;
   color: white;
 }
 
-.App-title {
+:local .title {
   font-size: 1.5em;
 }
 
-.App-intro {
+:local .intro {
   font-size: large;
 }
 
-@keyframes App-logo-spin {
+@keyframes :local(logo-spin) {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }

--- a/packages/react-scripts/template/src/App.js
+++ b/packages/react-scripts/template/src/App.js
@@ -5,12 +5,12 @@ import styles from './App.css';
 class App extends Component {
   render() {
     return (
-      <div className={styles.root}>
-        <header className={styles.header}>
-          <img src={logo} className={styles.logo} alt="logo" />
-          <h1 className={styles.title}>Welcome to React</h1>
+      <div className={styles.component}>
+        <header>
+          <img src={logo} alt="logo" />
+          <h1>Welcome to React</h1>
         </header>
-        <p className={styles.intro}>
+        <p>
           To get started, edit <code>src/App.js</code> and save to reload.
         </p>
       </div>

--- a/packages/react-scripts/template/src/App.js
+++ b/packages/react-scripts/template/src/App.js
@@ -1,16 +1,16 @@
 import React, { Component } from 'react';
 import logo from './logo.svg';
-import './App.css';
+import styles from './App.css';
 
 class App extends Component {
   render() {
     return (
-      <div className="App">
-        <header className="App-header">
-          <img src={logo} className="App-logo" alt="logo" />
-          <h1 className="App-title">Welcome to React</h1>
+      <div className={styles.root}>
+        <header className={styles.header}>
+          <img src={logo} className={styles.logo} alt="logo" />
+          <h1 className={styles.title}>Welcome to React</h1>
         </header>
-        <p className="App-intro">
+        <p className={styles.intro}>
           To get started, edit <code>src/App.js</code> and save to reload.
         </p>
       </div>


### PR DESCRIPTION
I though it would be pedagogical to use **CSS Modules** (locally scoped selectors), in a _light_ version where the non-standard ```local:``` directive from the webpack plugin css-loader is being used. If people start making components from Create React App, with this they can’t miss how to do locally scoped css.

The point is that one way or another, we will need this and it is **not** going to be standard

- Even if we do have **.module.css** files in 2.0, we will need a non-standard directive similar to ```:local``` and ```:global```
- We will need some non-standard directives should we use webpack or not
- Otherwise local and global styles have to be in separate files
- It does not seem w3c is going to help with standardization at the moment. The path there seems to be  :scope which requires style elements in the middle of markup, eg. at the top of a component, regions or :host. You would hope they took a look at **ECMAScript Symbols** and found a simpler approach
- besides the :scope aspect, it can also be foreseen that css is going to look even more like css in the future (ie. no scss cssinjs fancy-framework-dying-off-like-flies…)
- Styling React components is not going to be standard. Either some clever mapping of possibly standards-compliant css values over to ECMAScript like css-loader, or a custom react-css-loader.

This was obviously made to work from the extensive work from the last 7 months in #2278 #2285 by @ro-savage slated for version 2.0 at some undetermined future time

harsh words on this topic are in #90

This here is best evidence at the moment