### PR TITLE
Target specific node modules with babel. 

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -29,6 +29,10 @@ const publicPath = '/';
 const publicUrl = '';
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
+// The list of packages in node_modules that babel will include in it's transpile.
+// An array property in the apps package.json called "transpileDependencies"
+const transpileDependencies =
+  require(paths.appPackageJson).transpileDependencies || [];
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
@@ -163,7 +167,12 @@ module.exports = {
           // Process JS with Babel.
           {
             test: /\.(js|jsx|mjs)$/,
-            include: paths.appSrc,
+            include: [
+              paths.appSrc,
+              ...transpileDependencies.map(module =>
+                path.resolve(paths.appNodeModules, module)
+              ),
+            ],
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -29,11 +29,15 @@ const publicPath = '/';
 const publicUrl = '';
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
-// The list of packages in node_modules that babel will include in it's transpile.
+// Application package.json
+const pkg = require(paths.appPackageJson);
 // An array property in the apps package.json called "transpileDependencies"
-const transpileDependencies =
-  require(paths.appPackageJson).transpileDependencies || [];
-
+const transpileModules = pkg.transpileDependencies || [];
+// The list of packages in node_modules that babel will include in it's transpile.
+const babelInclude = [
+  paths.appSrc,
+  ...transpileModules.map(m => path.resolve(paths.appNodeModules, m)),
+];
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
 // The production configuration is different and lives in a separate file.
@@ -167,12 +171,7 @@ module.exports = {
           // Process JS with Babel.
           {
             test: /\.(js|jsx|mjs)$/,
-            include: [
-              paths.appSrc,
-              ...transpileDependencies.map(module =>
-                path.resolve(paths.appNodeModules, module)
-              ),
-            ],
+            include: babelInclude,
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -35,10 +35,15 @@ const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 const publicUrl = publicPath.slice(0, -1);
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
-// The list of packages in node_modules that babel will include in it's transpile.
+// Application package.json
+const pkg = require(paths.appPackageJson);
 // An array property in the apps package.json called "transpileDependencies"
-const transpileDependencies =
-  require(paths.appPackageJson).transpileDependencies || [];
+const transpileModules = pkg.transpileDependencies || [];
+// The list of packages in node_modules that babel will include in it's transpile.
+const babelInclude = [
+  paths.appSrc,
+  ...transpileModules.map(m => path.resolve(paths.appNodeModules, m)),
+];
 
 // Assert this just to be safe.
 // Development builds of React are slow and not intended for production.
@@ -174,12 +179,7 @@ module.exports = {
           // Process JS with Babel.
           {
             test: /\.(js|jsx|mjs)$/,
-            include: [
-              paths.appSrc,
-              ...transpileDependencies.map(module =>
-                path.resolve(paths.appNodeModules, module)
-              ),
-            ],
+            include: babelInclude,
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -35,6 +35,10 @@ const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 const publicUrl = publicPath.slice(0, -1);
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
+// The list of packages in node_modules that babel will include in it's transpile.
+// An array property in the apps package.json called "transpileDependencies"
+const transpileDependencies =
+  require(paths.appPackageJson).transpileDependencies || [];
 
 // Assert this just to be safe.
 // Development builds of React are slow and not intended for production.
@@ -170,7 +174,12 @@ module.exports = {
           // Process JS with Babel.
           {
             test: /\.(js|jsx|mjs)$/,
-            include: paths.appSrc,
+            include: [
+              paths.appSrc,
+              ...transpileDependencies.map(module =>
+                path.resolve(paths.appNodeModules, module)
+              ),
+            ],
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin


### PR DESCRIPTION
The pull request is motivated by: https://github.com/facebookincubator/create-react-app/issues/1125

From what I gathered from the thread, the only reason node_modules was not included in the babel transpile is because of performance, and the make perfect sense. However, app developers should at least be able to specify what modules they need transpiled. 

Each module inside node_modules the applications requires to be transpiled can be specified in the applications `package.json` through the new property `transpileDependencies`.

#### Example

```json
{
  "name": "my-app",
  "version": "0.1.0",
  "private": true,
  "dependencies": {
    "react": "^16.2.0",
    "react-dom": "^16.2.0",
    "react-scripts": "file:../packages/react-scripts/react-scripts-1.0.17.tgz",
    "@my-org/some-es6-module": "^0.0.1"
  },
  "scripts": {
    "start": "react-scripts start",
    "build": "react-scripts build",
    "test": "react-scripts test --env=jsdom",
    "eject": "react-scripts eject"
  },
  "transpileDependencies": [
    "@my-org/some-es6-module"
  ]
}
```

According to [CONTRIBUTING.md](https://github.com/facebookincubator/create-react-app/blob/master/CONTRIBUTING.md) this goes against the Core Ideas of the software, but I couldn't think of a better way (with my limited knowledge of this software) to implement this. Perhaps this will just serve as a concept. 

Initially I wanted to make these changes to `packages/react-scripts/config/paths.js` as that is where most paths are kept, however, this is a dynamic list of paths, so I opted to add the code into each webpack config file.

### Test Plan

Not the most ideal, but I verified this change with the following steps

- `npm run create-react-app my-app`
- `cd my-app`
- `npm install @my-org/some-es6-module`
- `npm start` / `npm run build`
- *Verify the source code was transpiled.





