### PR TITLE
Use mock for CSS-files

### DIFF
--- a/packages/react-scripts/config/jest/styleMock.js
+++ b/packages/react-scripts/config/jest/styleMock.js
@@ -1,0 +1,11 @@
+// @remove-on-eject-begin
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @remove-on-eject-end
+'use strict';
+
+module.exports = {};

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -42,6 +42,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$'],
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
+      '^.+\\.css$': resolve('config/jest/styleMock.js'),
     },
     moduleFileExtensions: [
       'web.js',


### PR DESCRIPTION
**Summary:**

Missing CSS files cause failing tests, this is problematic when using a
preprocessor such as SASS.

**Test plan:**

1. Create a project
2. Delete `src/App.css`.
3. Run `yarn test`.

Verify the test passes and does not fail with a `Cannot find module
'./App.css' from 'App.js'`-error.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
