### PR TITLE
Updated Debugging Tests for VSCode

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1572,12 +1572,9 @@ Use the following [`launch.json`](https://code.visualstudio.com/docs/editor/debu
       "name": "Debug CRA Tests",
       "type": "node",
       "request": "launch",
-      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
-      "runtimeArgs": [
-        "--inspect-brk",
-        "test"
-      ],
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",      
       "args": [
+        "test",
         "--runInBand",
         "--no-cache",
         "--env=jsdom"


### PR DESCRIPTION
The launch configuration code provided is not compatible with VSCode since version 1.19.
The proposed documentation change is based on the response by a VSCode team member.

References:
https://github.com/facebookincubator/create-react-app/issues/3602#issuecomment-352075571
https://github.com/Microsoft/vscode/issues/40293#issuecomment-352017028

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
