### PR TITLE
Update README.md: When to use public folder

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -723,6 +723,7 @@ The `public` folder is useful as a workaround for a number of less common cases:
 * You need a file with a specific name in the build output, such as [`manifest.webmanifest`](https://developer.mozilla.org/en-US/docs/Web/Manifest).
 * You have thousands of images and need to dynamically reference their paths.
 * You want to include a small script like [`pace.js`](http://github.hubspot.com/pace/docs/welcome/) outside of the bundled code.
+* You want to include (a) larger file(s) like `data.json` outside of the bundled code, because it shouldn't/[can't](https://github.com/facebookincubator/create-react-app/issues/2555) run through the build process.
 * Some library may be incompatible with Webpack and you have no other option but to include it as a `<script>` tag.
 
 Note that if you add a `<script>` that declares global variables, you also need to read the next section on using them.


### PR DESCRIPTION
I ran into this issue as well where I had to use a public folder to make larger (2mb) files (.json) available to my application via the public folder and a symlink to the files in the node_modules folder ([how to](https://github.com/javascript-machine-learning/mnist-neural-network-deeplearnjs/commit/2e4a79483be3a32a6bae9d59e51c11345eaed5cf), [issues](https://github.com/facebookincubator/create-react-app/issues/2555)). Just added this use case to the list of "When to use a public folder" for others in case they run into it as well.