### PR TITLE
Move browsers to cross-tool config

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -200,12 +200,6 @@ module.exports = {
                   plugins: () => [
                     require('postcss-flexbugs-fixes'),
                     autoprefixer({
-                      browsers: [
-                        '>1%',
-                        'last 4 versions',
-                        'Firefox ESR',
-                        'not ie < 9', // React doesn't support IE8 anyway
-                      ],
                       flexbox: 'no-2009',
                     }),
                   ],

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -221,12 +221,6 @@ module.exports = {
                         plugins: () => [
                           require('postcss-flexbugs-fixes'),
                           autoprefixer({
-                            browsers: [
-                              '>1%',
-                              'last 4 versions',
-                              'Firefox ESR',
-                              'not ie < 9', // React doesn't support IE8 anyway
-                            ],
                             flexbox: 'no-2009',
                           }),
                         ],

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -43,6 +43,13 @@ module.exports = function(
     eject: 'react-scripts eject',
   };
 
+  appPackage.browserslist = [
+    '>1%',
+    'last 4 versions',
+    'Firefox ESR',
+    'not ie < 9',
+  ];
+
   fs.writeFileSync(
     path.join(appPath, 'package.json'),
     JSON.stringify(appPackage, null, 2)


### PR DESCRIPTION
Hi. I moved browsers from Autoprefixer’s inner option to `browserslist` in `package.json`.

## Reason

* Autoprefixer team recommends only `package.browserslist` as a way to set target browsers.
* `package.browserslist` is used in many different tools. It is used by `autoprefixer`, `stylelint-no-unsupported-browser-features`, `eslint-plugin-compat`, `postcss-cssnext`, `postcss-preset-env`, `postcss-normalize`. The most important, this config will be used in next `babel-preset-env` 7.0.
* It is used by `autoprefixer-info` CLI tool. This CLI tool is part of `autoprefixer` package, but didn’t work correctly without Browserslist config.
* This config is useful not only for tools. The new developer will have the single place to check target browsers in a new project.
* CSS-Tricks [agree](https://css-tricks.com/browserlist-good-idea/) that Browserslist config is really good idea.

## Test

1. Create a new project.
2. Check project’s `package.json` for `browserslist` key.