### PR TITLE
Better documentation for setupTests.js when ejecting

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1334,7 +1334,7 @@ import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 ```
 
->Note: Please keep in mind that, if you decide to `npm run eject` before creating `src/setupTests.js`, the resulting package.json file won't contain any reference to it, [read here](#initializing-test-environment) for a complete description.
+>Note: Keep in mind that if you decide to "eject" before creating `src/setupTests.js`, the resulting `package.json` file won't contain any reference to it. [Read here](#initializing-test-environment) to learn how to add this after ejecting.
 
 Now you can write a smoke test with it:
 
@@ -1425,7 +1425,8 @@ const localStorageMock = {
 global.localStorage = localStorageMock
 ```
 
->Note: Keep in mind that if you decide to `npm run eject` before creating `src/setupTests.js`, the resulting `package.json` file won't contain any reference to it, so you should manually create the property `setupTestFrameworkScriptFile` in the configuration for Jest, something like the following: 
+>Note: Keep in mind that if you decide to "eject" before creating `src/setupTests.js`, the resulting `package.json` file won't contain any reference to it, so you should manually create the property `setupTestFrameworkScriptFile` in the configuration for Jest, something like the following:
+
 >```js
 >"jest": {
 >   // ...

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1286,6 +1286,8 @@ import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 ```
 
+>Note: Please keep in mind that, if you decide to `npm run eject` before creating `src/setupTests.js`, the resulting package.json file won't contain any reference to it, [read here](#initializing-test-environment) for a complete description.
+
 Now you can write a smoke test with it:
 
 ```js

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1425,15 +1425,11 @@ const localStorageMock = {
 global.localStorage = localStorageMock
 ```
 
->Note: Please keep in mind that, if you decide to `npm run eject` before creating `src/setupTests.js`, the resulting package.json file won't contain any reference to it, so you should manually create the property `setupTestFrameworkScriptFile` in the configuration for Jest, something like the following: 
->```
+>Note: Keep in mind that if you decide to `npm run eject` before creating `src/setupTests.js`, the resulting `package.json` file won't contain any reference to it, so you should manually create the property `setupTestFrameworkScriptFile` in the configuration for Jest, something like the following: 
+>```js
 >"jest": {
->   ...
->   "setupFiles": [
->     "<rootDir>/config/polyfills.js"
->   ],
->   "setupTestFrameworkScriptFile": "<rootDir>/src/setupTests.js",
->   ...
+>   // ...
+>   "setupTestFrameworkScriptFile": "<rootDir>/src/setupTests.js"
 >  }
 >  ```
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1375,6 +1375,18 @@ const localStorageMock = {
 global.localStorage = localStorageMock
 ```
 
+>Note: Please keep in mind that, if you decide to `npm run eject` before creating `src/setupTests.js`, the resulting package.json file won't contain any reference to it, so you should manually create the property `setupTestFrameworkScriptFile` in the configuration for Jest, something like the following: 
+>```
+>"jest": {
+>   ...
+>   "setupFiles": [
+>     "<rootDir>/config/polyfills.js"
+>   ],
+>   "setupTestFrameworkScriptFile": "<rootDir>/src/setupTests.js",
+>   ...
+>  }
+>  ```
+
 ### Focusing and Excluding Tests
 
 You can replace `it()` with `xit()` to temporarily exclude a test from being executed.<br>


### PR DESCRIPTION
When running `npm run eject` before creating `src/setupTests.js`, the resulting `package.json` file, won't contain any entry for it - and this is correct in my opinion, since otherwise Jest will crash - but it's useful to have it documented and avoid pointless waste of time.
