### PR TITLE
Travis CI use trusty instead precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 ---
-# Use Ubuntu Precise instead of new default Trusty which cause build fail
-# with pre installed yarn v0.17.8
-# https://github.com/facebookincubator/create-react-app/issues/3054
-# TODO: remove after Trusty environment is updated with a lastet version of yarn
-dist: precise
+dist: trusty
 language: node_js
 node_js:
   - 6


### PR DESCRIPTION
It appears Travis CI trusty version has Yarn v1.3.2 now.

So (#3054) shouldn’t be an issue changing to trusty. As Travis CI [precise support](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status) will be dropped in March 2018 .

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
