### PR TITLE
add experimental babel-plugin-macros support

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -7,6 +7,9 @@
 'use strict';
 
 const plugins = [
+  // Experimental macros support. Will be documented after it's had some time
+  // in the wild.
+  require.resolve('babel-plugin-macros'),
   // class { handleClick = () => { } }
   require.resolve('babel-plugin-transform-class-properties'),
   // The following two plugins use Object.assign directly, instead of Babel's

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "babel-plugin-dynamic-import-node": "1.1.0",
-    "babel-plugin-macros": "^2.0.0",
+    "babel-plugin-macros": "2.0.0",
     "babel-plugin-syntax-dynamic-import": "6.18.0",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-object-rest-spread": "6.26.0",

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -12,6 +12,7 @@
   ],
   "dependencies": {
     "babel-plugin-dynamic-import-node": "1.1.0",
+    "babel-plugin-macros": "^2.0.0",
     "babel-plugin-syntax-dynamic-import": "6.18.0",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-object-rest-spread": "6.26.0",


### PR DESCRIPTION
closes #2730

This will remain undocumented until the brave have tried it in the wild.

**Test Plan:**

There's currently no established way to test changes to
`babel-preset-react-app`. But I did create [`unmaintained-react-scripts-babel-macros`](https://www.npmjs.com/package/unmaintained-react-scripts-babel-macros) [a while back](https://github.com/facebookincubator/create-react-app/issues/2730#issuecomment-328153982) and it worked well.