### PR TITLE
Make the threshold whether assets should be inlined configurable for prod builds

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -54,6 +54,9 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
     { publicPath: Array(cssFilename.split('/').length).join('../') }
   : {};
 
+const definedLimit = require(paths.appPackageJson).inlineLimit;
+const inlineLimit = definedLimit === parseInt(definedLimit, 10) ? parseInt(definedLimit, 10) : 10000;
+
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
 // The development configuration is different and lives in a separate file.
@@ -163,7 +166,7 @@ module.exports = {
             test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
             loader: require.resolve('url-loader'),
             options: {
-              limit: 10000,
+              limit: inlineLimit,
               name: 'static/media/[name].[hash:8].[ext]',
             },
           },


### PR DESCRIPTION
For sites which have a large number of images, each of which has a lower probability of being seen,
combined with assets which rarely change, the other situation was inconvenient. Users were forced
to download the same assets over and over again for unrelated changes.

Apart from that, since each image has a low probability of being loaded, aggressively loading all
images is counterproductive.

By making the threshold configurable, but respecting the same default value, developers can use
techniques as lazyloading images when applicable (which cannot be done if they are part of the bundle)

Refs https://github.com/facebookincubator/create-react-app/issues/3437
