### PR TITLE
add log message for service worker doc

### DIFF
--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -19,6 +19,12 @@ const isLocalhost = Boolean(
 );
 
 export default function register() {
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(
+      'This project is configured to add a service worker caching in the production build. Read more on %o',
+      'http://bit.ly/2vJdu84'
+    );
+  }
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location);


### PR DESCRIPTION
Motivation: https://github.com/facebookincubator/create-react-app/issues/2398

Right now a lot of people is confused because they suddenly have service worker in production. Rather than letting people shoot their feet, i think we need to add this message to dev environment so they will know beforehand that there will be caching etc for PWA on production builds and can make the informed decision before running `npm run build`

screenshot of how it look in the console
![screen shot 2018-01-04 at 12 37 44](https://user-images.githubusercontent.com/9636410/34551414-40d5c3cc-f14c-11e7-83f6-52236cdc4654.png)

