### PR TITLE
Fix path regex match bug

### DIFF
--- a/packages/react-dev-utils/ignoredFiles.js
+++ b/packages/react-dev-utils/ignoredFiles.js
@@ -13,7 +13,8 @@ module.exports = function ignoredFiles(appSrc) {
   return new RegExp(
     `^(?!${path
       .normalize(appSrc + '/')
-      .replace(/[\\]+/g, '/')}).+/node_modules/`,
+      .replace(/[\\]+/g, '/')
+      .replace(/\+/g,'\\+')}).+/node_modules/`,
     'g'
   );
 };

--- a/packages/react-dev-utils/ignoredFiles.js
+++ b/packages/react-dev-utils/ignoredFiles.js
@@ -12,9 +12,7 @@ const escape = require('escape-string-regexp');
 
 module.exports = function ignoredFiles(appSrc) {
   return new RegExp(
-    `^(?!${escape(
-      path.normalize(appSrc + '/').replace(/[\\]+/g, '/')
-    )}).+/node_modules/`,
+    `^(?!${escape(path.normalize(appSrc + '/'))}).+/node_modules/`,
     'g'
   );
 };

--- a/packages/react-dev-utils/ignoredFiles.js
+++ b/packages/react-dev-utils/ignoredFiles.js
@@ -12,7 +12,9 @@ const escape = require('escape-string-regexp');
 
 module.exports = function ignoredFiles(appSrc) {
   return new RegExp(
-    `^(?!${escape(path.normalize(appSrc + '/'))}).+/node_modules/`,
+    `^(?!${escape(
+      path.normalize(appSrc + '/').replace(/[\\]+/g, '/')
+    )}).+/node_modules/`,
     'g'
   );
 };

--- a/packages/react-dev-utils/ignoredFiles.js
+++ b/packages/react-dev-utils/ignoredFiles.js
@@ -8,13 +8,13 @@
 'use strict';
 
 const path = require('path');
+const escape = require('escape-string-regexp');
 
 module.exports = function ignoredFiles(appSrc) {
   return new RegExp(
-    `^(?!${path
-      .normalize(appSrc + '/')
-      .replace(/[\\]+/g, '/')
-      .replace(/\+/g,'\\+')}).+/node_modules/`,
+    `^(?!${escape(
+      path.normalize(appSrc + '/').replace(/[\\]+/g, '/')
+    )}).+/node_modules/`,
     'g'
   );
 };


### PR DESCRIPTION
This change prevents Regex expression errors from being thrown when the paths passed to the function have a `++` in them.

Taking a path like `some/dummy/path/with++/`
the function transforms it to `some\/dummy\/path\/with++\/` the second  `+` is not ignored by the regex engine and hence throws an `Invalid Regular Expression Error`

This pull request changes the path to `some\/dummy\/path\/with\+\+\/` with all `+` escaped.  

I noticed the bug when i tried to run `npm start`  in a directory containing a `+` in it's name.
npm version 5.5.1
node version 8.9.3

```
$ npm start

> demoreact@0.1.0 start C:\Users\Norris\Desktop\C_C++\JS\NodeJs\demoreact
> react-scripts start

Invalid regular expression: /^(?!C:\\Users\\Norris\\Desktop\\C_C++\\JS\\NodeJs\\demoreact\\src\\).+[\\/]node_modules[\\/]/: Nothing to repeat
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! demoreact@0.1.0 start: `react-scripts start`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the demoreact@0.1.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

```

Changing the path for the project solved the problem.
