### PR TITLE
Stop webpack from resolving symlinks to real folders

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -76,6 +76,10 @@ module.exports = {
       path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
   },
   resolve: {
+    // This will tell webpack to not resolve symlinks to actual folders
+    // Symlinks into `src` folder will work with this option
+    // default value is set to `true`
+    symlinks: false,
     // This allows you to set a fallback for where Webpack should look for modules.
     // We placed these paths second because we want `node_modules` to "win"
     // if there are any conflicts. This matches Node resolution mechanism.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -82,6 +82,10 @@ module.exports = {
         .replace(/\\/g, '/'),
   },
   resolve: {
+    // This will tell webpack to not resolve symlinks to actual folders
+    // Symlinks into `src` folder will work with this option
+    // default value is set to `true`
+    symlinks: false,
     // This allows you to set a fallback for where Webpack should look for modules.
     // We placed these paths second because we want `node_modules` to "win"
     // if there are any conflicts. This matches Node resolution mechanism.


### PR DESCRIPTION
Webpack will not resolve symlinks to real folders
This allows to symlink into `src` folder
https://github.com/facebookincubator/create-react-app/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+symlinks

fixes: #3547 and others...
closes: #3689

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

  
  