### PR TITLE
Add editor support for Sublime Dev & VSCode Insiders

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -33,9 +33,13 @@ const COMMON_EDITORS_OSX = {
   '/Applications/Brackets.app/Contents/MacOS/Brackets': 'brackets',
   '/Applications/Sublime Text.app/Contents/MacOS/Sublime Text':
     '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl',
+  '/Applications/Sublime Text Dev.app/Contents/MacOS/Sublime Text':
+    '/Applications/Sublime Text Dev.app/Contents/SharedSupport/bin/subl',
   '/Applications/Sublime Text 2.app/Contents/MacOS/Sublime Text 2':
     '/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl',
   '/Applications/Visual Studio Code.app/Contents/MacOS/Electron': 'code',
+  '/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Electron':
+    'code-insiders',
   '/Applications/AppCode.app/Contents/MacOS/appcode':
     '/Applications/AppCode.app/Contents/MacOS/appcode',
   '/Applications/CLion.app/Contents/MacOS/clion':


### PR DESCRIPTION
Adapting the code for usage elsewhere and noticed it doesn't support the dev channels of some editors.