### PR TITLE
Extend --scripts-version to include .tar.gz format

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -84,6 +84,11 @@ const program = new commander.Command(packageJson.name)
       )}`
     );
     console.log(
+      `      - a .tar.gz archive: ${chalk.green(
+        'https://mysite.com/my-react-scripts-0.8.2.tar.gz'
+      )}`
+    );
+    console.log(
       `    It is not needed unless you specifically want to use a fork.`
     );
     console.log();
@@ -417,7 +422,7 @@ function extractStream(stream, dest) {
 
 // Extract package name from tarball url or path.
 function getPackageName(installPackage) {
-  if (installPackage.indexOf('.tgz') > -1) {
+  if (installPackage.match(/^.+\.(tgz|tar\.gz)$/)) {
     return getTemporaryDirectory()
       .then(obj => {
         let stream;
@@ -440,7 +445,7 @@ function getPackageName(installPackage) {
           `Could not extract the package name from the archive: ${err.message}`
         );
         const assumedProjectName = installPackage.match(
-          /^.+\/(.+?)(?:-\d+.+)?\.tgz$/
+          /^.+\/(.+?)(?:-\d+.+)?\.(tgz|tar\.gz)$/
         )[1];
         console.log(
           `Based on the filename, assuming it is "${chalk.cyan(
@@ -487,6 +492,7 @@ function checkNodeVersion(packageName) {
     packageName,
     'package.json'
   );
+  console.log(packageJsonPath);
   const packageJson = require(packageJsonPath);
   if (!packageJson.engines || !packageJson.engines.node) {
     return;

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -492,7 +492,6 @@ function checkNodeVersion(packageName) {
     packageName,
     'package.json'
   );
-  console.log(packageJsonPath);
   const packageJson = require(packageJsonPath);
   if (!packageJson.engines || !packageJson.engines.node) {
     return;


### PR DESCRIPTION
Closes #3573 

Added a minor change to allow `.tar.gz` extension for the `--scripts-version` CLI.
I didn't enable the `.tar` extension, It's supported by the package([tar-pack](https://github.com/ForbesLindesay/tar-pack)) but it seems not to be supported by Yarn.

Thanks!