### PR TITLE
Add warning when HOST environment variable is set (#3719)

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -54,14 +54,11 @@ const HOST = process.env.HOST || '0.0.0.0';
 if (process.env.HOST) {
   console.log(
     chalk.yellow(
-      "Attempting to bind to $HOST because it was specified. If this was unintentional, check that you haven't mistakenly set it in your shell."
+      `Attempting to bind to HOST environment variable: ${process.env
+        .HOST}. If this was unintentional, check that you haven't mistakenly set it in your shell.`
     )
   );
-  console.log(
-    chalk.cyan(
-      'https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#advanced-configuration\n'
-    )
-  );
+  console.log(chalk.yellow('Learn more here: http://bit.ly/2mwWSwH\n'));
 }
 
 // We attempt to use the default port but if it is busy, we offer the user to

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -53,12 +53,17 @@ const HOST = process.env.HOST || '0.0.0.0';
 
 if (process.env.HOST) {
   console.log(
-    chalk.yellow(
-      `Attempting to bind to HOST environment variable: ${process.env
-        .HOST}. If this was unintentional, check that you haven't mistakenly set it in your shell.`
+    chalk.cyan(
+      `Attempting to bind to HOST environment variable: ${chalk.yellow(
+        chalk.bold(process.env.HOST)
+      )}`
     )
   );
-  console.log(chalk.yellow('Learn more here: http://bit.ly/2mwWSwH\n'));
+  console.log(
+    `If this was unintentional, check that you haven't mistakenly set it in your shell.`
+  );
+  console.log(`Learn more here: ${chalk.yellow('http://bit.ly/2mwWSwH')}`);
+  console.log();
 }
 
 // We attempt to use the default port but if it is busy, we offer the user to

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -51,6 +51,19 @@ if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
 const HOST = process.env.HOST || '0.0.0.0';
 
+if (process.env.HOST) {
+  console.log(
+    chalk.yellow(
+      "Attempting to bind to $HOST because it was specified. If this was unintentional, check that you haven't mistakenly set it in your shell."
+    )
+  );
+  console.log(
+    chalk.cyan(
+      'https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#advanced-configuration\n'
+    )
+  );
+}
+
 // We attempt to use the default port but if it is busy, we offer the user to
 // run on a different port. `choosePort()` Promise resolves to the next free port.
 choosePort(HOST, DEFAULT_PORT)


### PR DESCRIPTION
To see the new warning message run `HOST=8.8.8.8 npm run start`.

Closes #3719 