### PR TITLE
Always use Yarn on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ script:
  - 'if [ $TEST_SUITE = "installs" ]; then tasks/e2e-installs.sh; fi'
  - 'if [ $TEST_SUITE = "kitchensink" ]; then tasks/e2e-kitchensink.sh; fi'
 env:
-  global:
-    - USE_YARN=no
   matrix:
     - TEST_SUITE=simple
     - TEST_SUITE=installs
@@ -25,7 +23,3 @@ matrix:
   include:
     - node_js: 0.10
       env: TEST_SUITE=simple
-# There's a weird Yarn/Lerna bug related to prerelease versions.
-# TODO: reenable after we ship 1.0.
-#    - node_js: 6
-#      env: USE_YARN=yes TEST_SUITE=simple

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -103,13 +103,6 @@ grep -v "postinstall" package.json > temp && mv temp package.json
 npm install
 mv package.json.bak package.json
 
-if [ "$USE_YARN" = "yes" ]
-then
-  # Install Yarn so that the test can use it to install packages.
-  npm install -g yarn
-  yarn cache clean
-fi
-
 # We removed the postinstall, so do it manually
 node bootstrap.js
 

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -58,12 +58,7 @@ function install_package {
 
   # Install `dependencies`
   cd node_modules/$pkg/
-  if [ "$USE_YARN" = "yes" ]
-  then
-    yarn install --production
-  else
-    npm install --only=production
-  fi
+  npm install --only=production
   # Remove our packages to ensure side-by-side versions are used (which we link)
   rm -rf node_modules/{babel-preset-react-app,eslint-config-react-app,react-dev-utils,react-error-overlay,react-scripts}
   cd ../..
@@ -119,13 +114,6 @@ cp package.json package.json.bak
 grep -v "postinstall" package.json > temp && mv temp package.json
 npm install
 mv package.json.bak package.json
-
-if [ "$USE_YARN" = "yes" ]
-then
-  # Install Yarn so that the test can use it to install packages.
-  npm install -g yarn
-  yarn cache clean
-fi
 
 # We removed the postinstall, so do it manually
 node bootstrap.js

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -57,12 +57,7 @@ function install_package {
 
   # Install `dependencies`
   cd node_modules/$pkg/
-  if [ "$USE_YARN" = "yes" ]
-  then
-    yarn install --production
-  else
-    npm install --only=production
-  fi
+  npm install --only=production
   # Remove our packages to ensure side-by-side versions are used (which we link)
   rm -rf node_modules/{babel-preset-react-app,eslint-config-react-app,react-dev-utils,react-error-overlay,react-scripts}
   cd ../..
@@ -145,13 +140,6 @@ then
   cd $temp_app_path
   err_output=`node "$root_path"/packages/create-react-app/index.js test-node-version 2>&1 > /dev/null || echo ''`
   [[ $err_output =~ You\ are\ running\ Node ]] && exit 0 || exit 1
-fi
-
-if [ "$USE_YARN" = "yes" ]
-then
-  # Install Yarn so that the test can use it to install packages.
-  npm install -g yarn
-  yarn cache clean
 fi
 
 # We removed the postinstall, so do it manually here

--- a/tasks/local-test.sh
+++ b/tasks/local-test.sh
@@ -11,7 +11,6 @@ function print_help {
   echo "  --node-version <version>  the node version to use while testing [6]"
   echo "  --git-branch <branch>     the git branch to checkout for testing [the current one]"
   echo "  --test-suite <suite>      which test suite to use ('simple', installs', 'kitchensink', 'all') ['all']"
-  echo "  --yarn                    if present, use yarn as the package manager"
   echo "  --interactive             gain a bash shell after the test run"
   echo "  --help                    print this message and exit"
   echo ""
@@ -22,7 +21,6 @@ cd $(dirname $0)
 node_version=6
 current_git_branch=`git rev-parse --abbrev-ref HEAD`
 git_branch=${current_git_branch}
-use_yarn=no
 test_suite=all
 interactive=false
 
@@ -35,9 +33,6 @@ while [ "$1" != "" ]; do
     "--git-branch")
       shift
       git_branch=$1
-      ;;
-    "--yarn")
-      use_yarn=yes
       ;;
     "--test-suite")
       shift
@@ -107,7 +102,6 @@ CMD
 docker run \
   --env CI=true \
   --env NPM_CONFIG_QUIET=true \
-  --env USE_YARN=${use_yarn} \
   --tty \
   --user node \
   --volume ${PWD}/..:/var/create-react-app \


### PR DESCRIPTION
Our E2E tests are in a very messy state right now. Due to a pile of hacks that accumulated over months, it's very hard to understand what's happening to the packages.

I want to simplify this. As a first step I want to get rid of this variable.

It looks like it's not actually being used. (The branch is always false.) And since Yarn now ships with CI images, we actually *do* use Yarn on CI already.

With this change, we're just eliminating already dead code. Next, I'll try to simplify the actual CI script, but for now I just want the code to reflect what it actually does because it wasn't obvious.