### PR TITLE
Adding some more non-conflicting config files to validFiles

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -619,6 +619,12 @@ function isSafeToCreateProjectIn(root, name) {
     '.hg',
     '.hgignore',
     '.hgcheck',
+    '.npmignore',
+    'mkdocs.yml',
+    'docs',
+    '.travis.yml',
+    '.gitlab-ci.yml',
+    '.gitattributes',
   ];
   console.log();
 


### PR DESCRIPTION
These fairly common project config files shouldn't ever conflict with create-react-app generated files.

**.npmignore**: [Files that should not be published by npm](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package)
**mkdocs.yml**: [Project config for MkDocs utility](http://www.mkdocs.org/user-guide/configuration/)
**docs**: [Default docs dir for MkDocs](http://www.mkdocs.org/user-guide/configuration/#docs_dir)
**.travis.yml**: [Project config for Travis CI](https://docs.travis-ci.com/user/customizing-the-build/)
**.gitlab-ci.yml**: [Project config for GitLab CI](https://docs.gitlab.com/ce/ci/yaml/README.html)
**.gitattributes**: [Path specific git attribute config](https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes)
