### PR TITLE
Specify JavaScript version for Uglify

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -293,6 +293,7 @@ module.exports = {
     // Minify the code.
     new UglifyJsPlugin({
       uglifyOptions: {
+        ecma: 5,
         compress: {
           warnings: false,
           // Disabled because of an issue with Uglify breaking seemingly valid code:

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -53,7 +53,7 @@
     "react-dev-utils": "^4.2.1",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
-    "uglifyjs-webpack-plugin": "1.1.4",
+    "uglifyjs-webpack-plugin": "1.1.6",
     "url-loader": "0.6.2",
     "webpack": "3.8.1",
     "webpack-dev-server": "2.9.4",


### PR DESCRIPTION
Since this now uses `uglify-es` under the hood, we want to restrict language support to ES5.

This is in line with the **current behavior**.

Given we've recently merged browserlist support, we should probably set this option based on specific browsers (in a follow up PR).