### PR TITLE
Follow-up: use private registry

### DIFF
--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -14,7 +14,6 @@ cd "$(dirname "$0")"
 
 # CLI, app, and test module temporary locations
 # http://unix.stackexchange.com/a/84980
-temp_cli_path=`mktemp -d 2>/dev/null || mktemp -d -t 'temp_cli_path'`
 temp_app_path=`mktemp -d 2>/dev/null || mktemp -d -t 'temp_app_path'`
 temp_module_path=`mktemp -d 2>/dev/null || mktemp -d -t 'temp_module_path'`
 
@@ -23,7 +22,7 @@ function cleanup {
   ps -ef | grep 'react-scripts' | grep -v grep | awk '{print $2}' | xargs kill -9
   cd "$root_path"
   # TODO: fix "Device or resource busy" and remove ``|| $CI`
-  rm -rf "$temp_cli_path" "$temp_app_path" "$temp_module_path" || $CI
+  rm -rf "$temp_app_path" "$temp_module_path" || $CI
 }
 
 # Error messages are redirected to stderr
@@ -38,30 +37,6 @@ function handle_exit {
   cleanup
   echo 'Exiting without error.' 1>&2;
   exit
-}
-
-function create_react_app {
-  node "$temp_cli_path"/node_modules/create-react-app/index.js "$@"
-}
-
-function install_package {
-  local pkg=$(basename $1)
-
-  # Clean target (for safety)
-  rm -rf node_modules/$pkg/
-  rm -rf node_modules/**/$pkg/
-
-  # Copy package into node_modules/ ignoring installed deps
-  # rsync -a ${1%/} node_modules/ --exclude node_modules
-  cp -R ${1%/} node_modules/
-  rm -rf node_modules/$pkg/node_modules/
-
-  # Install `dependencies`
-  cd node_modules/$pkg/
-  yarn --production
-  # Remove our packages to ensure side-by-side versions are used (which we link)
-  rm -rf node_modules/{babel-preset-react-app,eslint-config-react-app,react-dev-utils,react-error-overlay,react-scripts}
-  cd ../..
 }
 
 # Check for the existence of one or more files.
@@ -98,41 +73,33 @@ yarn build:prod
 cd ../..
 
 # ******************************************************************************
-# First, pack react-scripts and create-react-app so we can use them.
+# First, publish the monorepo.
 # ******************************************************************************
 
-# Pack CLI
-cd "$root_path"/packages/create-react-app
-cli_path=$PWD/`npm pack`
+# Start local registry
+tmp_registry_log=`mktemp`
+nohup npx verdaccio@2.7.2 &>$tmp_registry_log &
+# Wait for `verdaccio` to boot
+grep -q 'http address' <(tail -f $tmp_registry_log)
 
-# Go to react-scripts
-cd "$root_path"/packages/react-scripts
+# Set registry to local registry
+npm set registry http://localhost:4873
+yarn config set registry http://localhost:4873
 
-# Save package.json because we're going to touch it
-cp package.json package.json.orig
+# Login so we can publish packages
+npx npm-cli-login@0.0.10 -u user -p password -e user@example.com -r http://localhost:4873 --quotes
 
-# Replace own dependencies (those in the `packages` dir) with the local paths
-# of those packages.
-node "$root_path"/tasks/replace-own-deps.js
-
-# Finally, pack react-scripts
-scripts_path="$root_path"/packages/react-scripts/`npm pack`
-
-# Restore package.json
-rm package.json
-mv package.json.orig package.json
+# Publish the monorepo
+git clean -f
+./tasks/release.sh --yes --force-publish=* --skip-git --cd-version=prerelease --exact --npm-tag=latest
 
 # ******************************************************************************
-# Now that we have packed them, create a clean app folder and install them.
+# Now that we have published them, create a clean app folder and install them.
 # ******************************************************************************
-
-# Install the CLI in a temporary location
-cd "$temp_cli_path"
-yarn add "$cli_path"
 
 # Install the app in a temporary location
 cd $temp_app_path
-create_react_app --scripts-version="$scripts_path" --internal-testing-template="$root_path"/packages/react-scripts/fixtures/kitchensink test-kitchensink
+npx create-react-app --internal-testing-template="$root_path"/packages/react-scripts/fixtures/kitchensink test-kitchensink
 
 # Install the test module
 cd "$temp_module_path"
@@ -146,14 +113,8 @@ yarn add test-integrity@^2.0.1
 # Enter the app directory
 cd "$temp_app_path/test-kitchensink"
 
-# Link to our preset
-install_package "$root_path"/packages/babel-preset-react-app
-# Link to error overlay package because now it's a dependency
-# of react-dev-utils and not react-scripts
-install_package "$root_path"/packages/react-error-overlay
-
 # Link to test module
-install_package "$temp_module_path/node_modules/test-integrity"
+npm link "$temp_module_path/node_modules/test-integrity"
 
 # Test the build
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
@@ -198,16 +159,10 @@ E2E_FILE=./build/index.html \
 # ******************************************************************************
 
 # Eject...
-echo yes | npm run eject
-
-# ...but still link to the local packages
-install_package "$root_path"/packages/babel-preset-react-app
-install_package "$root_path"/packages/eslint-config-react-app
-install_package "$root_path"/packages/react-error-overlay
-install_package "$root_path"/packages/react-dev-utils
+echo yes | yarn eject
 
 # Link to test module
-install_package "$temp_module_path/node_modules/test-integrity"
+npm link "$temp_module_path/node_modules/test-integrity"
 
 # Test the build
 REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -59,6 +59,12 @@ set -x
 cd ..
 root_path=$PWD
 
+if hash npm 2>/dev/null
+then
+  npm i -g npm@latest
+  npm cache clean || npm cache verify
+fi
+
 # Prevent bootstrap, we only want top-level dependencies
 cp package.json package.json.bak
 grep -v "postinstall" package.json > temp && mv temp package.json


### PR DESCRIPTION
This PR removes `install_package` and emulates true end-user use via publishing for the installs and kitchensink tests.

Follow up to #3744.