### PR TITLE
Add cache busting for the service worker so it works correctly for more people by default

### DIFF
--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -30,7 +30,9 @@ export default function register() {
     }
 
     window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+      // Avoid service worker caching issues.
+      const noCache = new Date() * 1;
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js?nocache=${noCache}`;
 
       if (isLocalhost) {
         // This is running on localhost. Lets check if a service worker still exists or not.


### PR DESCRIPTION
This simply adds a cache busting url param to the service worker url.  Appears to work well in production.  This does far less than #2563 but might resolve SWI3 in https://github.com/facebookincubator/create-react-app/issues/2554 ?
