### PR TITLE
Enable Yarn check files

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
 --install.no-lockfile true
+--install.check-files true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,3 @@
 --install.no-lockfile true
 --install.check-files true
+--add.no-lockfile true


### PR DESCRIPTION
Adds ~2-3 seconds to install time, but can save some headaches.
Pretty important when multiple users start fiddling with package.json files and we start using more advanced package manager settings.

Also will help recover your tree after you use `npm` by accident without wiping out all `node_modules`.