### PR TITLE
Loosen Babel preset to use browserslist

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -52,7 +52,7 @@ module.exports = function(api, opts) {
           // This is probably a fine default to help trim down bundles when
           // end-users inevitably import '@babel/polyfill'.
           useBuiltIns: 'entry',
-          // Do not transform modules to CJS.
+          // Do not transform modules to CJS
           modules: false,
         },
       ],

--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -46,16 +46,13 @@ module.exports = function(api, opts) {
         // Latest stable ECMAScript features
         require('@babel/preset-env').default,
         {
-          targets: {
-            // React parses on ie 9, so we should too
-            ie: 9,
-          },
-          // We currently minify with uglify
-          // Remove after https://github.com/mishoo/UglifyJS2/issues/448
-          forceAllTransforms: true,
-          // Disable polyfill transforms
-          useBuiltIns: false,
-          // Do not transform modules to CJS
+          // `entry` transforms `@babel/polyfill` into individual requires for
+          // the targeted browsers. This is safer than `usage` which performs
+          // static code analysis to determine what's required.
+          // This is probably a fine default to help trim down bundles when
+          // end-users inevitably import '@babel/polyfill'.
+          useBuiltIns: 'entry',
+          // Do not transform modules to CJS.
           modules: false,
         },
       ],
@@ -104,7 +101,7 @@ module.exports = function(api, opts) {
       !isEnvTest && [
         require('@babel/plugin-transform-regenerator').default,
         {
-          // Async functions are converted to generators by babel-preset-env
+          // Async functions are converted to generators by @babel/preset-env
           async: false,
         },
       ],

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -43,12 +43,12 @@ module.exports = function(
     eject: 'react-scripts eject',
   };
 
-  appPackage.browserslist = [
-    '>1%',
-    'last 4 versions',
-    'Firefox ESR',
-    'not ie < 9',
-  ];
+  appPackage.browserslist = {
+    development: ['chrome', 'firefox', 'edge'].map(
+      browser => `last 2 ${browser} versions`
+    ),
+    production: ['>1%', 'last 4 versions', 'Firefox ESR', 'not ie < 11'],
+  };
 
   fs.writeFileSync(
     path.join(appPath, 'package.json'),

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -22,6 +22,7 @@ original_yarn_registry_url=`yarn config get registry`
 
 function cleanup {
   echo 'Cleaning up.'
+  unset BROWSERSLIST
   ps -ef | grep 'react-scripts' | grep -v grep | awk '{print $2}' | xargs kill -9
   cd "$root_path"
   # TODO: fix "Device or resource busy" and remove ``|| $CI`
@@ -113,6 +114,9 @@ yarn add test-integrity@^2.0.1
 
 # Enter the app directory
 cd "$temp_app_path/test-kitchensink"
+
+# In kitchensink, we want to test all transforms
+export BROWSERSLIST='ie 9'
 
 # Link to test module
 npm link "$temp_module_path/node_modules/test-integrity"

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -151,14 +151,12 @@ E2E_URL="http://localhost:3001" \
   REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
   CI=true NODE_PATH=src \
   NODE_ENV=development \
-  BABEL_ENV=test \
   node_modules/.bin/mocha --compilers js:@babel/register --require @babel/polyfill integration/*.test.js
 # Test "production" environment
 E2E_FILE=./build/index.html \
   CI=true \
   NODE_PATH=src \
   NODE_ENV=production \
-  BABEL_ENV=test \
   PUBLIC_URL=http://www.example.org/spa/ \
   node_modules/.bin/mocha --compilers js:@babel/register --require @babel/polyfill integration/*.test.js
 
@@ -204,14 +202,12 @@ E2E_URL="http://localhost:3002" \
   REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
   CI=true NODE_PATH=src \
   NODE_ENV=development \
-  BABEL_ENV=test \
   node_modules/.bin/mocha --compilers js:@babel/register --require @babel/polyfill integration/*.test.js
 
 # Test "production" environment
 E2E_FILE=./build/index.html \
   CI=true \
   NODE_ENV=production \
-  BABEL_ENV=test \
   NODE_PATH=src \
   PUBLIC_URL=http://www.example.org/spa/ \
   node_modules/.bin/mocha --compilers js:@babel/register --require @babel/polyfill integration/*.test.js

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -151,12 +151,14 @@ E2E_URL="http://localhost:3001" \
   REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
   CI=true NODE_PATH=src \
   NODE_ENV=development \
+  BABEL_ENV=test \
   node_modules/.bin/mocha --compilers js:@babel/register --require @babel/polyfill integration/*.test.js
 # Test "production" environment
 E2E_FILE=./build/index.html \
   CI=true \
   NODE_PATH=src \
   NODE_ENV=production \
+  BABEL_ENV=test \
   PUBLIC_URL=http://www.example.org/spa/ \
   node_modules/.bin/mocha --compilers js:@babel/register --require @babel/polyfill integration/*.test.js
 
@@ -202,12 +204,14 @@ E2E_URL="http://localhost:3002" \
   REACT_APP_SHELL_ENV_MESSAGE=fromtheshell \
   CI=true NODE_PATH=src \
   NODE_ENV=development \
+  BABEL_ENV=test \
   node_modules/.bin/mocha --compilers js:@babel/register --require @babel/polyfill integration/*.test.js
 
 # Test "production" environment
 E2E_FILE=./build/index.html \
   CI=true \
   NODE_ENV=production \
+  BABEL_ENV=test \
   NODE_PATH=src \
   PUBLIC_URL=http://www.example.org/spa/ \
   node_modules/.bin/mocha --compilers js:@babel/register --require @babel/polyfill integration/*.test.js


### PR DESCRIPTION
This removes the `ie 9` target and `forceAllTransforms` since we're dropping IE9 support by default.

We want to allow target browsers to be configurable via the `browserslist` key in `package.json`.
This also enables `useBuiltIns` for smaller bundles.

I've also adjusted the defaults we generate for a more ergonomic development experience.

----

There's still no story for users upgrading from * -> 2.x (it'd use browserlist defaults currently).