### PR TITLE
Compile dependencies with babel-preset-env

### DIFF
--- a/packages/babel-preset-react-app/dependencies.js
+++ b/packages/babel-preset-react-app/dependencies.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+module.exports = function(api, opts) {
+  if (!opts) {
+    opts = {};
+  }
+
+  // This is similar to how `env` works in Babel:
+  // https://babeljs.io/docs/usage/babelrc/#env-option
+  // We are not using `env` because it’s ignored in versions > babel-core@6.10.4:
+  // https://github.com/babel/babel/issues/4539
+  // https://github.com/facebookincubator/create-react-app/issues/720
+  // It’s also nice that we can enforce `NODE_ENV` being specified.
+  var env = process.env.BABEL_ENV || process.env.NODE_ENV;
+  var isEnvDevelopment = env === 'development';
+  var isEnvProduction = env === 'production';
+  var isEnvTest = env === 'test';
+  if (!isEnvDevelopment && !isEnvProduction && !isEnvTest) {
+    throw new Error(
+      'Using `babel-preset-react-app` requires that you specify `NODE_ENV` or ' +
+        '`BABEL_ENV` environment variables. Valid values are "development", ' +
+        '"test", and "production". Instead, received: ' +
+        JSON.stringify(env) +
+        '.'
+    );
+  }
+
+  return {
+    presets: [
+      isEnvTest && [
+        // ES features necessary for user's Node version
+        require('@babel/preset-env').default,
+        {
+          targets: {
+            node: 'current',
+          },
+          // Do not transform modules to CJS
+          modules: false,
+        },
+      ],
+      (isEnvProduction || isEnvDevelopment) && [
+        // Latest stable ECMAScript features
+        require('@babel/preset-env').default,
+        {
+          // Do not transform modules to CJS
+          modules: false,
+        },
+      ],
+    ].filter(Boolean),
+  };
+};

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/facebookincubator/create-react-app/issues"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "dependencies.js"
   ],
   "dependencies": {
     "@babel/core": "7.0.0-beta.36",

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -159,7 +159,8 @@ module.exports = {
               name: 'static/media/[name].[hash:8].[ext]',
             },
           },
-          // Process JS with Babel.
+          // Process application JS with Babel.
+          // The preset includes JSX, Flow, and some ESnext features.
           {
             test: /\.(js|jsx|mjs)$/,
             include: paths.appSrc,
@@ -172,6 +173,18 @@ module.exports = {
               // This is a feature of `babel-loader` for webpack (not Babel itself).
               // It enables caching results in ./node_modules/.cache/babel-loader/
               // directory for faster rebuilds.
+              cacheDirectory: true,
+            },
+          },
+          // Process any JS outside of the app with Babel.
+          // Unlike the application JS, we only compile the standard ES features.
+          {
+            test: /\.js$/,
+            loader: require.resolve('babel-loader'),
+            options: {
+              babelrc: false,
+              compact: false,
+              presets: [require.resolve('babel-preset-react-app/dependencies')],
               cacheDirectory: true,
             },
           },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -167,7 +167,8 @@ module.exports = {
               name: 'static/media/[name].[hash:8].[ext]',
             },
           },
-          // Process JS with Babel.
+          // Process application JS with Babel.
+          // The preset includes JSX, Flow, and some ESnext features.
           {
             test: /\.(js|jsx|mjs)$/,
             include: paths.appSrc,
@@ -178,6 +179,18 @@ module.exports = {
               presets: [require.resolve('babel-preset-react-app')],
               // @remove-on-eject-end
               compact: true,
+            },
+          },
+          // Process any JS outside of the app with Babel.
+          // Unlike the application JS, we only compile the standard ES features.
+          {
+            test: /\.js$/,
+            loader: require.resolve('babel-loader'),
+            options: {
+              babelrc: false,
+              compact: false,
+              presets: [require.resolve('babel-preset-react-app/dependencies')],
+              cacheDirectory: true,
             },
           },
           // The notation here is somewhat confusing.


### PR DESCRIPTION
Proof of concept for https://github.com/facebookincubator/create-react-app/issues/1125.
This currently runs *all* `node_modules` through `babel-preset-env`.

(Which was unsafe in Babel 6, but should—maybe—be safe in Babel 7.)

I don't know the impact on the build time. It'll definitely make the cold start slower but hopefully repeated builds will be okay. We need some measurements with larger projects here: https://mobile.twitter.com/dan_abramov/status/952248179478745089.

I intentionally only did this for webpack. I don’t think we need to do this for tests because you control the Node version on which you run the tests, unlike the user’s browser. And it’s never required to compile because we intentionally don’t allow any custom transforms (like JSX). Only “real” JS gets compiled.

TODO:

- [x] Measure build time impact
- [ ] Consider opt-out heuristics (e.g. "too old" `engines` field that implies we don't need compilation)
- [ ] Verify this doesn't break third-party code
- [ ] Verify generators and async/await work in deps
- [ ] Verify helpers for the above are being shared (e.g. runtime transform)
- [ ] Verify `.babelrc` in packages gets ignored
- [ ] Create end-to-end tests for these situations
