### PR TITLE
Add an explicit link to our Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.


### PR DESCRIPTION
All FB open source projects including this one enforce [our code of conduct](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct), but I just realized we haven't explicitly linked to it from a Markdown file. So I'm doing just that.
