### PR TITLE
Bump detect-port-alt

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -40,7 +40,7 @@
     "babel-code-frame": "6.26.0",
     "chalk": "1.1.3",
     "cross-spawn": "5.1.0",
-    "detect-port-alt": "1.1.4",
+    "detect-port-alt": "1.1.5",
     "escape-string-regexp": "1.0.5",
     "filesize": "3.5.11",
     "global-modules": "1.0.0",

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -40,7 +40,7 @@
     "babel-code-frame": "6.26.0",
     "chalk": "1.1.3",
     "cross-spawn": "5.1.0",
-    "detect-port-alt": "1.1.3",
+    "detect-port-alt": "1.1.4",
     "escape-string-regexp": "1.0.5",
     "filesize": "3.5.11",
     "global-modules": "1.0.0",


### PR DESCRIPTION
This should include some error handling that would work around https://github.com/facebookincubator/create-react-app/issues/3690.

I haven't verified it works yet, but the last time I tried to do similar edits locally, and then inserted a `throw` in the same place the error was reported, `detect-port` said the ports were taken and jumped to a high port. I'm not sure why it didn't give me an error instead but this seems edge casey enough that I don't care strongly how it works as long as it doesn't crash.