### PR TITLE
Test Node 9 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 dist: trusty
 language: node_js
 node_js:
-  - 6
   - 8
+  - 9
 cache:
   directories:
   - node_modules
@@ -21,6 +21,9 @@ env:
     - TEST_SUITE=installs
     - TEST_SUITE=kitchensink
 matrix:
+  include:
+    - node_js: 6
+      env: TEST_SUITE=kitchensink
   include:
     - node_js: 0.10
       env: TEST_SUITE=old-node


### PR DESCRIPTION
Replaces Node 6 tests with Node 9.
Adds an extra Node 6 kitchensink test for safety.

Since Travis runs them in parallel it's probably okay to add one more.
Or maybe we could exclude one of Node 9 tests somehow?
