### PR TITLE
Support Jest --watchAll flag

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -36,8 +36,8 @@ const argv = process.argv.slice(2);
 // Watch unless on CI in coverage mode, or explicitly running all tests
 if (
   !process.env.CI &&
-  argv.indexOf('--coverage') < 0 &&
-  argv.indexOf('--watchAll') < 0
+  argv.indexOf('--coverage') === -1 &&
+  argv.indexOf('--watchAll') === -1
 ) {
   argv.push('--watch');
 }

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -33,8 +33,12 @@ if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
 const jest = require('jest');
 const argv = process.argv.slice(2);
 
-// Watch unless on CI or in coverage mode
-if (!process.env.CI && argv.indexOf('--coverage') < 0) {
+// Watch unless on CI in coverage mode, or explicitly running all tests
+if (
+  !process.env.CI &&
+  argv.indexOf('--coverage') < 0 &&
+  argv.indexOf('--watchAll') < 0
+) {
   argv.push('--watch');
 }
 

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -33,7 +33,7 @@ if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
 const jest = require('jest');
 const argv = process.argv.slice(2);
 
-// Watch unless on CI in coverage mode, or explicitly running all tests
+// Watch unless on CI, in coverage mode, or explicitly running all tests
 if (
   !process.env.CI &&
   argv.indexOf('--coverage') === -1 &&


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/create-react-app/issues/3801.

To use, run `yarn test --watchAll` or `npm test -- --watchAll` or add `--watchAll` to the test command in your `scripts` section of `package.json`.