### PR TITLE
Use wmic to get process list on Windows

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -56,8 +56,7 @@ const COMMON_EDITORS_OSX = {
     '/Applications/RubyMine.app/Contents/MacOS/rubymine',
   '/Applications/WebStorm.app/Contents/MacOS/webstorm':
     '/Applications/WebStorm.app/Contents/MacOS/webstorm',
-  '/Applications/MacVim.app/Contents/MacOS/MacVim':
-    'mvim',
+  '/Applications/MacVim.app/Contents/MacOS/MacVim': 'mvim',
 };
 
 const COMMON_EDITORS_LINUX = {
@@ -188,23 +187,19 @@ function guessEditor() {
         }
       }
     } else if (process.platform === 'win32') {
+      // Some processes need elevated rights to get its executable path.
+      // Just filter them out upfront. This also saves 10-20ms on the command.
       const output = child_process
-        .execSync('powershell -Command "Get-Process | Select-Object Path"', {
-          stdio: ['pipe', 'pipe', 'ignore'],
-        })
+        .execSync(
+          'wmic process where "executablepath is not null" get executablepath'
+        )
         .toString();
       const runningProcesses = output.split('\r\n');
       for (let i = 0; i < runningProcesses.length; i++) {
-        // `Get-Process` sometimes returns empty lines
-        if (!runningProcesses[i]) {
-          continue;
-        }
-
-        const fullProcessPath = runningProcesses[i].trim();
-        const shortProcessName = path.basename(fullProcessPath);
-
-        if (COMMON_EDITORS_WIN.indexOf(shortProcessName) !== -1) {
-          return [fullProcessPath];
+        const processPath = runningProcesses[i].trim();
+        const processName = path.basename(processPath);
+        if (COMMON_EDITORS_WIN.indexOf(processName) !== -1) {
+          return [processPath];
         }
       }
     } else if (process.platform === 'linux') {


### PR DESCRIPTION
- `powershell -Command "Get-Process | Select-Object Path"`: ~1300ms (current implementation)
- `Get-Process | Select-Object Path` on already running PowerShell daemon/agent: ~300ms (implementation in #2711)
- `wmic process where "executablepath is not null" get executablepath`: ~110ms (this implementation)

_Tested on Windows 10 with an i5-4690_

For comparison on other platforms:

- `ps x` on macOS: ~60ms
