### PR TITLE
Remove PropTypes from production build (#209)

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -101,6 +101,13 @@ module.exports = function(api, opts) {
           regenerator: true,
         },
       ],
+      isEnvProduction && [
+        // Remove PropTypes from production build
+        require('babel-plugin-transform-react-remove-prop-types').default,
+        {
+          removeImport: true,
+        },
+      ],
       // function* () { yield 42; yield 43; }
       !isEnvTest && [
         require('@babel/plugin-transform-regenerator').default,

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -26,6 +26,7 @@
     "@babel/preset-flow": "7.0.0-beta.37",
     "@babel/preset-react": "7.0.0-beta.37",
     "babel-plugin-macros": "2.0.0",
-    "babel-plugin-transform-dynamic-import": "2.0.0"
+    "babel-plugin-transform-dynamic-import": "2.0.0",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.12"
   }
 }

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -187,6 +187,7 @@ module.exports = {
     'import/no-webpack-loader-syntax': 'error',
 
     // https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules
+    'react/forbid-foreign-prop-types': 'warn',
     'react/jsx-no-comment-textnodes': 'warn',
     'react/jsx-no-duplicate-props': ['warn', { ignoreCase: true }],
     'react/jsx-no-target-blank': 'warn',

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -187,7 +187,6 @@ module.exports = {
     'import/no-webpack-loader-syntax': 'error',
 
     // https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules
-    'react/forbid-foreign-prop-types': 'warn',
     'react/jsx-no-comment-textnodes': 'warn',
     'react/jsx-no-duplicate-props': ['warn', { ignoreCase: true }],
     'react/jsx-no-target-blank': 'warn',


### PR DESCRIPTION
Apply `babel-plugin-transform-react-remove-prop-types` when building for production.

Closes #209 