### PR TITLE
Use a better* solution for the missing CMD file issue on Windows

### DIFF
--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -248,9 +248,11 @@ inquirer
         // https://github.com/facebookincubator/create-react-app/pull/3806#issuecomment-357781035
         // Yarn is diligent about cleaning up after itself, but this causes the react-scripts.cmd file
         // to be deleted while it is running. This trips Windows up after the eject completes.
-        // We'll read the batch file and later "write it back" to match npm behavior.
+        // We'll reduce the the batch file to a single line to avoid CMD tripping over the file going missing.
         try {
-          windowsCmdFileContent = fs.readFileSync(windowsCmdFilePath);
+          windowsCmdFileContent = fs.readFileSync(windowsCmdFilePath).toString('ansi');
+          windowsCmdFileContent = windowsCmdFileContent.replace(/(\()\r\n\s*|\s*\r\n\s*(\))/g, '$1$2').replace(/\s*\r\n\s*/g, ' & ') + ' & EXIT';
+          fs.writeFileSync(windowsCmdFilePath, windowsCmdFileContent);
         } catch (err) {
           // If this fails we're not worse off than if we didn't try to fix it.
         }
@@ -258,14 +260,6 @@ inquirer
 
       console.log(cyan('Running yarn...'));
       spawnSync('yarnpkg', ['--cwd', process.cwd()], { stdio: 'inherit' });
-
-      if (windowsCmdFileContent && !fs.existsSync(windowsCmdFilePath)) {
-        try {
-          fs.writeFileSync(windowsCmdFilePath, windowsCmdFileContent);
-        } catch (err) {
-          // If this fails we're not worse off than if we didn't try to fix it.
-        }
-      }
     } else {
       console.log(cyan('Running npm install...'));
       spawnSync('npm', ['install', '--loglevel', 'error'], {

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -250,8 +250,13 @@ inquirer
         // to be deleted while it is running. This trips Windows up after the eject completes.
         // We'll reduce the the batch file to a single line to avoid CMD tripping over the file going missing.
         try {
-          windowsCmdFileContent = fs.readFileSync(windowsCmdFilePath).toString('ansi');
-          windowsCmdFileContent = windowsCmdFileContent.replace(/(\()\r\n\s*|\s*\r\n\s*(\))/g, '$1$2').replace(/\s*\r\n\s*/g, ' & ') + ' & EXIT';
+          windowsCmdFileContent = fs
+            .readFileSync(windowsCmdFilePath)
+            .toString('ansi');
+          windowsCmdFileContent =
+            windowsCmdFileContent
+              .replace(/(\()\r\n\s*|\s*\r\n\s*(\))/g, '$1$2')
+              .replace(/\s*\r\n\s*/g, ' & ') + ' & EXIT';
           fs.writeFileSync(windowsCmdFilePath, windowsCmdFileContent);
         } catch (err) {
           // If this fails we're not worse off than if we didn't try to fix it.


### PR DESCRIPTION
This is a follow up to #3806. Instead of recreating the file and
leaving it there, we trick CMD to stop reading the file after the
first line by modifying the CMD script.

*This is a "better" solution because:

1. It doesn't leave obsolete files around
2. This fix can be incorporated into npm and yarn via https://github.com/npm/cmd-shim/