### PR TITLE
update react error overlay to be compatible with chalk 2

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -669,6 +669,7 @@ function getProxy() {
     }
   }
 }
+
 function checkThatNpmCanReadCwd() {
   const cwd = process.cwd();
   let childOutput = null;

--- a/packages/react-error-overlay/build.js
+++ b/packages/react-error-overlay/build.js
@@ -5,11 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 const webpack = require('webpack');
-const chalk = require('chalk');
+const Chalk = require('chalk');
 const webpackConfig = require('./webpack.config.js');
 const iframeWebpackConfig = require('./webpack.config.iframe.js');
 const rimraf = require('rimraf');
 const chokidar = require('chokidar');
+const chalk = new Chalk.constructor({ enabled: true, level: 1 });
 
 const args = process.argv.slice(2);
 const watchMode = args[0] === '--watch' || args[0] === '-w';


### PR DESCRIPTION
updated react error overlay to be compatible with chalk 2 with @Timer given instructions
<img width="1440" alt="screen shot 2018-01-18 at 1 27 50 am" src="https://user-images.githubusercontent.com/20615964/35069594-e583625a-fbef-11e7-9689-8f6e30020646.png">
<img width="1440" alt="screen shot 2018-01-18 at 1 28 04 am" src="https://user-images.githubusercontent.com/20615964/35069595-e5e34058-fbef-11e7-8d60-38c39b67e55f.png">

