### PR TITLE
Provide callbacks in serviceWorker (next)

### DIFF
--- a/packages/react-scripts/template/src/serviceWorker.js
+++ b/packages/react-scripts/template/src/serviceWorker.js
@@ -18,7 +18,7 @@ const isLocalhost = Boolean(
     )
 );
 
-export function register() {
+export default function register(config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location);
@@ -34,7 +34,7 @@ export function register() {
 
       if (isLocalhost) {
         // This is running on localhost. Lets check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl);
+        checkValidServiceWorker(swUrl, config);
 
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
@@ -46,13 +46,13 @@ export function register() {
         });
       } else {
         // Is not local host. Just register service worker
-        registerValidSW(swUrl);
+        registerValidSW(swUrl, config);
       }
     });
   }
 }
 
-function registerValidSW(swUrl) {
+function registerValidSW(swUrl, config) {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
@@ -66,11 +66,21 @@ function registerValidSW(swUrl) {
               // It's the perfect time to display a "New content is
               // available; please refresh." message in your web app.
               console.log('New content is available; please refresh.');
+
+              // Execute callback
+              if (config.onUpdate) {
+                config.onUpdate(registration);
+              }
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
               console.log('Content is cached for offline use.');
+
+              // Execute callback
+              if (config.onSuccess) {
+                config.onSuccess(registration);
+              }
             }
           }
         };
@@ -81,7 +91,7 @@ function registerValidSW(swUrl) {
     });
 }
 
-function checkValidServiceWorker(swUrl) {
+function checkValidServiceWorker(swUrl, config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
     .then(response => {
@@ -98,7 +108,7 @@ function checkValidServiceWorker(swUrl) {
         });
       } else {
         // Service worker found. Proceed as normal.
-        registerValidSW(swUrl);
+        registerValidSW(swUrl, config);
       }
     })
     .catch(() => {

--- a/packages/react-scripts/template/src/serviceWorker.js
+++ b/packages/react-scripts/template/src/serviceWorker.js
@@ -18,7 +18,7 @@ const isLocalhost = Boolean(
     )
 );
 
-export default function register(config) {
+export function register(config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location);


### PR DESCRIPTION
This is PR version of #3375 for `next` branch.

Adding two callbacks in `serviceWorker.js` file:
- `onUpdate` - executed when service worker has been updated in the background
  (console logs _New content is available; please refresh._)
- `onSuccess` - executed after service worker has been installed for the first time
  (console logs _Content is cached for offline use._)

To use it inside application to show notification (toast/ icon etc) register service worker inside App.js file:

```js
// App.js

import { register as registerServiceWorker } from './serviceWorker.js'

export default class App {
  constructor() {
    // Register service worker and add onUpdate callback
    registerServiceWorker({
      onUpdate: this.handleServiceWorkerUpdate
    })
  }

  // Simplest notification implementation example.
  handleServiceWorkerUpdate(registration) {
    if (window.confirm('New update has been installed, click to restart')) {
      window.location.reload()
    }
  }
}
```