### PR TITLE
Add Rails Webpacker as alternative to CRA in Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Here’s a few common cases where you might want to try something else:
 
 * If you want to **try React** without hundreds of transitive build tool dependencies, consider [using a single HTML file or an online sandbox instead](https://reactjs.org/docs/try-react.html).
 
-* If you need to **integrate React code with a server-side template framework** like Rails or Django, or if you’re **not building a single-page app**, consider using [nwb](https://github.com/insin/nwb), [Neutrino](https://neutrino.js.org/) or [Rails Webpacker](https://github.com/rails/webpacker) which are more flexible.
+* If you need to **integrate React code with a server-side template framework** like Rails or Django, or if you’re **not building a single-page app**, consider using [nwb](https://github.com/insin/nwb), or [Neutrino](https://neutrino.js.org/) which are more flexible. For Rails specifically, you can use [Rails Webpacker](https://github.com/rails/webpacker).
 
 * If you need to **publish a React component**, [nwb](https://github.com/insin/nwb) can [also do this](https://github.com/insin/nwb#react-components-and-libraries), as well as [Neutrino's react-components preset](https://neutrino.js.org/packages/react-components/).
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Here’s a few common cases where you might want to try something else:
 
 * If you want to **try React** without hundreds of transitive build tool dependencies, consider [using a single HTML file or an online sandbox instead](https://reactjs.org/docs/try-react.html).
 
-* If you need to **integrate React code with a server-side template framework** like Rails or Django, or if you’re **not building a single-page app**, consider using [nwb](https://github.com/insin/nwb) or [Neutrino](https://neutrino.js.org/) which are more flexible.
+* If you need to **integrate React code with a server-side template framework** like Rails or Django, or if you’re **not building a single-page app**, consider using [nwb](https://github.com/insin/nwb), [Neutrino](https://neutrino.js.org/) or [Rails Webpacker](https://github.com/rails/webpacker) which are more flexible.
 
 * If you need to **publish a React component**, [nwb](https://github.com/insin/nwb) can [also do this](https://github.com/insin/nwb#react-components-and-libraries), as well as [Neutrino's react-components preset](https://neutrino.js.org/packages/react-components/).
 


### PR DESCRIPTION
Rails Webpacker is the "official" Rails way to use modern JavaScript (ES6, modules, etc.) *within* a Rails app, totally bypassing and even replacing the traditional asset pipeline. For uses of React in Rails without the intention to build a SPA, this is a very straightforward approach.