### PR TITLE
Don't use app node_modules folder as a resolve fallback

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -95,7 +95,7 @@ module.exports = {
     // We placed these paths second because we want `node_modules` to "win"
     // if there are any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
-    modules: ['node_modules', paths.appNodeModules].concat(
+    modules: ['node_modules'].concat(
       // It is guaranteed to exist because we tweak it in `env.js`
       process.env.NODE_PATH.split(path.delimiter).filter(Boolean)
     ),

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -102,7 +102,7 @@ module.exports = {
     // We placed these paths second because we want `node_modules` to "win"
     // if there are any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
-    modules: ['node_modules', paths.appNodeModules].concat(
+    modules: ['node_modules'].concat(
       // It is guaranteed to exist because we tweak it in `env.js`
       process.env.NODE_PATH.split(path.delimiter).filter(Boolean)
     ),


### PR DESCRIPTION
This behavior was originally introduced in #1359 as we thought it would fix the `npm link` development workflow issues.

However, we have since found several problems with it:

* It doesn’t match the Node resolution mechanism (which reverted a similar change in https://github.com/nodejs/node/pull/6537 and kept it behind a flag)
* It still leads to the “duplicate React” problem (#675)
* It is inconsistent with Jest (as described in https://github.com/facebookincubator/create-react-app/issues/3883, past versions of Jest had this behavior but it led to issues like https://github.com/facebook/jest/issues/3830 and https://github.com/facebook/jest/pull/4761#issuecomment-339419335 so I fixed it in https://github.com/facebook/jest/pull/4761 to match the Node resolution mechanism)

There are also gotchas like https://github.com/webpack/webpack/issues/985#issuecomment-280253786, and I feel like it’s only going to get worse once we start supporting monorepos (#3741).

I propose that we completely disable this behavior for now. People who really need it can use an escape hatch: add `NODE_PATH=node_modules` to their `.env` file. This restores the 1.x behavior (and conveniently works in Jest too).

Our recommendation in any case will be to use monorepos instead (#3741) and stop relying on `npm link`.