### PR TITLE
Include `{json,css}` files in prettier command

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -348,7 +348,7 @@ Next we add a 'lint-staged' field to the `package.json`, for example:
   "scripts": {
 ```
 
-Now, whenever you make a commit, Prettier will format the changed files automatically. You can also run `./node_modules/.bin/prettier --single-quote --write "src/**/*.{js,jsx}"` to format your entire project for the first time.
+Now, whenever you make a commit, Prettier will format the changed files automatically. You can also run `./node_modules/.bin/prettier --single-quote --write "src/**/*.{js,jsx,json,css}"` to format your entire project for the first time.
 
 Next you might want to integrate Prettier in your favorite editor. Read the section on [Editor Integration](https://prettier.io/docs/en/editors.html) on the Prettier GitHub page.
 


### PR DESCRIPTION
Update User Guide's README.md to include `json` and `css`
files in the command to format the entire project for the first time
with prettier, that it's consistent with the `lint-staged` command.

----

As simple as that, don't think any more explanation is needed. Does it make sense to you guys?

Feel free to edit the PR or commit message if needed.